### PR TITLE
feat: 목표 행동 엔티티 생성 및 테이블 추가

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -16,6 +16,20 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - name: Setup pnpm
+        run: corepack enable
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run backend tests with coverage
+        run: pnpm -F @web24/backend test:cov
+
       # 소나큐브 스캔 실행
       - name: SonarQube Scan
         uses: sonarsource/sonarqube-scan-action@v5.0.0

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -27,6 +27,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Build shared package
+        run: pnpm -F @web24/shared build
+
       - name: Run backend tests with coverage
         run: pnpm -F @web24/backend test:cov
 

--- a/apps/backend/src/app.controller.spec.ts
+++ b/apps/backend/src/app.controller.spec.ts
@@ -3,6 +3,7 @@ import { getRepositoryToken } from '@nestjs/typeorm';
 import { AppController } from './app.controller';
 import { AppEntitySample } from './app.sample.entity';
 import { AppService } from './app.service';
+import { User } from './features/user/user.entity';
 
 describe('AppController', () => {
   let appController: AppController;
@@ -14,6 +15,13 @@ describe('AppController', () => {
         AppService,
         {
           provide: getRepositoryToken(AppEntitySample),
+          useValue: {
+            create: jest.fn(),
+            save: jest.fn(),
+          },
+        },
+        {
+          provide: getRepositoryToken(User),
           useValue: {
             create: jest.fn(),
             save: jest.fn(),

--- a/apps/backend/src/app.controller.spec.ts
+++ b/apps/backend/src/app.controller.spec.ts
@@ -7,25 +7,36 @@ import { User } from './features/user/user.entity';
 
 describe('AppController', () => {
   let appController: AppController;
+  let samplesRepository: {
+    create: jest.Mock;
+    save: jest.Mock;
+  };
+  let userRepository: {
+    create: jest.Mock;
+    save: jest.Mock;
+  };
 
   beforeEach(async () => {
+    samplesRepository = {
+      create: jest.fn(),
+      save: jest.fn(),
+    };
+    userRepository = {
+      create: jest.fn(),
+      save: jest.fn(),
+    };
+
     const app: TestingModule = await Test.createTestingModule({
       controllers: [AppController],
       providers: [
         AppService,
         {
           provide: getRepositoryToken(AppEntitySample),
-          useValue: {
-            create: jest.fn(),
-            save: jest.fn(),
-          },
+          useValue: samplesRepository,
         },
         {
           provide: getRepositoryToken(User),
-          useValue: {
-            create: jest.fn(),
-            save: jest.fn(),
-          },
+          useValue: userRepository,
         },
       ],
     }).compile();
@@ -34,8 +45,47 @@ describe('AppController', () => {
   });
 
   describe('root', () => {
-    it('should return "Hello World!"', () => {
+    it('"Hello World!"를 반환한다', () => {
       expect(appController.getHello()).toBe('Hello World!');
+    });
+  });
+
+  describe('samples', () => {
+    it('샘플을 생성한다', async () => {
+      const body = { name: 'sample' };
+      const created = { name: body.name };
+      const saved: AppEntitySample = {
+        id: 'sample-id',
+        name: body.name,
+        createdAt: new Date(),
+      };
+
+      samplesRepository.create.mockReturnValue(created);
+      samplesRepository.save.mockResolvedValue(saved);
+
+      await expect(appController.createSample(body)).resolves.toBe(saved);
+      expect(samplesRepository.create).toHaveBeenCalledWith({ name: body.name });
+      expect(samplesRepository.save).toHaveBeenCalledWith(created);
+    });
+  });
+
+  describe('user', () => {
+    it('사용자를 생성한다', async () => {
+      const created = { nickname: '테스트' };
+      const saved: User = {
+        id: 'user-id',
+        nickname: '테스트',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        deletedAt: null,
+      };
+
+      userRepository.create.mockReturnValue(created);
+      userRepository.save.mockResolvedValue(saved);
+
+      await expect(appController.createUser()).resolves.toBe(saved);
+      expect(userRepository.create).toHaveBeenCalledWith({ nickname: '테스트' });
+      expect(userRepository.save).toHaveBeenCalledWith(created);
     });
   });
 });

--- a/apps/backend/src/app.controller.ts
+++ b/apps/backend/src/app.controller.ts
@@ -6,6 +6,7 @@ import { CreateSampleSchema, type CreateSampleRequest } from '@web24/shared';
 import { AppEntitySample } from './app.sample.entity';
 import { AppService } from './app.service';
 import { ZodValidationPipe } from './common/pipes/zod-validation.pipe';
+import { User } from './features/user/user.entity';
 
 @Controller()
 export class AppController {
@@ -13,6 +14,8 @@ export class AppController {
     private readonly appService: AppService,
     @InjectRepository(AppEntitySample)
     private readonly samplesRepository: Repository<AppEntitySample>,
+    @InjectRepository(User)
+    private readonly userRepository: Repository<User>,
   ) {}
 
   @Get()
@@ -26,5 +29,11 @@ export class AppController {
   ): Promise<AppEntitySample> {
     const sample = this.samplesRepository.create({ name: body.name });
     return this.samplesRepository.save(sample);
+  }
+
+  @Post('test/user')
+  async createUser(): Promise<User> {
+    const user = this.userRepository.create({ nickname: '테스트' });
+    return this.userRepository.save(user);
   }
 }

--- a/apps/backend/src/app.module.ts
+++ b/apps/backend/src/app.module.ts
@@ -6,6 +6,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { AppController } from './app.controller';
 import { AppEntitySample } from './app.sample.entity';
 import { AppService } from './app.service';
+import { User } from './features/user/user.entity';
 
 @Module({
   imports: [
@@ -39,7 +40,7 @@ import { AppService } from './app.service';
         };
       },
     }),
-    TypeOrmModule.forFeature([AppEntitySample]),
+    TypeOrmModule.forFeature([AppEntitySample, User]),
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/apps/backend/src/common/database/migrations/1767782727667-auto.ts
+++ b/apps/backend/src/common/database/migrations/1767782727667-auto.ts
@@ -1,0 +1,31 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class Auto1767782727667 implements MigrationInterface {
+  name = 'Auto1767782727667';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TYPE "public"."behaviors_difficulty_enum" AS ENUM('마음열기', '시작하기', '이어하기', '몰입하기', 'AI')`,
+    );
+    await queryRunner.query(
+      `CREATE TABLE "behaviors" ("id" uuid NOT NULL DEFAULT uuidv7(), "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "deletedAt" TIMESTAMP WITH TIME ZONE, "title" character varying(30) NOT NULL, "difficulty" "public"."behaviors_difficulty_enum" NOT NULL, "goalId" uuid, CONSTRAINT "PK_dc34a2b981fe38b508ba9957255" PRIMARY KEY ("id"))`,
+    );
+    await queryRunner.query(
+      `CREATE TABLE "users" ("id" uuid NOT NULL DEFAULT uuidv7(), "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "deletedAt" TIMESTAMP WITH TIME ZONE, "nickname" character varying(10) NOT NULL, CONSTRAINT "PK_a3ffb1c0c8416b9fc6f907b7433" PRIMARY KEY ("id"))`,
+    );
+    await queryRunner.query(
+      `CREATE TYPE "public"."goals_color_enum" AS ENUM('#e4b2b9', '#e48b84', '#edc06a', '#d7d1ab', '#abd7b9', '#abd1d7', '#8ba49d', '#b6aea8', '#d7c1ab', '#c9bae3')`,
+    );
+    await queryRunner.query(
+      `CREATE TABLE "goals" ("id" uuid NOT NULL DEFAULT uuidv7(), "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "deletedAt" TIMESTAMP WITH TIME ZONE, "title" character varying(20) NOT NULL, "color" "public"."goals_color_enum" NOT NULL, "userId" uuid, CONSTRAINT "PK_26e17b251afab35580dff769223" PRIMARY KEY ("id"))`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP TABLE "goals"`);
+    await queryRunner.query(`DROP TYPE "public"."goals_color_enum"`);
+    await queryRunner.query(`DROP TABLE "users"`);
+    await queryRunner.query(`DROP TABLE "behaviors"`);
+    await queryRunner.query(`DROP TYPE "public"."behaviors_difficulty_enum"`);
+  }
+}

--- a/apps/backend/src/common/database/migrations/1767837980166-auto.ts
+++ b/apps/backend/src/common/database/migrations/1767837980166-auto.ts
@@ -1,0 +1,31 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class Auto1767837980166 implements MigrationInterface {
+  name = 'Auto1767837980166';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TYPE "public"."goals_color_enum" RENAME TO "goals_color_enum_old"`,
+    );
+    await queryRunner.query(
+      `CREATE TYPE "public"."goals_color_enum" AS ENUM('light-pink', 'pink', 'yellow', 'sand', 'mint', 'blue', 'gray-mint', 'warm-gray', 'beige', 'lavender')`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "goals" ALTER COLUMN "color" TYPE "public"."goals_color_enum" USING "color"::"text"::"public"."goals_color_enum"`,
+    );
+    await queryRunner.query(`DROP TYPE "public"."goals_color_enum_old"`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TYPE "public"."goals_color_enum_old" AS ENUM('#e4b2b9', '#e48b84', '#edc06a', '#d7d1ab', '#abd7b9', '#abd1d7', '#8ba49d', '#b6aea8', '#d7c1ab', '#c9bae3')`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "goals" ALTER COLUMN "color" TYPE "public"."goals_color_enum_old" USING "color"::"text"::"public"."goals_color_enum_old"`,
+    );
+    await queryRunner.query(`DROP TYPE "public"."goals_color_enum"`);
+    await queryRunner.query(
+      `ALTER TYPE "public"."goals_color_enum_old" RENAME TO "goals_color_enum"`,
+    );
+  }
+}

--- a/apps/backend/src/features/behavior/behavior.entity.spec.ts
+++ b/apps/backend/src/features/behavior/behavior.entity.spec.ts
@@ -1,0 +1,33 @@
+import { getMetadataArgsStorage } from 'typeorm';
+import { Behavior } from './behavior.entity';
+
+const storage = getMetadataArgsStorage();
+
+const getTableName = (target: Function): string | undefined =>
+  storage.tables.find((table) => table.target === target)?.name;
+
+const getColumnNames = (target: Function): string[] =>
+  storage.columns.filter((column) => column.target === target).map((column) => column.propertyName);
+
+const getRelation = (target: Function, propertyName: string) =>
+  storage.relations.find(
+    (relation) => relation.target === target && relation.propertyName === propertyName,
+  );
+
+const getJoinColumn = (target: Function, propertyName: string) =>
+  storage.joinColumns.find(
+    (joinColumn) => joinColumn.target === target && joinColumn.propertyName === propertyName,
+  );
+
+describe('Behavior', () => {
+  it('테이블과 컬럼 매핑을 가진다', () => {
+    expect(getTableName(Behavior)).toBe('behaviors');
+    expect(getColumnNames(Behavior)).toEqual(expect.arrayContaining(['title', 'difficulty']));
+  });
+
+  it('Goal 관계 매핑을 가진다', () => {
+    const goalRelation = getRelation(Behavior, 'goal');
+    expect(goalRelation?.relationType).toBe('many-to-one');
+    expect(getJoinColumn(Behavior, 'goal')?.name).toBe('goalId');
+  });
+});

--- a/apps/backend/src/features/behavior/behavior.entity.ts
+++ b/apps/backend/src/features/behavior/behavior.entity.ts
@@ -1,0 +1,19 @@
+import { BaseIdCreatedUpdatedDeletedEntity } from 'src/common/entities/base-id-created-updated-deleted.entity';
+import { Column, Entity, JoinColumn, ManyToOne } from 'typeorm';
+import { BEHAVIOR_TITLE_MAX_LENGTH, BehaviorDifficulty } from '@web24/shared';
+import { Goal } from '../goal/goal.entity';
+
+@Entity({ name: 'behaviors' })
+export class Behavior extends BaseIdCreatedUpdatedDeletedEntity {
+  @ManyToOne(() => Goal, (goal) => goal.behaviors, {
+    createForeignKeyConstraints: false,
+  })
+  @JoinColumn({ name: 'goalId' })
+  goal!: Goal;
+
+  @Column({ type: 'varchar', length: BEHAVIOR_TITLE_MAX_LENGTH })
+  title!: string;
+
+  @Column({ type: 'enum', enum: BehaviorDifficulty })
+  difficulty!: BehaviorDifficulty;
+}

--- a/apps/backend/src/features/behavior/behavior.entity.ts
+++ b/apps/backend/src/features/behavior/behavior.entity.ts
@@ -1,6 +1,6 @@
-import { BaseIdCreatedUpdatedDeletedEntity } from 'src/common/entities/base-id-created-updated-deleted.entity';
 import { Column, Entity, JoinColumn, ManyToOne } from 'typeorm';
 import { BEHAVIOR_TITLE_MAX_LENGTH, BehaviorDifficulty } from '@web24/shared';
+import { BaseIdCreatedUpdatedDeletedEntity } from '../../common/entities/base.entity';
 import { Goal } from '../goal/goal.entity';
 
 @Entity({ name: 'behaviors' })

--- a/apps/backend/src/features/behavior/behavior.entity.ts
+++ b/apps/backend/src/features/behavior/behavior.entity.ts
@@ -1,5 +1,9 @@
 import { Column, Entity, JoinColumn, ManyToOne } from 'typeorm';
-import { BEHAVIOR_TITLE_MAX_LENGTH, BehaviorDifficulty } from '@web24/shared';
+import {
+  BEHAVIOR_DIFFICULTIES,
+  BEHAVIOR_TITLE_MAX_LENGTH,
+  type BehaviorDifficulty,
+} from '@web24/shared';
 import { BaseIdCreatedUpdatedDeletedEntity } from '../../common/entities/base.entity';
 import { Goal } from '../goal/goal.entity';
 
@@ -14,6 +18,6 @@ export class Behavior extends BaseIdCreatedUpdatedDeletedEntity {
   @Column({ type: 'varchar', length: BEHAVIOR_TITLE_MAX_LENGTH })
   title!: string;
 
-  @Column({ type: 'enum', enum: BehaviorDifficulty })
+  @Column({ type: 'enum', enum: BEHAVIOR_DIFFICULTIES })
   difficulty!: BehaviorDifficulty;
 }

--- a/apps/backend/src/features/goal/goal.entity.spec.ts
+++ b/apps/backend/src/features/goal/goal.entity.spec.ts
@@ -1,0 +1,36 @@
+import { getMetadataArgsStorage } from 'typeorm';
+import { Goal } from './goal.entity';
+
+const storage = getMetadataArgsStorage();
+
+const getTableName = (target: Function): string | undefined =>
+  storage.tables.find((table) => table.target === target)?.name;
+
+const getColumnNames = (target: Function): string[] =>
+  storage.columns.filter((column) => column.target === target).map((column) => column.propertyName);
+
+const getRelation = (target: Function, propertyName: string) =>
+  storage.relations.find(
+    (relation) => relation.target === target && relation.propertyName === propertyName,
+  );
+
+const getJoinColumn = (target: Function, propertyName: string) =>
+  storage.joinColumns.find(
+    (joinColumn) => joinColumn.target === target && joinColumn.propertyName === propertyName,
+  );
+
+describe('Goal', () => {
+  it('테이블과 컬럼 매핑을 가진다', () => {
+    expect(getTableName(Goal)).toBe('goals');
+    expect(getColumnNames(Goal)).toEqual(expect.arrayContaining(['title', 'color']));
+  });
+
+  it('User, Behavior 관계 매핑을 가진다', () => {
+    const userRelation = getRelation(Goal, 'user');
+    expect(userRelation?.relationType).toBe('many-to-one');
+    expect(getJoinColumn(Goal, 'user')?.name).toBe('userId');
+
+    const behaviorsRelation = getRelation(Goal, 'behaviors');
+    expect(behaviorsRelation?.relationType).toBe('one-to-many');
+  });
+});

--- a/apps/backend/src/features/goal/goal.entity.ts
+++ b/apps/backend/src/features/goal/goal.entity.ts
@@ -1,7 +1,7 @@
 import { GOAL_TITLE_MAX_LENGTH, GoalColors } from '@web24/shared';
-import { BaseIdCreatedUpdatedDeletedEntity } from 'src/common/entities/base-id-created-updated-deleted.entity';
 import { Column, Entity, JoinColumn, ManyToOne, OneToMany } from 'typeorm';
 import { Behavior } from '../behavior/behavior.entity';
+import { BaseIdCreatedUpdatedDeletedEntity } from '../../common/entities/base.entity';
 import { User } from '../user/user.entity';
 
 @Entity({ name: 'goals' })

--- a/apps/backend/src/features/goal/goal.entity.ts
+++ b/apps/backend/src/features/goal/goal.entity.ts
@@ -1,4 +1,4 @@
-import { GOAL_TITLE_MAX_LENGTH, GoalColors } from '@web24/shared';
+import { GOAL_COLORS, GOAL_TITLE_MAX_LENGTH, type GoalColor } from '@web24/shared';
 import { Column, Entity, JoinColumn, ManyToOne, OneToMany } from 'typeorm';
 import { Behavior } from '../behavior/behavior.entity';
 import { BaseIdCreatedUpdatedDeletedEntity } from '../../common/entities/base.entity';
@@ -15,8 +15,8 @@ export class Goal extends BaseIdCreatedUpdatedDeletedEntity {
   @JoinColumn({ name: 'userId' })
   user!: User;
 
-  @Column({ type: 'enum', enum: GoalColors })
-  color!: GoalColors;
+  @Column({ type: 'enum', enum: Object.values(GOAL_COLORS) })
+  color!: GoalColor;
 
   @OneToMany(() => Behavior, (behavior) => behavior.goal)
   behaviors!: Behavior[];

--- a/apps/backend/src/features/goal/goal.entity.ts
+++ b/apps/backend/src/features/goal/goal.entity.ts
@@ -1,0 +1,23 @@
+import { GOAL_TITLE_MAX_LENGTH, GoalColors } from '@web24/shared';
+import { BaseIdCreatedUpdatedDeletedEntity } from 'src/common/entities/base-id-created-updated-deleted.entity';
+import { Column, Entity, JoinColumn, ManyToOne, OneToMany } from 'typeorm';
+import { Behavior } from '../behavior/behavior.entity';
+import { User } from '../user/user.entity';
+
+@Entity({ name: 'goals' })
+export class Goal extends BaseIdCreatedUpdatedDeletedEntity {
+  @Column({ type: 'varchar', length: GOAL_TITLE_MAX_LENGTH })
+  title!: string;
+
+  @ManyToOne(() => User, {
+    createForeignKeyConstraints: false,
+  })
+  @JoinColumn({ name: 'userId' })
+  user!: User;
+
+  @Column({ type: 'enum', enum: GoalColors })
+  color!: GoalColors;
+
+  @OneToMany(() => Behavior, (behavior) => behavior.goal)
+  behaviors!: Behavior[];
+}

--- a/apps/backend/src/features/user/user.entity.spec.ts
+++ b/apps/backend/src/features/user/user.entity.spec.ts
@@ -1,0 +1,17 @@
+import { getMetadataArgsStorage } from 'typeorm';
+import { User } from './user.entity';
+
+const storage = getMetadataArgsStorage();
+
+const getTableName = (target: Function): string | undefined =>
+  storage.tables.find((table) => table.target === target)?.name;
+
+const getColumnNames = (target: Function): string[] =>
+  storage.columns.filter((column) => column.target === target).map((column) => column.propertyName);
+
+describe('User', () => {
+  it('테이블과 컬럼 매핑을 가진다', () => {
+    expect(getTableName(User)).toBe('users');
+    expect(getColumnNames(User)).toEqual(expect.arrayContaining(['nickname']));
+  });
+});

--- a/apps/backend/src/features/user/user.entity.ts
+++ b/apps/backend/src/features/user/user.entity.ts
@@ -1,0 +1,9 @@
+import { USER_NICKNAME_MAX_LENGTH } from '@web24/shared';
+import { BaseIdCreatedUpdatedDeletedEntity } from 'src/common/entities/base-id-created-updated-deleted.entity';
+import { Column, Entity } from 'typeorm';
+
+@Entity({ name: 'users' })
+export class User extends BaseIdCreatedUpdatedDeletedEntity {
+  @Column({ type: 'varchar', length: USER_NICKNAME_MAX_LENGTH })
+  nickname!: string;
+}

--- a/apps/backend/src/features/user/user.entity.ts
+++ b/apps/backend/src/features/user/user.entity.ts
@@ -1,6 +1,6 @@
 import { USER_NICKNAME_MAX_LENGTH } from '@web24/shared';
-import { BaseIdCreatedUpdatedDeletedEntity } from 'src/common/entities/base-id-created-updated-deleted.entity';
 import { Column, Entity } from 'typeorm';
+import { BaseIdCreatedUpdatedDeletedEntity } from '../../common/entities/base.entity';
 
 @Entity({ name: 'users' })
 export class User extends BaseIdCreatedUpdatedDeletedEntity {

--- a/apps/frontend/src/index.css
+++ b/apps/frontend/src/index.css
@@ -26,16 +26,16 @@
   --color-secondary-strong: #b7bda2;
 
   /* Goal Colors */
-  --color-goal-1: #e4b2b9;
-  --color-goal-2: #e48b84;
-  --color-goal-3: #edc06a;
-  --color-goal-4: #d7d1ab;
-  --color-goal-5: #abd7b9;
-  --color-goal-6: #abd1d7;
-  --color-goal-7: #8ba49d;
-  --color-goal-8: #b6aea8;
-  --color-goal-9: #d7c1ab;
-  --color-goal-10: #c9bae3;
+  --color-goal-light-pink: #e4b2b9;
+  --color-goal-pink: #e48b84;
+  --color-goal-yellow: #edc06a;
+  --color-goal-sand: #d7d1ab;
+  --color-goal-mint: #abd7b9;
+  --color-goal-blue: #abd1d7;
+  --color-goal-gray-mint: #8ba49d;
+  --color-goal-warm-gray: #b6aea8;
+  --color-goal-beige: #d7c1ab;
+  --color-goal-lavender: #c9bae3;
 
   /* Difficulty Colors */
   --color-difficulty-1: #81c784;

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -81,6 +81,12 @@ export default [
       '@typescript-eslint/no-unsafe-argument': 'warn',
     },
   },
+  {
+    files: ['apps/backend/**/*.entity.ts'],
+    rules: {
+      'import/no-cycle': 'off',
+    },
+  },
 
   {
     files: ['**/*.{ts,tsx}'],

--- a/packages/shared/src/constants/behavior.constants.ts
+++ b/packages/shared/src/constants/behavior.constants.ts
@@ -1,0 +1,1 @@
+export const BEHAVIOR_TITLE_MAX_LENGTH = 30;

--- a/packages/shared/src/constants/goal.constants.ts
+++ b/packages/shared/src/constants/goal.constants.ts
@@ -1,0 +1,1 @@
+export const GOAL_TITLE_MAX_LENGTH = 20;

--- a/packages/shared/src/constants/index.ts
+++ b/packages/shared/src/constants/index.ts
@@ -1,1 +1,4 @@
 export * from './some.constants';
+export * from './behavior.constants';
+export * from './goal.constants';
+export * from './user.constants';

--- a/packages/shared/src/constants/user.constants.ts
+++ b/packages/shared/src/constants/user.constants.ts
@@ -1,0 +1,1 @@
+export const USER_NICKNAME_MAX_LENGTH = 10;

--- a/packages/shared/src/types/behavior.types.ts
+++ b/packages/shared/src/types/behavior.types.ts
@@ -1,0 +1,7 @@
+export enum BehaviorDifficulty {
+  VeryLow = '마음열기',
+  Low = '시작하기',
+  Medium = '이어하기',
+  High = '몰입하기',
+  Ai = 'AI',
+}

--- a/packages/shared/src/types/behavior.types.ts
+++ b/packages/shared/src/types/behavior.types.ts
@@ -1,7 +1,9 @@
-export enum BehaviorDifficulty {
-  VeryLow = '마음열기',
-  Low = '시작하기',
-  Medium = '이어하기',
-  High = '몰입하기',
-  Ai = 'AI',
-}
+export const BEHAVIOR_DIFFICULTIES = [
+  '마음열기',
+  '시작하기',
+  '이어하기',
+  '몰입하기',
+  'AI',
+] as const;
+
+export type BehaviorDifficulty = (typeof BEHAVIOR_DIFFICULTIES)[number];

--- a/packages/shared/src/types/goal.types.ts
+++ b/packages/shared/src/types/goal.types.ts
@@ -1,14 +1,14 @@
 export const GOAL_COLORS = [
-  'LightPink',
-  'Pink',
-  'Yellow',
-  'Sand',
-  'Mint',
-  'Blue',
-  'GrayMint',
-  'WarmGray',
-  'Beige',
-  'Lavender',
+  'light-pink',
+  'pink',
+  'yellow',
+  'sand',
+  'mint',
+  'blue',
+  'gray-mint',
+  'warm-gray',
+  'beige',
+  'lavender',
 ] as const;
 
 export type GoalColor = (typeof GOAL_COLORS)[number];

--- a/packages/shared/src/types/goal.types.ts
+++ b/packages/shared/src/types/goal.types.ts
@@ -1,0 +1,12 @@
+export enum GoalColors {
+  LightPink = '#e4b2b9',
+  Pink = '#e48b84',
+  Yellow = '#edc06a',
+  Sand = '#d7d1ab',
+  Mint = '#abd7b9',
+  Blue = '#abd1d7',
+  GrayMint = '#8ba49d',
+  WarmGray = '#b6aea8',
+  Beige = '#d7c1ab',
+  Lavender = '#c9bae3',
+}

--- a/packages/shared/src/types/goal.types.ts
+++ b/packages/shared/src/types/goal.types.ts
@@ -1,12 +1,14 @@
-export enum GoalColors {
-  LightPink = '#e4b2b9',
-  Pink = '#e48b84',
-  Yellow = '#edc06a',
-  Sand = '#d7d1ab',
-  Mint = '#abd7b9',
-  Blue = '#abd1d7',
-  GrayMint = '#8ba49d',
-  WarmGray = '#b6aea8',
-  Beige = '#d7c1ab',
-  Lavender = '#c9bae3',
-}
+export const GOAL_COLORS = [
+  'LightPink',
+  'Pink',
+  'Yellow',
+  'Sand',
+  'Mint',
+  'Blue',
+  'GrayMint',
+  'WarmGray',
+  'Beige',
+  'Lavender',
+] as const;
+
+export type GoalColor = (typeof GOAL_COLORS)[number];

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -1,1 +1,2 @@
 export * from './some.types';
+export * from './goal.types';

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -1,2 +1,3 @@
 export * from './some.types';
 export * from './goal.types';
+export * from './behavior.types';

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -4,6 +4,6 @@ sonar.projectName=doowell
 
 sonar.sources=apps/backend,apps/frontend
 
-sonar.exclusions=**/node_modules/**,**/*.test.js,**/test/**,**/*.spec.ts,**/dist/**,**/build/**
+sonar.exclusions=**/node_modules/**,**/*.test.js,**/test/**,**/*.spec.ts,**/dist/**,**/build/**,**/migrations/**
 
 sonar.sourceEncoding=UTF-8

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -6,4 +6,9 @@ sonar.sources=apps/backend,apps/frontend
 
 sonar.exclusions=**/node_modules/**,**/*.test.js,**/test/**,**/*.spec.ts,**/dist/**,**/build/**,**/migrations/**
 
+sonar.tests=apps/backend/test,apps/backend/src,apps/frontend/src
+sonar.test.inclusions=**/*.spec.ts,**/*.test.ts,**/*.spec.tsx,**/*.test.tsx
+
+sonar.typescript.lcov.reportPaths=apps/backend/coverage/lcov.info
+
 sonar.sourceEncoding=UTF-8


### PR DESCRIPTION
## 🔗 관련 이슈

- close: #106

## ✅ 작업 내용

- 목표(Goal), 행동(Behavior), 사용자(User) 엔티티를 모델링했습니다.
  - 사용자의 경우 목표와의 관계를 나타낼 때 보여주기 위해서 최소한으로 모델링했습니다.
- 목표(goals), 행동(behaviors), 사용자(users) 테이블을 만들었습니다.
  - 각 테이블명은 복수형이며 열Columns은 camelCase 로 나타납니다.
- 목표명, 행동명, 유저 닉네임 최대 길이를 나타내는 상수를 추가했습니다.
- 목표 색상 Enum을 shared에 추가했습니다.
- 행동 난이도 Enum을 shared에 추가했습니다.
- 테스트 및 개발 편의 목적으로 테스트 사용자를 만드는 엔드포인트를 추가했습니다.

## 💡 체크리스트

- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (예: `feature/login` -> `develop`)
- [x] 테스트는 잘 통과했나요?
- [x] 빌드에 성공했나요?

## 💬 To Reviewers

해당 PR은 migration 파일을 가지고 있으므로 pnpm run migration:run 을 통해 해당 migration 파일을 DB 에 적용 시킬 수 있습니다.

오늘 행동, 추천 행동 등의 테이블은 필요에 따라 추가적으로 생성할 필요가 있습니다.