### PR TITLE
setting: shared cjs, esm dual 빌드 적용

### DIFF
--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -5,15 +5,24 @@
   "type": "commonjs",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
-      "default": "./dist/index.js"
+      "types": "./dist/types/index.d.ts",
+      "import": "./dist/esm/index.js",
+      "require": "./dist/cjs/index.js",
+      "default": "./dist/cjs/index.js"
     }
   },
-  "main": "./dist/index.js",
-  "types": "./dist/index.d.ts",
+  "main": "./dist/cjs/index.js",
+  "module": "./dist/esm/index.js",
+  "types": "./dist/types/index.d.ts",
   "scripts": {
-    "build": "tsc -p tsconfig.json",
-    "dev": "tsc -p tsconfig.json --watch"
+    "build": "pnpm run build:types && pnpm run build:cjs && pnpm run build:esm",
+    "build:cjs": "tsc -p tsconfig.cjs.json",
+    "build:esm": "tsc -p tsconfig.esm.json && node ./scripts/write-esm-package-json.cjs",
+    "build:types": "tsc -p tsconfig.types.json",
+    "dev": "pnpm -w exec concurrently \"pnpm --filter @web24/shared run dev:types\" \"pnpm --filter @web24/shared run dev:cjs\" \"pnpm --filter @web24/shared run dev:esm\"",
+    "dev:cjs": "tsc -p tsconfig.cjs.json --watch",
+    "dev:esm": "node ./scripts/write-esm-package-json.cjs && tsc -p tsconfig.esm.json --watch",
+    "dev:types": "tsc -p tsconfig.types.json --watch"
   },
   "dependencies": {
     "@asteasolutions/zod-to-openapi": "^8.4.0",

--- a/packages/shared/scripts/write-esm-package-json.cjs
+++ b/packages/shared/scripts/write-esm-package-json.cjs
@@ -1,0 +1,9 @@
+const fs = require('node:fs');
+const path = require('node:path');
+
+const outDir = path.join(__dirname, '..', 'dist', 'esm');
+fs.mkdirSync(outDir, { recursive: true });
+
+const pkgPath = path.join(outDir, 'package.json');
+const pkgJson = JSON.stringify({ type: 'module' }, null, 2);
+fs.writeFileSync(pkgPath, `${pkgJson}\n`);

--- a/packages/shared/tsconfig.cjs.json
+++ b/packages/shared/tsconfig.cjs.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "CommonJS",
+    "outDir": "./dist/cjs",
+    "declaration": false,
+    "declarationMap": false
+  }
+}

--- a/packages/shared/tsconfig.esm.json
+++ b/packages/shared/tsconfig.esm.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "ES2022",
+    "outDir": "./dist/esm",
+    "declaration": false,
+    "declarationMap": false
+  }
+}

--- a/packages/shared/tsconfig.types.json
+++ b/packages/shared/tsconfig.types.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist/types",
+    "emitDeclarationOnly": true
+  }
+}


### PR DESCRIPTION
## 🔗 관련 이슈

- close: #114

## ✅ 작업 내용

- packages/shared 가 기존 CJS 방식 빌드만 지원해서 ESM 방식을 사용하는 frontend 에서는 사용이 안 되는 문제 해결
- CJS, ESM 방식 모두로 build 하게 변경했습니다.

## 💡 체크리스트

- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (예: `feature/login` -> `develop`)
- [x] 테스트는 잘 통과했나요?
- [x] 빌드에 성공했나요?
