### PR TITLE
feat: 메인페이지의 행동카드를 클릭해서 행동의 상태를 변경할 수 있다.

### DIFF
--- a/apps/backend/src/common/database/migrations/1768285007894-auto.ts
+++ b/apps/backend/src/common/database/migrations/1768285007894-auto.ts
@@ -1,0 +1,23 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class Auto1768285007894 implements MigrationInterface {
+  name = 'Auto1768285007894';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TYPE "public"."today_behaviors_status_enum" AS ENUM('completed', 'skipped', 'ignored')`,
+    );
+    await queryRunner.query(
+      `CREATE TYPE "public"."today_behaviors_origin_enum" AS ENUM('user', 'recommendation')`,
+    );
+    await queryRunner.query(
+      `CREATE TABLE "today_behaviors" ("id" uuid NOT NULL DEFAULT uuidv7(), "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "deletedAt" TIMESTAMP WITH TIME ZONE, "date" date NOT NULL, "status" "public"."today_behaviors_status_enum" NOT NULL, "origin" "public"."today_behaviors_origin_enum" NOT NULL, "behaviorId" uuid, "userId" uuid, CONSTRAINT "PK_2e78bbed4665e030cac6457348c" PRIMARY KEY ("id"))`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP TABLE "today_behaviors"`);
+    await queryRunner.query(`DROP TYPE "public"."today_behaviors_origin_enum"`);
+    await queryRunner.query(`DROP TYPE "public"."today_behaviors_status_enum"`);
+  }
+}

--- a/apps/backend/src/common/database/migrations/1768291935168-auto.ts
+++ b/apps/backend/src/common/database/migrations/1768291935168-auto.ts
@@ -1,0 +1,31 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class Auto1768291935168 implements MigrationInterface {
+  name = 'Auto1768291935168';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TYPE "public"."today_behaviors_status_enum" RENAME TO "today_behaviors_status_enum_old"`,
+    );
+    await queryRunner.query(
+      `CREATE TYPE "public"."today_behaviors_status_enum" AS ENUM('pending', 'completed', 'skipped', 'ignored')`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "today_behaviors" ALTER COLUMN "status" TYPE "public"."today_behaviors_status_enum" USING "status"::"text"::"public"."today_behaviors_status_enum"`,
+    );
+    await queryRunner.query(`DROP TYPE "public"."today_behaviors_status_enum_old"`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TYPE "public"."today_behaviors_status_enum_old" AS ENUM('completed', 'skipped', 'ignored')`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "today_behaviors" ALTER COLUMN "status" TYPE "public"."today_behaviors_status_enum_old" USING "status"::"text"::"public"."today_behaviors_status_enum_old"`,
+    );
+    await queryRunner.query(`DROP TYPE "public"."today_behaviors_status_enum"`);
+    await queryRunner.query(
+      `ALTER TYPE "public"."today_behaviors_status_enum_old" RENAME TO "today_behaviors_status_enum"`,
+    );
+  }
+}

--- a/apps/backend/src/common/database/seed.ts
+++ b/apps/backend/src/common/database/seed.ts
@@ -4,6 +4,7 @@ import { AppDataSource } from './data-source';
 import { User } from '../../features/user/user.entity';
 import { Goal } from '../../features/goal/goal.entity';
 import { Behavior } from '../../features/behavior/behavior.entity';
+import { TodayBehavior } from '../../features/behavior/today-behavior.entity';
 
 async function seed() {
   await AppDataSource.initialize();
@@ -11,6 +12,7 @@ async function seed() {
   const userRepo = AppDataSource.getRepository(User);
   const goalRepo = AppDataSource.getRepository(Goal);
   const behaviorRepo = AppDataSource.getRepository(Behavior);
+  const todayBehaviorRepo = AppDataSource.getRepository(TodayBehavior);
 
   const nickname = '테스트유저';
   let user = await userRepo.findOne({ where: { nickname } });
@@ -60,6 +62,45 @@ async function seed() {
           goal,
         }),
       );
+    }
+  }
+
+  const todayDate = new Date().toISOString().slice(0, 10);
+  const todayBehaviorsData = [
+    { title: '물 1컵 마시기', goalTitle: '건강한 생활', status: 'completed', origin: 'user' },
+    { title: '스트레칭 5분', goalTitle: '건강한 생활', status: 'pending', origin: 'user' },
+    { title: '선 긋기 연습', goalTitle: '드로잉 마스터', status: 'skipped', origin: 'user' },
+  ] as const;
+
+  for (const tb of todayBehaviorsData) {
+    const goal = goals[tb.goalTitle];
+    if (goal) {
+      const behavior = await behaviorRepo.findOne({
+        where: { title: tb.title, goal: { id: goal.id } },
+        relations: { goal: true },
+      });
+
+      if (behavior) {
+        const exists = await todayBehaviorRepo.findOne({
+          where: {
+            date: todayDate,
+            user: { id: user.id },
+            behavior: { id: behavior.id },
+          },
+          relations: { user: true, behavior: true },
+        });
+        if (!exists) {
+          await todayBehaviorRepo.save(
+            todayBehaviorRepo.create({
+              date: todayDate,
+              status: tb.status,
+              origin: tb.origin,
+              user,
+              behavior,
+            }),
+          );
+        }
+      }
     }
   }
 

--- a/apps/backend/src/common/logger/http-exception.filter.ts
+++ b/apps/backend/src/common/logger/http-exception.filter.ts
@@ -8,6 +8,7 @@ import {
 } from '@nestjs/common';
 import type { Request, Response } from 'express';
 
+// MEMO: 성공 응답 통일
 @Catch()
 export class HttpExceptionLoggingFilter implements ExceptionFilter {
   private readonly logger = new Logger('HTTP');

--- a/apps/backend/src/features/behavior/behavior.controller.ts
+++ b/apps/backend/src/features/behavior/behavior.controller.ts
@@ -1,10 +1,11 @@
 import { Controller, Get } from '@nestjs/common';
 import { BehaviorService } from './behavior.service';
 
-@Controller('behavior')
+@Controller('behavior') // MEMO: s 추가하기, 추가한 후 프론트 엔드포인트, OPEN API 문서 경로 변경하기
 export class BehaviorController {
   constructor(private readonly behaviorService: BehaviorService) {}
 
+  // MEMO: 현재는 임시, 나중에 today-behavior.controller 로 이동
   @Get()
   async getTodayBehaviors() {
     return this.behaviorService.getTodayBehaviors();

--- a/apps/backend/src/features/behavior/behavior.docs.ts
+++ b/apps/backend/src/features/behavior/behavior.docs.ts
@@ -1,10 +1,32 @@
 import { OpenAPIRegistry } from '@asteasolutions/zod-to-openapi';
-import { GetTodayBehaviorsResponseSchema } from '@web24/shared';
+import { z } from 'zod';
+import {
+  GetTodayBehaviorsResponseSchema,
+  PatchTodayBehaviorStatusRequestSchema,
+  PatchTodayBehaviorStatusResponseSchema,
+} from '@web24/shared';
 
 export function registerBehaviorApi(registry: OpenAPIRegistry) {
   const getTodayBehaviorsResponse = registry.register(
     'GetTodayBehaviorsResponse',
     GetTodayBehaviorsResponseSchema,
+  );
+  const patchTodayBehaviorStatusRequest = registry.register(
+    'PatchTodayBehaviorStatusRequest',
+    PatchTodayBehaviorStatusRequestSchema,
+  );
+  const patchTodayBehaviorStatusResponse = registry.register(
+    'PatchTodayBehaviorStatusResponse',
+    PatchTodayBehaviorStatusResponseSchema,
+  );
+  const errorResponse = registry.register(
+    'ErrorResponse',
+    z.object({
+      statusCode: z.number().int(),
+      message: z.string(),
+      path: z.string(),
+      timestamp: z.string(),
+    }),
   );
 
   registry.registerPath({
@@ -16,6 +38,39 @@ export function registerBehaviorApi(registry: OpenAPIRegistry) {
         content: {
           'application/json': {
             schema: getTodayBehaviorsResponse,
+          },
+        },
+      },
+    },
+  });
+
+  registry.registerPath({
+    method: 'patch',
+    path: '/today-behaviors/{id}/status',
+    request: {
+      body: {
+        content: {
+          'application/json': {
+            schema: patchTodayBehaviorStatusRequest,
+          },
+        },
+      },
+    },
+    responses: {
+      200: {
+        description: 'Today behavior status updated',
+        content: {
+          'application/json': {
+            schema: patchTodayBehaviorStatusResponse,
+          },
+        },
+      },
+      404: {
+        description:
+          'Today behavior not found (service에서 대상 today behavior가 없어 상태 변경에 실패한 경우)',
+        content: {
+          'application/json': {
+            schema: errorResponse,
           },
         },
       },

--- a/apps/backend/src/features/behavior/behavior.module.ts
+++ b/apps/backend/src/features/behavior/behavior.module.ts
@@ -4,9 +4,10 @@ import { BehaviorController } from './behavior.controller';
 import { BehaviorService } from './behavior.service';
 import { Behavior } from './behavior.entity';
 import { Goal } from '../goal/goal.entity';
+import { TodayBehavior } from './today-behavior.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Behavior, Goal])],
+  imports: [TypeOrmModule.forFeature([Behavior, Goal, TodayBehavior])],
   controllers: [BehaviorController],
   providers: [BehaviorService],
 })

--- a/apps/backend/src/features/behavior/behavior.module.ts
+++ b/apps/backend/src/features/behavior/behavior.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { BehaviorController } from './behavior.controller';
+import { TodayBehaviorController } from './today-behavior.controller';
 import { BehaviorService } from './behavior.service';
 import { Behavior } from './behavior.entity';
 import { Goal } from '../goal/goal.entity';
@@ -8,7 +9,7 @@ import { TodayBehavior } from './today-behavior.entity';
 
 @Module({
   imports: [TypeOrmModule.forFeature([Behavior, Goal, TodayBehavior])],
-  controllers: [BehaviorController],
+  controllers: [BehaviorController, TodayBehaviorController],
   providers: [BehaviorService],
 })
 export class BehaviorModule {}

--- a/apps/backend/src/features/behavior/behavior.service.spec.ts
+++ b/apps/backend/src/features/behavior/behavior.service.spec.ts
@@ -1,14 +1,18 @@
+import { NotFoundException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { randomInt } from 'crypto';
+import { TodayBehaviorStatus } from '@web24/shared';
 import { BehaviorService } from './behavior.service';
 import { Behavior } from './behavior.entity';
+import { TodayBehavior } from './today-behavior.entity';
 
 jest.mock('crypto', () => ({ randomInt: jest.fn() }));
 
 describe('BehaviorService', () => {
   let service: BehaviorService;
   let repository: { createQueryBuilder: jest.Mock };
+  let todayBehaviorRepository: { update: jest.Mock };
   let queryBuilder: {
     leftJoinAndSelect: jest.Mock;
     orderBy: jest.Mock;
@@ -26,9 +30,14 @@ describe('BehaviorService', () => {
     repository = {
       createQueryBuilder: jest.fn().mockReturnValue(queryBuilder),
     };
+    todayBehaviorRepository = { update: jest.fn() };
 
     const module: TestingModule = await Test.createTestingModule({
-      providers: [BehaviorService, { provide: getRepositoryToken(Behavior), useValue: repository }],
+      providers: [
+        BehaviorService,
+        { provide: getRepositoryToken(Behavior), useValue: repository },
+        { provide: getRepositoryToken(TodayBehavior), useValue: todayBehaviorRepository },
+      ],
     }).compile();
 
     service = module.get<BehaviorService>(BehaviorService);
@@ -69,5 +78,28 @@ describe('BehaviorService', () => {
         isRecommended: false,
       },
     ]);
+  });
+
+  it('today behavior 상태를 업데이트한다', async () => {
+    todayBehaviorRepository.update.mockResolvedValue({ affected: 1 });
+
+    const result = await service.updateTodayBehaviorStatus(
+      'tb-1',
+      'completed' as TodayBehaviorStatus,
+    );
+
+    expect(todayBehaviorRepository.update).toHaveBeenCalledWith(
+      { id: 'tb-1' },
+      { status: 'completed' },
+    );
+    expect(result).toEqual({ id: 'tb-1', status: 'completed' });
+  });
+
+  it('대상이 없으면 NotFoundException을 던진다', async () => {
+    todayBehaviorRepository.update.mockResolvedValue({ affected: 0 });
+
+    await expect(
+      service.updateTodayBehaviorStatus('tb-404', 'completed' as TodayBehaviorStatus),
+    ).rejects.toBeInstanceOf(NotFoundException);
   });
 });

--- a/apps/backend/src/features/behavior/behavior.service.ts
+++ b/apps/backend/src/features/behavior/behavior.service.ts
@@ -11,6 +11,7 @@ export class BehaviorService {
   constructor(
     @InjectRepository(Behavior)
     private readonly behaviorRepository: Repository<Behavior>,
+    @InjectRepository(TodayBehavior)
     private readonly todayBehaviorRepository: Repository<TodayBehavior>,
   ) {}
 

--- a/apps/backend/src/features/behavior/behavior.service.ts
+++ b/apps/backend/src/features/behavior/behavior.service.ts
@@ -1,14 +1,17 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { Repository } from 'typeorm';
 import { InjectRepository } from '@nestjs/typeorm';
 import { randomInt } from 'node:crypto';
+import { TodayBehaviorStatus } from '@web24/shared';
 import { Behavior } from './behavior.entity';
+import { TodayBehavior } from './today-behavior.entity';
 
 @Injectable()
 export class BehaviorService {
   constructor(
     @InjectRepository(Behavior)
     private readonly behaviorRepository: Repository<Behavior>,
+    private readonly todayBehaviorRepository: Repository<TodayBehavior>,
   ) {}
 
   async getTodayBehaviors() {
@@ -32,5 +35,13 @@ export class BehaviorService {
       isChecked: false,
       isRecommended: false,
     }));
+  }
+
+  async updateTodayBehaviorStatus(id: string, status: TodayBehaviorStatus) {
+    const result = await this.todayBehaviorRepository.update({ id }, { status });
+    if (result.affected === 0) {
+      throw new NotFoundException('TodayBehavior not found');
+    }
+    return { id, status };
   }
 }

--- a/apps/backend/src/features/behavior/today-behavior.controller.spec.ts
+++ b/apps/backend/src/features/behavior/today-behavior.controller.spec.ts
@@ -1,0 +1,35 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { TodayBehaviorController } from './today-behavior.controller';
+import { BehaviorService } from './behavior.service';
+
+describe('TodayBehaviorController', () => {
+  let controller: TodayBehaviorController;
+  let service: { updateTodayBehaviorStatus: jest.Mock };
+
+  beforeEach(async () => {
+    service = { updateTodayBehaviorStatus: jest.fn() };
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [TodayBehaviorController],
+      providers: [{ provide: BehaviorService, useValue: service }],
+    }).compile();
+
+    controller = module.get<TodayBehaviorController>(TodayBehaviorController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  it('updateTodayBehaviorStatus가 서비스 결과를 반환한다', async () => {
+    const id = '01890fba-7e6a-7b6b-9e5d-0f3c9b8b4c6d';
+    const body = { status: 'completed' as const };
+    const mock = { id, status: body.status };
+    service.updateTodayBehaviorStatus.mockResolvedValue(mock);
+
+    const result = await controller.updateTodayBehaviorStatus(id, body);
+
+    expect(service.updateTodayBehaviorStatus).toHaveBeenCalledWith(id, body.status);
+    expect(result).toBe(mock);
+  });
+});

--- a/apps/backend/src/features/behavior/today-behavior.controller.ts
+++ b/apps/backend/src/features/behavior/today-behavior.controller.ts
@@ -1,0 +1,22 @@
+import { Body, Controller, Param, ParseUUIDPipe, Patch } from '@nestjs/common';
+import {
+  type PatchTodayBehaviorStatusRequest,
+  PatchTodayBehaviorStatusRequestSchema,
+  PatchTodayBehaviorStatusResponse,
+} from '@web24/shared';
+import { ZodValidationPipe } from 'src/common/pipes/zod-validation.pipe';
+import { BehaviorService } from './behavior.service';
+
+@Controller('today-behaviors')
+export class TodayBehaviorController {
+  constructor(private readonly behaviorService: BehaviorService) {}
+
+  @Patch(':id/status')
+  async updateTodayBehaviorStatus(
+    @Param('id', new ParseUUIDPipe()) id: string,
+    @Body(new ZodValidationPipe(PatchTodayBehaviorStatusRequestSchema))
+    body: PatchTodayBehaviorStatusRequest,
+  ): Promise<PatchTodayBehaviorStatusResponse> {
+    return this.behaviorService.updateTodayBehaviorStatus(id, body.status);
+  }
+}

--- a/apps/backend/src/features/behavior/today-behavior.controller.ts
+++ b/apps/backend/src/features/behavior/today-behavior.controller.ts
@@ -4,7 +4,7 @@ import {
   PatchTodayBehaviorStatusRequestSchema,
   PatchTodayBehaviorStatusResponse,
 } from '@web24/shared';
-import { ZodValidationPipe } from 'src/common/pipes/zod-validation.pipe';
+import { ZodValidationPipe } from '../../common/pipes/zod-validation.pipe';
 import { BehaviorService } from './behavior.service';
 
 @Controller('today-behaviors')

--- a/apps/backend/src/features/behavior/today-behavior.entity.spec.ts
+++ b/apps/backend/src/features/behavior/today-behavior.entity.spec.ts
@@ -1,0 +1,39 @@
+import { getMetadataArgsStorage } from 'typeorm';
+import { TodayBehavior } from './today-behavior.entity';
+
+const storage = getMetadataArgsStorage();
+
+const getTableName = (target: Function): string | undefined =>
+  storage.tables.find((table) => table.target === target)?.name;
+
+const getColumnNames = (target: Function): string[] =>
+  storage.columns.filter((column) => column.target === target).map((column) => column.propertyName);
+
+const getRelation = (target: Function, propertyName: string) =>
+  storage.relations.find(
+    (relation) => relation.target === target && relation.propertyName === propertyName,
+  );
+
+const getJoinColumn = (target: Function, propertyName: string) =>
+  storage.joinColumns.find(
+    (joinColumn) => joinColumn.target === target && joinColumn.propertyName === propertyName,
+  );
+
+describe('TodayBehavior', () => {
+  it('테이블과 컬럼 매핑을 가진다', () => {
+    expect(getTableName(TodayBehavior)).toBe('today_behaviors');
+    expect(getColumnNames(TodayBehavior)).toEqual(
+      expect.arrayContaining(['date', 'status', 'origin']),
+    );
+  });
+
+  it('Behavior, User 관계 매핑을 가진다', () => {
+    const behaviorRelation = getRelation(TodayBehavior, 'behavior');
+    expect(behaviorRelation?.relationType).toBe('many-to-one');
+    expect(getJoinColumn(TodayBehavior, 'behavior')?.name).toBe('behaviorId');
+
+    const userRelation = getRelation(TodayBehavior, 'user');
+    expect(userRelation?.relationType).toBe('many-to-one');
+    expect(getJoinColumn(TodayBehavior, 'user')?.name).toBe('userId');
+  });
+});

--- a/apps/backend/src/features/behavior/today-behavior.entity.ts
+++ b/apps/backend/src/features/behavior/today-behavior.entity.ts
@@ -1,0 +1,34 @@
+import { Column, Entity, JoinColumn, ManyToOne } from 'typeorm';
+import {
+  TODAY_BEHAVIOR_ORIGIN,
+  TODAY_BEHAVIOR_STATUS,
+  type TodayBehaviorOrigin,
+  type TodayBehaviorStatus,
+} from '@web24/shared';
+import { BaseIdCreatedUpdatedDeletedEntity } from '../../common/entities/base.entity';
+import { Behavior } from './behavior.entity';
+import { User } from '../user/user.entity';
+
+@Entity({ name: 'today_behaviors' })
+export class TodayBehavior extends BaseIdCreatedUpdatedDeletedEntity {
+  @ManyToOne(() => Behavior, {
+    createForeignKeyConstraints: false,
+  })
+  @JoinColumn({ name: 'behaviorId' })
+  behavior!: Behavior;
+
+  @ManyToOne(() => User, {
+    createForeignKeyConstraints: false,
+  })
+  @JoinColumn({ name: 'userId' })
+  user!: User;
+
+  @Column({ type: 'date' })
+  date!: string; // YYYY-MM-DD
+
+  @Column({ type: 'enum', enum: TODAY_BEHAVIOR_STATUS })
+  status!: TodayBehaviorStatus;
+
+  @Column({ type: 'enum', enum: TODAY_BEHAVIOR_ORIGIN })
+  origin!: TodayBehaviorOrigin;
+}

--- a/apps/frontend/src/features/behavior/apis/updateTodayBehaviorStatus.api.spec.ts
+++ b/apps/frontend/src/features/behavior/apis/updateTodayBehaviorStatus.api.spec.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { updateTodayBehaviorStatus } from './updateTodayBehaviorStatus.api';
+
+describe('updateTodayBehaviorStatus', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('성공 시 응답을 반환한다', async () => {
+    const id = '01890fba-7e6a-7b6b-9e5d-0f3c9b8b4c6d';
+    const status = 'completed';
+    const response = { id, status };
+
+    (fetch as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      json: async () => response,
+    });
+
+    const result = await updateTodayBehaviorStatus(id, status);
+
+    expect(result).toEqual(response);
+    expect(fetch).toHaveBeenCalledWith(`/api/today-behaviors/${id}/status`, {
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ status }),
+    });
+  });
+
+  it('요청 실패 시 에러를 던진다', async () => {
+    (fetch as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: false,
+    });
+
+    await expect(updateTodayBehaviorStatus('id', 'completed')).rejects.toThrow('Failed to fetch');
+  });
+});

--- a/apps/frontend/src/features/behavior/apis/updateTodayBehaviorStatus.api.ts
+++ b/apps/frontend/src/features/behavior/apis/updateTodayBehaviorStatus.api.ts
@@ -1,0 +1,25 @@
+import {
+  PatchTodayBehaviorStatusResponseSchema,
+  type PatchTodayBehaviorStatusResponse,
+  type TodayBehaviorStatus,
+} from '@web24/shared';
+
+export async function updateTodayBehaviorStatus(
+  id: string,
+  status: TodayBehaviorStatus,
+): Promise<PatchTodayBehaviorStatusResponse> {
+  const res = await fetch(`/api/today-behaviors/${id}/status`, {
+    method: 'PATCH',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ status }),
+  });
+
+  if (!res.ok) {
+    throw new Error('Failed to fetch');
+  }
+
+  const json = await res.json();
+  return PatchTodayBehaviorStatusResponseSchema.parse(json);
+}

--- a/apps/frontend/src/pages/IndexPage.tsx
+++ b/apps/frontend/src/pages/IndexPage.tsx
@@ -6,6 +6,7 @@ import type { Behavior } from '@/shared/components/behavior/BehaviorCard.types';
 import { TodayBahaviorList } from '@/features/behavior/components/TodayBehaviorList';
 import { fetchTodayBehaviors } from '@/features/behavior/apis/fetchBehaviors.api';
 import { fetchGoals } from '@/features/goal/apis/fetchGoals.api';
+import { updateTodayBehaviorStatus } from '@/features/behavior/apis/updateTodayBehaviorStatus.api';
 
 export function IndexPage() {
   const [behaviors, setBehaviors] = useState<Behavior[]>([]);
@@ -13,7 +14,15 @@ export function IndexPage() {
   const { quote, resetQuote } = useDodoChatStore();
 
   const handleToggle = (id: string) => {
+    const targetBehavior = behaviors.find((bs) => bs.id === id);
+    if (!targetBehavior) return;
+
     setBehaviors((bs) => bs.map((b) => (b.id === id ? { ...b, isChecked: !b.isChecked } : b)));
+
+    const nextStatus = targetBehavior.isChecked ? 'pending' : 'completed';
+    updateTodayBehaviorStatus(id, nextStatus).catch(() =>
+      setBehaviors((bs) => bs.map((b) => (b.id === id ? { ...b, isChecked: !b.isChecked } : b))),
+    );
   };
 
   useEffect(() => {

--- a/apps/frontend/src/pages/IndexPage.tsx
+++ b/apps/frontend/src/pages/IndexPage.tsx
@@ -13,15 +13,15 @@ export function IndexPage() {
   const [goalTitles, setGoalTitles] = useState<string[]>([]);
   const { quote, resetQuote } = useDodoChatStore();
 
+  const toggleBehaviorIsChecked = (behaviorId: string) => {
+    setBehaviors((bs) =>
+      bs.map((b) => (b.id === behaviorId ? { ...b, isChecked: !b.isChecked } : b)),
+    );
+  };
+
   const handleToggle = (id: string) => {
     const targetBehavior = behaviors.find((bs) => bs.id === id);
     if (!targetBehavior) return;
-
-    const toggleBehaviorIsChecked = (behaviorId: string) => {
-      setBehaviors((bs) =>
-        bs.map((b) => (b.id === behaviorId ? { ...b, isChecked: !b.isChecked } : b)),
-      );
-    };
 
     toggleBehaviorIsChecked(id);
 

--- a/apps/frontend/src/pages/IndexPage.tsx
+++ b/apps/frontend/src/pages/IndexPage.tsx
@@ -17,12 +17,16 @@ export function IndexPage() {
     const targetBehavior = behaviors.find((bs) => bs.id === id);
     if (!targetBehavior) return;
 
-    setBehaviors((bs) => bs.map((b) => (b.id === id ? { ...b, isChecked: !b.isChecked } : b)));
+    const toggleBehaviorIsChecked = (behaviorId: string) => {
+      setBehaviors((bs) =>
+        bs.map((b) => (b.id === behaviorId ? { ...b, isChecked: !b.isChecked } : b)),
+      );
+    };
+
+    toggleBehaviorIsChecked(id);
 
     const nextStatus = targetBehavior.isChecked ? 'pending' : 'completed';
-    updateTodayBehaviorStatus(id, nextStatus).catch(() =>
-      setBehaviors((bs) => bs.map((b) => (b.id === id ? { ...b, isChecked: !b.isChecked } : b))),
-    );
+    updateTodayBehaviorStatus(id, nextStatus).catch(() => toggleBehaviorIsChecked(id));
   };
 
   useEffect(() => {

--- a/packages/shared/src/schemas/behavior.schemas.ts
+++ b/packages/shared/src/schemas/behavior.schemas.ts
@@ -1,4 +1,4 @@
-import { BEHAVIOR_DIFFICULTIES } from '../types/behavior.types';
+import { BEHAVIOR_DIFFICULTIES, TODAY_BEHAVIOR_STATUS } from '../types/behavior.types';
 import { GOAL_COLORS } from '../types/goal.types';
 import { z } from '../zod';
 
@@ -16,3 +16,16 @@ export type TodayBehavior = z.infer<typeof TodayBehaviorSchema>;
 
 export const GetTodayBehaviorsResponseSchema = z.array(TodayBehaviorSchema);
 export type GetTodayBehaviorsResponse = z.infer<typeof GetTodayBehaviorsResponseSchema>;
+
+export const PatchTodayBehaviorStatusRequestSchema = z.object({
+  status: z.enum(TODAY_BEHAVIOR_STATUS),
+});
+export type PatchTodayBehaviorStatusRequest = z.infer<typeof PatchTodayBehaviorStatusRequestSchema>;
+
+export const PatchTodayBehaviorStatusResponseSchema = z.object({
+  id: z.uuid({ version: 'v7' }),
+  status: z.enum(TODAY_BEHAVIOR_STATUS),
+});
+export type PatchTodayBehaviorStatusResponse = z.infer<
+  typeof PatchTodayBehaviorStatusRequestSchema
+>;

--- a/packages/shared/src/types/behavior.types.ts
+++ b/packages/shared/src/types/behavior.types.ts
@@ -7,3 +7,11 @@ export const BEHAVIOR_DIFFICULTIES = [
 ] as const;
 
 export type BehaviorDifficulty = (typeof BEHAVIOR_DIFFICULTIES)[number];
+
+export const TODAY_BEHAVIOR_STATUS = ['completed', 'skipped', 'ignored'] as const;
+
+export type TodayBehaviorStatus = (typeof TODAY_BEHAVIOR_STATUS)[number];
+
+export const TODAY_BEHAVIOR_ORIGIN = ['user', 'recommendation'] as const;
+
+export type TodayBehaviorOrigin = (typeof TODAY_BEHAVIOR_ORIGIN)[number];

--- a/packages/shared/src/types/behavior.types.ts
+++ b/packages/shared/src/types/behavior.types.ts
@@ -8,7 +8,7 @@ export const BEHAVIOR_DIFFICULTIES = [
 
 export type BehaviorDifficulty = (typeof BEHAVIOR_DIFFICULTIES)[number];
 
-export const TODAY_BEHAVIOR_STATUS = ['completed', 'skipped', 'ignored'] as const;
+export const TODAY_BEHAVIOR_STATUS = ['pending', 'completed', 'skipped', 'ignored'] as const;
 
 export type TodayBehaviorStatus = (typeof TODAY_BEHAVIOR_STATUS)[number];
 


### PR DESCRIPTION
## 🔗 관련 이슈

- close: #136

## ✅ 작업 내용

- TodayBehavior 엔티티 생성 및 today_behavior 테이블 생성용 migration 파일 추가
- PATCH /today-behavior/:id/status 엔드포인트 추가, body로 { status: TodayBehaviorStatus } 받음.
  - 응답 성공 시 { id: string(uuid), status: TodayBehaviorStatus }
  - today_behavior 테이블에 id 에 해당하는 row 가 없을 경우 404 응답 (NotFoundException 던짐)
- IndexPage.tsx의 handleToggle 함수에서 낙관적 업데이트로 카드 상태를 먼저 변경
  - 먼저 UI 변경, 이후 updateTodayBehaviorStatus 를 호출하고, 실패시 rollback

## 💡 체크리스트

- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (예: `feature/login` -> `develop`)
- [x] 테스트는 잘 통과했나요?
- [x] 빌드에 성공했나요?

## 💬 To Reviewers

