### PR TITLE
feat: 웹 레이아웃 및 반응형 UI 구성

### DIFF
--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "@web24/shared": "workspace:*",
+    "lucide-react": "^0.561.0",
     "react": "^19.2.3",
     "react-compiler-runtime": "^1.0.0",
     "react-dom": "^19.2.3",

--- a/apps/frontend/src/App.tsx
+++ b/apps/frontend/src/App.tsx
@@ -1,18 +1,10 @@
-import { APP_NAME } from '@web24/shared';
-
-import { AppRoutes } from '@/routes';
+import Layout from '@/shared/components/layout/Layout';
+import { AppRoutes } from './routes';
 
 export function App() {
   return (
-    <div className="min-h-dvh">
-      <header className="border-b border-zinc-800">
-        <div className="mx-auto flex max-w-5xl items-center justify-between px-4 py-4">
-          <h1 className="text-lg font-semibold">{APP_NAME}</h1>
-        </div>
-      </header>
-      <main className="mx-auto max-w-5xl px-4 py-6">
-        <AppRoutes />
-      </main>
-    </div>
+    <Layout>
+      <AppRoutes />
+    </Layout>
   );
 }

--- a/apps/frontend/src/shared/components/layout/DesktopHeader.tsx
+++ b/apps/frontend/src/shared/components/layout/DesktopHeader.tsx
@@ -1,19 +1,12 @@
 import { useScroll } from '@/shared/hooks/useScroll';
 import { Bell } from 'lucide-react';
-import type { RoutePath } from '@/shared/types/layout.types';
 import { useLocation, useNavigate } from 'react-router-dom';
+import { MENU_ITEMS } from '@/shared/constants/menu';
 
 function DesktopHeader() {
   const navigate = useNavigate();
   const location = useLocation();
   const isScrolled = useScroll(10);
-
-  const menuItems: { path: RoutePath; label: string }[] = [
-    { path: '/', label: '홈' },
-    { path: '/all-habits', label: '전체 습관' },
-    { path: '/stats', label: '통계' },
-    { path: '/myroom', label: '두두의방' },
-  ];
 
   return (
     <header
@@ -30,7 +23,7 @@ function DesktopHeader() {
 
         {/* 메뉴 */}
         <nav className="flex items-center gap-12">
-          {menuItems.map((item) => {
+          {MENU_ITEMS.map((item) => {
             const isActive = location.pathname === item.path;
             return (
               <button

--- a/apps/frontend/src/shared/components/layout/DesktopHeader.tsx
+++ b/apps/frontend/src/shared/components/layout/DesktopHeader.tsx
@@ -1,0 +1,69 @@
+import { useScroll } from '@/shared/hooks/useScroll';
+import { Bell } from 'lucide-react';
+import type { RoutePath } from '@/shared/types/layout.types';
+import { useLocation, useNavigate } from 'react-router-dom';
+
+function DesktopHeader() {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const isScrolled = useScroll(10);
+
+  const menuItems: { path: RoutePath; label: string }[] = [
+    { path: '/', label: '홈' },
+    { path: '/all-habits', label: '전체 습관' },
+    { path: '/stats', label: '통계' },
+    { path: '/myroom', label: '두두의방' },
+  ];
+
+  return (
+    <header
+      className={`fixed left-0 right-0 top-0 z-30 hidden justify-center border-b border-gray-100 bg-white transition-all duration-300 ease-in-out md:flex ${isScrolled ? 'h-16 shadow-sm' : 'h-24 shadow-none'} `}
+    >
+      <div className="flex h-full w-full max-w-5xl items-center justify-between px-8">
+        {/* 로고 */}
+        <div className="flex items-center gap-2">
+          <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-indigo-500 font-bold text-white">
+            DW
+          </div>
+          <span className="text-xl font-bold tracking-tight text-gray-800">뚜웰</span>
+        </div>
+
+        {/* 메뉴 */}
+        <nav className="flex items-center gap-12">
+          {menuItems.map((item) => {
+            const isActive = location.pathname === item.path;
+            return (
+              <button
+                key={item.path}
+                type="button"
+                onClick={() => navigate(item.path)}
+                className={`relative px-1 py-2 text-sm font-semibold transition-colors duration-200 ${isActive ? 'text-indigo-600' : 'text-gray-500 hover:text-indigo-500'} `}
+              >
+                {item.label}
+                {isActive && (
+                  <span className="animate-in fade-in zoom-in absolute bottom-0 left-0 h-0.5 w-full rounded-full bg-indigo-600 duration-200" />
+                )}
+              </button>
+            );
+          })}
+        </nav>
+
+        {/* 우측 아이콘 */}
+        <div className="flex items-center gap-3">
+          <button
+            className="relative p-2 text-gray-400 transition-colors hover:text-gray-600"
+            type="button"
+          >
+            <Bell size={20} />
+            <span className="absolute right-2 top-2 h-1.5 w-1.5 rounded-full border border-white bg-red-500" />
+          </button>
+          <div className="flex h-9 w-9 cursor-pointer items-center justify-center rounded-full border border-gray-200 bg-gradient-to-tr from-indigo-100 to-purple-100 text-sm font-bold text-indigo-700 transition-all hover:border-indigo-300">
+            U
+          </div>
+        </div>
+      </div>
+    </header>
+  );
+}
+
+export default DesktopHeader;

--- a/apps/frontend/src/shared/components/layout/Layout.tsx
+++ b/apps/frontend/src/shared/components/layout/Layout.tsx
@@ -1,0 +1,32 @@
+import { useState, type ReactNode } from 'react';
+import DesktopHeader from './DesktopHeader';
+import MobileHeader from './MobileHeader';
+import MobileTabBar from './MobileTabBar';
+import SideMenu from './SideMenu';
+
+function Layout({ children }: { children: ReactNode }) {
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
+
+  return (
+    <div className="flex min-h-screen flex-col bg-gray-50 font-sans text-gray-900">
+      {/* 헤더 */}
+      <DesktopHeader />
+      <MobileHeader onMenuClick={() => setIsMenuOpen(true)} />
+
+      {/* 사이드 메뉴 */}
+      <SideMenu isOpen={isMenuOpen} onClose={() => setIsMenuOpen(false)} />
+
+      {/* 메인 컨텐츠 */}
+      <main className="mx-auto w-full max-w-5xl flex-1 px-4 pb-24 pt-20 transition-all duration-300 md:px-8 md:pb-10 md:pt-28">
+        {children}
+      </main>
+
+      {/* + FAB 버튼 */}
+
+      {/* 모바일 탭 바 */}
+      <MobileTabBar />
+    </div>
+  );
+}
+
+export default Layout;

--- a/apps/frontend/src/shared/components/layout/MobileHeader.tsx
+++ b/apps/frontend/src/shared/components/layout/MobileHeader.tsx
@@ -1,0 +1,23 @@
+import { Menu, Bell } from 'lucide-react';
+
+function MobileHeader({ onMenuClick }: { onMenuClick: () => void }) {
+  return (
+    <header className="fixed left-0 right-0 top-0 z-30 flex h-14 items-center justify-between border-b border-gray-200 bg-white/90 px-4 backdrop-blur-sm md:hidden">
+      <h1 className="text-lg font-bold text-gray-800">뚜웰</h1>
+      <div className="flex items-center gap-1">
+        <button className="rounded-full p-2 text-gray-500 active:bg-gray-100" type="button">
+          <Bell size={22} />
+        </button>
+        <button
+          className="rounded-full p-2 text-gray-800 active:bg-gray-100"
+          type="button"
+          onClick={onMenuClick}
+        >
+          <Menu size={24} />
+        </button>
+      </div>
+    </header>
+  );
+}
+
+export default MobileHeader;

--- a/apps/frontend/src/shared/components/layout/MobileTabBar.tsx
+++ b/apps/frontend/src/shared/components/layout/MobileTabBar.tsx
@@ -1,22 +1,14 @@
-import type { RoutePath } from '@/shared/types/layout.types';
-import { Home, BarChart2, User, Grid } from 'lucide-react';
-import type { ReactNode } from 'react';
+import { MENU_ITEMS } from '@/shared/constants/menu';
 import { useLocation, useNavigate } from 'react-router-dom';
 
 function MobileTabBar() {
   const navigate = useNavigate();
   const location = useLocation();
 
-  const tabs: { path: RoutePath; icon: ReactNode; label: string }[] = [
-    { path: '/', icon: <Home size={24} />, label: '홈' },
-    { path: '/all-habits', icon: <Grid size={24} />, label: '전체' },
-    { path: '/stats', icon: <BarChart2 size={24} />, label: '통계' },
-    { path: '/myroom', icon: <User size={24} />, label: '두두의 방' },
-  ];
-
   return (
     <nav className="pb-safe fixed bottom-0 left-0 right-0 z-30 flex h-16 items-center justify-between border-t border-gray-200 bg-white px-6 md:hidden">
-      {tabs.map((tab) => {
+      {MENU_ITEMS.map((tab) => {
+        const Icon = tab.icon;
         const isActive = location.pathname === tab.path;
         return (
           <button
@@ -25,7 +17,7 @@ function MobileTabBar() {
             onClick={() => navigate(tab.path)}
             className={`flex w-12 flex-col items-center justify-center gap-1 transition-colors duration-200 ${isActive ? 'text-indigo-600' : 'text-gray-400'} `}
           >
-            {tab.icon}
+            {Icon && <Icon size={24} />}
             <span className="text-[10px] font-medium">{tab.label}</span>
           </button>
         );

--- a/apps/frontend/src/shared/components/layout/MobileTabBar.tsx
+++ b/apps/frontend/src/shared/components/layout/MobileTabBar.tsx
@@ -1,0 +1,37 @@
+import type { RoutePath } from '@/shared/types/layout.types';
+import { Home, BarChart2, User, Grid } from 'lucide-react';
+import type { ReactNode } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+
+function MobileTabBar() {
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  const tabs: { path: RoutePath; icon: ReactNode; label: string }[] = [
+    { path: '/', icon: <Home size={24} />, label: '홈' },
+    { path: '/all-habits', icon: <Grid size={24} />, label: '전체' },
+    { path: '/stats', icon: <BarChart2 size={24} />, label: '통계' },
+    { path: '/myroom', icon: <User size={24} />, label: '두두의 방' },
+  ];
+
+  return (
+    <nav className="pb-safe fixed bottom-0 left-0 right-0 z-30 flex h-16 items-center justify-between border-t border-gray-200 bg-white px-6 md:hidden">
+      {tabs.map((tab) => {
+        const isActive = location.pathname === tab.path;
+        return (
+          <button
+            key={tab.path}
+            type="button"
+            onClick={() => navigate(tab.path)}
+            className={`flex w-12 flex-col items-center justify-center gap-1 transition-colors duration-200 ${isActive ? 'text-indigo-600' : 'text-gray-400'} `}
+          >
+            {tab.icon}
+            <span className="text-[10px] font-medium">{tab.label}</span>
+          </button>
+        );
+      })}
+    </nav>
+  );
+}
+
+export default MobileTabBar;

--- a/apps/frontend/src/shared/components/layout/SideMenu.tsx
+++ b/apps/frontend/src/shared/components/layout/SideMenu.tsx
@@ -1,6 +1,7 @@
 import type { SideMenuProps } from '@/shared/types/layout.types';
 import { useEffect } from 'react';
 import { X } from 'lucide-react';
+import { BREAKPOINTS } from '@/shared/constants/breakpoints';
 
 function SideMenu({ isOpen, onClose }: SideMenuProps) {
   // 스크롤 잠금
@@ -18,7 +19,7 @@ function SideMenu({ isOpen, onClose }: SideMenuProps) {
   // 데스크탑 크기가 되면 닫기
   useEffect(() => {
     const handleResize = () => {
-      if (window.innerWidth >= 768 && isOpen) {
+      if (window.innerWidth >= BREAKPOINTS.TABLET && isOpen) {
         onClose();
       }
     };

--- a/apps/frontend/src/shared/components/layout/SideMenu.tsx
+++ b/apps/frontend/src/shared/components/layout/SideMenu.tsx
@@ -1,0 +1,62 @@
+import type { SideMenuProps } from '@/shared/types/layout.types';
+import { useEffect } from 'react';
+import { X } from 'lucide-react';
+
+function SideMenu({ isOpen, onClose }: SideMenuProps) {
+  // 스크롤 잠금
+  useEffect(() => {
+    if (isOpen) {
+      document.body.style.overflow = 'hidden'; // 스크롤 금지
+    } else {
+      document.body.style.overflow = 'unset'; // 스크롤 복구
+    }
+    return () => {
+      document.body.style.overflow = 'unset'; // 컴포넌트 언마운트 시 복구
+    };
+  }, [isOpen]);
+
+  // 데스크탑 크기가 되면 닫기
+  useEffect(() => {
+    const handleResize = () => {
+      if (window.innerWidth >= 768 && isOpen) {
+        onClose();
+      }
+    };
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, [isOpen, onClose]);
+
+  return (
+    <>
+      {/* 오버레이 */}
+      <div
+        className={`fixed inset-0 z-40 bg-black/50 transition-opacity duration-300 ${isOpen ? 'visible opacity-100' : 'pointer-events-none invisible opacity-0'} `}
+        role="presentation"
+        aria-hidden="true"
+        onClick={onClose}
+      />
+
+      {/* 슬라이딩 메뉴 */}
+      <div
+        className={`fixed bottom-0 right-0 top-0 z-50 w-64 transform bg-white shadow-2xl transition-transform duration-300 ease-in-out ${isOpen ? 'translate-x-0' : 'translate-x-full'} `}
+      >
+        <div className="flex h-full flex-col p-5">
+          <div className="mb-8 flex items-center justify-between">
+            <h2 className="text-xl font-bold text-gray-800">Menu</h2>
+            <button type="button" className="rounded-full p-1 hover:bg-gray-100" onClick={onClose}>
+              <X size={24} className="text-gray-500" />
+            </button>
+          </div>
+
+          <div className="flex-1 space-y-4">
+            <div className="h-10 animate-pulse rounded-lg bg-gray-100" />
+            <div className="h-10 animate-pulse rounded-lg bg-gray-100" />
+            <div className="h-10 animate-pulse rounded-lg bg-gray-100" />
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}
+
+export default SideMenu;

--- a/apps/frontend/src/shared/constants/breakpoints.ts
+++ b/apps/frontend/src/shared/constants/breakpoints.ts
@@ -1,0 +1,5 @@
+export const BREAKPOINTS = {
+  DESKTOP: 1024,
+  TABLET: 768,
+  MOBILE: 0,
+};

--- a/apps/frontend/src/shared/constants/menu.ts
+++ b/apps/frontend/src/shared/constants/menu.ts
@@ -1,0 +1,9 @@
+import type { MenuItem } from '@/shared/types/layout.types';
+import { Home, Grid, BarChart2, User } from 'lucide-react';
+
+export const MENU_ITEMS: MenuItem[] = [
+  { path: '/', icon: Home, label: '홈' },
+  { path: '/all-habits', icon: Grid, label: '전체' },
+  { path: '/stats', icon: BarChart2, label: '통계' },
+  { path: '/myroom', icon: User, label: '두두의방' },
+];

--- a/apps/frontend/src/shared/hooks/useScroll.ts
+++ b/apps/frontend/src/shared/hooks/useScroll.ts
@@ -1,0 +1,18 @@
+import { useState, useEffect } from 'react';
+
+export const useScroll = (threshold: number = 10) => {
+  const [isScrolled, setIsScrolled] = useState<boolean>(false);
+
+  useEffect(() => {
+    const handleScroll = () => {
+      setIsScrolled(window.scrollY > threshold);
+    };
+
+    handleScroll();
+    window.addEventListener('scroll', handleScroll);
+
+    return () => window.removeEventListener('scroll', handleScroll);
+  }, [threshold]);
+
+  return isScrolled;
+};

--- a/apps/frontend/src/shared/types/layout.types.ts
+++ b/apps/frontend/src/shared/types/layout.types.ts
@@ -1,6 +1,14 @@
+import type { LucideIcon } from 'lucide-react';
+
 export type RoutePath = '/' | '/all-habits' | '/stats' | '/myroom';
 
 export interface SideMenuProps {
   isOpen: boolean;
   onClose: () => void;
 }
+
+export type MenuItem = {
+  path: RoutePath;
+  label: string;
+  icon?: LucideIcon;
+};

--- a/apps/frontend/src/shared/types/layout.types.ts
+++ b/apps/frontend/src/shared/types/layout.types.ts
@@ -1,0 +1,6 @@
+export type RoutePath = '/' | '/all-habits' | '/stats' | '/myroom';
+
+export interface SideMenuProps {
+  isOpen: boolean;
+  onClose: () => void;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,6 +62,9 @@ importers:
       '@web24/shared':
         specifier: workspace:*
         version: link:../../packages/shared
+      lucide-react:
+        specifier: ^0.561.0
+        version: 0.561.0(react@19.2.3)
       react:
         specifier: ^19.2.3
         version: 19.2.3
@@ -1923,6 +1926,11 @@ packages:
 
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  lucide-react@0.561.0:
+    resolution: {integrity: sha512-Y59gMY38tl4/i0qewcqohPdEbieBy7SovpBL9IFebhc2mDd8x4PZSOsiFRkpPcOq6bj1r/mjH/Rk73gSlIJP2A==}
+    peerDependencies:
+      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   lz-string@1.5.0:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
@@ -4784,6 +4792,10 @@ snapshots:
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
+
+  lucide-react@0.561.0(react@19.2.3):
+    dependencies:
+      react: 19.2.3
 
   lz-string@1.5.0: {}
 


### PR DESCRIPTION
## 🔗 관련 이슈

- close: #78 

## ✅ 작업 내용

- chore: lucide-react 아이콘 라이브러리 추가
- feat: 앱 레이아웃 기본 구조 추가
- feat: 반응형 헤더 컴포넌트 추가
- feat: 모바일 하단 탭바 추가
- feat: 모바일 사이드 메뉴 추가
- feat: 스크롤 상태 관리 훅 추가
- chore: 레이아웃 관련 타입 정의

## 📸 스크린샷 / 데모 (옵션)

### 데스크톱
<img width="600" alt="desktop" src="https://github.com/user-attachments/assets/86210572-1835-4c55-a095-1e36c179c6bb" />

### 모바일
<img width="250" alt="mobile" src="https://github.com/user-attachments/assets/4ffac4aa-a056-440f-92cc-8dcb1187af7d" />

### 사이드 메뉴
<img width="300" alt="menu" src="https://github.com/user-attachments/assets/2398bbe6-6a4a-4b33-81aa-ec494b850ff4" />

## 🧪 테스트 방법 (옵션)

- 실행 후 레이아웃/헤더/탭바/사이드메뉴가 정상 표시되는지 확인

## 💡 체크리스트

- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (예: `feature/login` -> `develop`)
- [x] 테스트는 잘 통과했나요?
- [x] 빌드에 성공했나요?

## 💬 To Reviewers

레이아웃, 반응형 헤더/탭바/사이드 메뉴 중심으로 확인부탁드립니다
