### PR TITLE
feat: 오늘 행동 조회 API 구현 (추출 알고리즘 적용)

### DIFF
--- a/apps/backend/src/common/database/migrations/1768377501583-auto.ts
+++ b/apps/backend/src/common/database/migrations/1768377501583-auto.ts
@@ -1,0 +1,31 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class Auto1768377501583 implements MigrationInterface {
+  name = 'Auto1768377501583';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TYPE "public"."today_behaviors_origin_enum" RENAME TO "today_behaviors_origin_enum_old"`,
+    );
+    await queryRunner.query(
+      `CREATE TYPE "public"."today_behaviors_origin_enum" AS ENUM('user', 'system')`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "today_behaviors" ALTER COLUMN "origin" TYPE "public"."today_behaviors_origin_enum" USING "origin"::"text"::"public"."today_behaviors_origin_enum"`,
+    );
+    await queryRunner.query(`DROP TYPE "public"."today_behaviors_origin_enum_old"`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TYPE "public"."today_behaviors_origin_enum_old" AS ENUM('user', 'recommendation')`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "today_behaviors" ALTER COLUMN "origin" TYPE "public"."today_behaviors_origin_enum_old" USING "origin"::"text"::"public"."today_behaviors_origin_enum_old"`,
+    );
+    await queryRunner.query(`DROP TYPE "public"."today_behaviors_origin_enum"`);
+    await queryRunner.query(
+      `ALTER TYPE "public"."today_behaviors_origin_enum_old" RENAME TO "today_behaviors_origin_enum"`,
+    );
+  }
+}

--- a/apps/backend/src/common/utils/time.utils.spec.ts
+++ b/apps/backend/src/common/utils/time.utils.spec.ts
@@ -1,0 +1,35 @@
+import { getKstDayKey } from './time.utils';
+
+describe('getKstDayKey', () => {
+  it('기본 baseHour=4(오전 4시) 기준으로 날짜 문자열을 반환한다', () => {
+    const now = new Date(Date.UTC(2026, 0, 1, 0, 0, 0)); // 2026-01-01T00:00:00Z
+
+    const result = getKstDayKey(now);
+
+    expect(result).toBe('2026-01-01');
+  });
+
+  it('기본 baseHour=4(오전 4시) 기준으로 날짜가 넘어가면 다음 날짜를 반환한다', () => {
+    const now = new Date(Date.UTC(2026, 0, 1, 20, 0, 0)); // 2026-01-01T20:00:00Z -> KST:2026-01-02T05:00:00Z
+
+    const result = getKstDayKey(now);
+
+    expect(result).toBe('2026-01-02');
+  });
+
+  it('baseHour를 변경하면 기준 날짜가 달라진다', () => {
+    const now = new Date(Date.UTC(2026, 0, 1, 16, 0, 0));
+
+    const result = getKstDayKey(now, 0); // 날짜 변경 기준 시간을 00:00으로 설정
+
+    expect(result).toBe('2026-01-02');
+  });
+
+  it('baseHour(기본 오전 4시)부터는 해당 날짜로 계산한다', () => {
+    const kstThreeFiftyNine = new Date(Date.UTC(2025, 11, 31, 18, 59, 0)); // KST 2026-01-01 03:59
+    const kstFourAM = new Date(Date.UTC(2025, 11, 31, 19, 0, 0)); // KST 2026-01-01 04:00
+
+    expect(getKstDayKey(kstThreeFiftyNine)).toBe('2025-12-31');
+    expect(getKstDayKey(kstFourAM)).toBe('2026-01-01');
+  });
+});

--- a/apps/backend/src/common/utils/time.utils.ts
+++ b/apps/backend/src/common/utils/time.utils.ts
@@ -1,3 +1,5 @@
+// KST(UTC+9) 기준 날짜 키(YYYY-MM-DD)를 만든다.
+// 기본 baseHour=4: 하루 기준을 새벽 4시로 맞춘 뒤 날짜를 계산.
 export function getKstDayKey(now = new Date(), baseHour = 4) {
   const MILLISECONDS_PER_HOUR = 3_600_000;
   const kstMillis = now.getTime() + (9 - baseHour) * MILLISECONDS_PER_HOUR;

--- a/apps/backend/src/common/utils/time.utils.ts
+++ b/apps/backend/src/common/utils/time.utils.ts
@@ -1,0 +1,8 @@
+export function getKstDayKey(now = new Date(), baseHour = 4) {
+  const kstMillis =
+    now.getTime() +
+    9 * 60 * 60 * 1000 - // KST
+    baseHour * 60 * 60 * 1000; // 기준 시각
+
+  return new Date(kstMillis).toISOString().slice(0, 10);
+}

--- a/apps/backend/src/common/utils/time.utils.ts
+++ b/apps/backend/src/common/utils/time.utils.ts
@@ -1,8 +1,6 @@
 export function getKstDayKey(now = new Date(), baseHour = 4) {
-  const kstMillis =
-    now.getTime() +
-    9 * 60 * 60 * 1000 - // KST
-    baseHour * 60 * 60 * 1000; // 기준 시각
+  const MILLISECONDS_PER_HOUR = 3_600_000;
+  const kstMillis = now.getTime() + (9 - baseHour) * MILLISECONDS_PER_HOUR;
 
   return new Date(kstMillis).toISOString().slice(0, 10);
 }

--- a/apps/backend/src/features/behavior/behavior.controller.spec.ts
+++ b/apps/backend/src/features/behavior/behavior.controller.spec.ts
@@ -5,13 +5,11 @@ import { BehaviorService } from './behavior.service';
 describe('BehaviorController', () => {
   let controller: BehaviorController;
   let service: {
-    getTodayBehaviors: jest.Mock;
     getAllBehaviors: jest.Mock;
   };
 
   beforeEach(async () => {
     service = {
-      getTodayBehaviors: jest.fn(),
       getAllBehaviors: jest.fn(),
     };
 
@@ -25,16 +23,6 @@ describe('BehaviorController', () => {
 
   it('should be defined', () => {
     expect(controller).toBeDefined();
-  });
-
-  it('getTodayBehaviors가 서비스 결과를 반환한다', async () => {
-    const mock = [{ id: '1' }];
-    service.getTodayBehaviors.mockResolvedValue(mock);
-
-    const result = await controller.getTodayBehaviors();
-
-    expect(service.getTodayBehaviors).toHaveBeenCalledTimes(1);
-    expect(result).toBe(mock);
   });
 
   it('getAllBehaviors가 서비스 결과를 반환한다', async () => {

--- a/apps/backend/src/features/behavior/behavior.controller.ts
+++ b/apps/backend/src/features/behavior/behavior.controller.ts
@@ -1,15 +1,9 @@
 import { Controller, Get } from '@nestjs/common';
 import { BehaviorService } from './behavior.service';
 
-@Controller('behaviors') // MEMO: s 추가하기, 추가한 후 프론트 엔드포인트, OPEN API 문서 경로 변경하기
+@Controller('behaviors')
 export class BehaviorController {
   constructor(private readonly behaviorService: BehaviorService) {}
-
-  // MEMO: 현재는 임시, 나중에 today-behavior.controller 로 이동
-  @Get()
-  async getTodayBehaviors() {
-    return this.behaviorService.getTodayBehaviors();
-  }
 
   @Get('all')
   async getAllBehaviors() {

--- a/apps/backend/src/features/behavior/behavior.controller.ts
+++ b/apps/backend/src/features/behavior/behavior.controller.ts
@@ -1,7 +1,7 @@
 import { Controller, Get } from '@nestjs/common';
 import { BehaviorService } from './behavior.service';
 
-@Controller('behavior') // MEMO: s 추가하기, 추가한 후 프론트 엔드포인트, OPEN API 문서 경로 변경하기
+@Controller('behaviors') // MEMO: s 추가하기, 추가한 후 프론트 엔드포인트, OPEN API 문서 경로 변경하기
 export class BehaviorController {
   constructor(private readonly behaviorService: BehaviorService) {}
 

--- a/apps/backend/src/features/behavior/behavior.docs.ts
+++ b/apps/backend/src/features/behavior/behavior.docs.ts
@@ -36,7 +36,7 @@ export function registerBehaviorApi(registry: OpenAPIRegistry) {
 
   registry.registerPath({
     method: 'get',
-    path: '/behavior',
+    path: '/behaviors',
     responses: {
       200: {
         description: "Today's behaviors",

--- a/apps/backend/src/features/behavior/behavior.docs.ts
+++ b/apps/backend/src/features/behavior/behavior.docs.ts
@@ -36,7 +36,7 @@ export function registerBehaviorApi(registry: OpenAPIRegistry) {
 
   registry.registerPath({
     method: 'get',
-    path: '/behaviors',
+    path: '/today-behaviors',
     responses: {
       200: {
         description: "Today's behaviors",

--- a/apps/backend/src/features/behavior/behavior.docs.ts
+++ b/apps/backend/src/features/behavior/behavior.docs.ts
@@ -39,7 +39,8 @@ export function registerBehaviorApi(registry: OpenAPIRegistry) {
     path: '/today-behaviors',
     responses: {
       200: {
-        description: "Today's behaviors",
+        description:
+          '해당 날짜(새벽 4시 기준으로 변경)에 pending, completed 된 오늘 행동이 없으면 생성하고 반환, 있으면 기존 오늘 행동을 반환',
         content: {
           'application/json': {
             schema: getTodayBehaviorsResponse,

--- a/apps/backend/src/features/behavior/behavior.service.spec.ts
+++ b/apps/backend/src/features/behavior/behavior.service.spec.ts
@@ -146,7 +146,12 @@ describe('BehaviorService', () => {
     const todayRepository = {
       find: jest.fn().mockResolvedValue([]),
       create: jest.fn((value) => value),
-      save: jest.fn(),
+      save: jest.fn().mockResolvedValue([
+        {
+          id: 'b-1',
+          behavior: behaviors[0],
+        },
+      ]),
     };
     const userRepository = { findOne: jest.fn().mockResolvedValue(user) };
     const behaviorRepository = { find: jest.fn().mockResolvedValue(behaviors) };

--- a/apps/backend/src/features/behavior/behavior.service.spec.ts
+++ b/apps/backend/src/features/behavior/behavior.service.spec.ts
@@ -1,7 +1,6 @@
 import { NotFoundException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
-import { getRepositoryToken } from '@nestjs/typeorm';
-import { randomInt } from 'crypto';
+import { getDataSourceToken, getRepositoryToken } from '@nestjs/typeorm';
 import { TodayBehaviorStatus } from '@web24/shared';
 import { BehaviorService } from './behavior.service';
 import { Behavior } from './behavior.entity';
@@ -16,6 +15,7 @@ describe('BehaviorService', () => {
     find: jest.Mock;
   };
   let todayBehaviorRepository: { update: jest.Mock };
+  let dataSource: { transaction: jest.Mock };
   let queryBuilder: {
     leftJoinAndSelect: jest.Mock;
     orderBy: jest.Mock;
@@ -35,12 +35,14 @@ describe('BehaviorService', () => {
       find: jest.fn(),
     };
     todayBehaviorRepository = { update: jest.fn() };
+    dataSource = { transaction: jest.fn() };
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         BehaviorService,
         { provide: getRepositoryToken(Behavior), useValue: repository },
         { provide: getRepositoryToken(TodayBehavior), useValue: todayBehaviorRepository },
+        { provide: getDataSourceToken(), useValue: dataSource },
       ],
     }).compile();
 
@@ -49,39 +51,6 @@ describe('BehaviorService', () => {
 
   it('should be defined', () => {
     expect(service).toBeDefined();
-  });
-
-  it('랜덤 개수로 행동을 조회하고 응답을 매핑한다', async () => {
-    (randomInt as jest.Mock).mockReturnValue(4);
-
-    queryBuilder.getMany.mockResolvedValue([
-      {
-        id: 'b1',
-        title: '물 1컵 마시기',
-        difficulty: '마음열기',
-        goal: { title: '건강한 생활', color: 'mint' },
-      },
-    ]);
-
-    const result = await service.getTodayBehaviors();
-
-    expect(randomInt).toHaveBeenCalledWith(3, 13);
-    expect(repository.createQueryBuilder).toHaveBeenCalledWith('behavior');
-    expect(queryBuilder.leftJoinAndSelect).toHaveBeenCalledWith('behavior.goal', 'goal');
-    expect(queryBuilder.orderBy).toHaveBeenCalledWith('RANDOM()');
-    expect(queryBuilder.limit).toHaveBeenCalledWith(4);
-
-    expect(result).toEqual([
-      {
-        id: 'b1',
-        title: '물 1컵 마시기',
-        goalTitle: '건강한 생활',
-        goalColor: 'mint',
-        difficulty: '마음열기',
-        isChecked: false,
-        isRecommended: false,
-      },
-    ]);
   });
 
   it('today behavior 상태를 업데이트한다', async () => {

--- a/apps/backend/src/features/behavior/behavior.service.spec.ts
+++ b/apps/backend/src/features/behavior/behavior.service.spec.ts
@@ -1,3 +1,4 @@
+import { In, Not } from 'typeorm';
 import { NotFoundException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { getDataSourceToken, getRepositoryToken } from '@nestjs/typeorm';
@@ -74,6 +75,120 @@ describe('BehaviorService', () => {
     await expect(
       service.updateTodayBehaviorStatus('tb-404', 'completed' as TodayBehaviorStatus),
     ).rejects.toBeInstanceOf(NotFoundException);
+  });
+
+  it('getTodayBehaviors가 기존 오늘 행동이 있으면 매핑해서 반환한다', async () => {
+    const user = { id: 'user-1', nickname: '테스트유저' };
+    const existing = [
+      {
+        id: 'tb-1',
+        status: 'completed',
+        behavior: {
+          title: '물 1컵 마시기',
+          difficulty: '마음열기',
+          goal: { title: '건강한 생활', color: 'mint' },
+        },
+        user,
+      },
+    ] as TodayBehavior[];
+
+    const userRepository = { findOne: jest.fn().mockResolvedValue(user) };
+    const todayRepository = { find: jest.fn().mockResolvedValue(existing) };
+    const behaviorRepository = { find: jest.fn() };
+    const manager = {
+      getRepository: (entity: unknown) => {
+        if (entity === (Behavior as unknown)) return behaviorRepository;
+        if (entity === (TodayBehavior as unknown)) return todayRepository;
+        return userRepository;
+      },
+    };
+
+    dataSource.transaction.mockImplementation(async (work: (m: typeof manager) => unknown) =>
+      work(manager),
+    );
+
+    const result = await service.getTodayBehaviors();
+
+    expect(userRepository.findOne).toHaveBeenCalledWith({ where: { nickname: '테스트유저' } });
+    expect(todayRepository.find).toHaveBeenCalledWith({
+      where: {
+        date: expect.any(String),
+        user: { id: user.id },
+        status: Not(In(['skipped', 'ignored'])),
+      },
+      relations: { behavior: { goal: true }, user: true },
+    });
+    expect(behaviorRepository.find).not.toHaveBeenCalled();
+    expect(result).toEqual([
+      {
+        id: 'tb-1',
+        title: '물 1컵 마시기',
+        goalTitle: '건강한 생활',
+        goalColor: 'mint',
+        difficulty: '마음열기',
+        isChecked: true,
+        isRecommended: false,
+      },
+    ]);
+  });
+
+  it('getTodayBehaviors가 기존 오늘 행동이 없으면 추출 후 저장하고 반환한다', async () => {
+    const user = { id: 'user-1', nickname: '테스트유저' };
+    const behaviors = [
+      {
+        id: 'b-1',
+        title: '물 1컵 마시기',
+        difficulty: '마음열기',
+        goal: { title: '건강한 생활', color: 'mint' },
+      },
+    ] as Behavior[];
+
+    const todayRepository = {
+      find: jest.fn().mockResolvedValue([]),
+      create: jest.fn((value) => value),
+      save: jest.fn(),
+    };
+    const userRepository = { findOne: jest.fn().mockResolvedValue(user) };
+    const behaviorRepository = { find: jest.fn().mockResolvedValue(behaviors) };
+    const manager = {
+      getRepository: (entity: unknown) => {
+        if (entity === (Behavior as unknown)) return behaviorRepository;
+        if (entity === (TodayBehavior as unknown)) return todayRepository;
+        return userRepository;
+      },
+    };
+
+    dataSource.transaction.mockImplementation(async (work: (m: typeof manager) => unknown) =>
+      work(manager),
+    );
+    const extractSpy = jest.spyOn(service, 'extractTodayBehaviors').mockReturnValue(behaviors);
+
+    const result = await service.getTodayBehaviors();
+
+    expect(userRepository.findOne).toHaveBeenCalledWith({ where: { nickname: '테스트유저' } });
+    expect(todayRepository.find).toHaveBeenCalledWith({
+      where: {
+        date: expect.any(String),
+        user: { id: user.id },
+        status: Not(In(['skipped', 'ignored'])),
+      },
+      relations: { behavior: { goal: true }, user: true },
+    });
+    expect(behaviorRepository.find).toHaveBeenCalledWith({ relations: { goal: true } });
+    expect(extractSpy).toHaveBeenCalledWith(behaviors);
+    expect(todayRepository.save).toHaveBeenCalledTimes(1);
+    expect(result).toEqual([
+      {
+        id: 'b-1',
+        title: '물 1컵 마시기',
+        goalTitle: '건강한 생활',
+        goalColor: 'mint',
+        difficulty: '마음열기',
+        isChecked: false,
+        isRecommended: false,
+      },
+    ]);
+    extractSpy.mockRestore();
   });
 
   describe('extractTodayBehaviors', () => {

--- a/apps/backend/src/features/behavior/behavior.service.ts
+++ b/apps/backend/src/features/behavior/behavior.service.ts
@@ -60,14 +60,14 @@ export class BehaviorService {
         }),
       );
 
-      await manager.getRepository(TodayBehavior).save(toSave);
+      const newTodayBehaviors = await manager.getRepository(TodayBehavior).save(toSave);
 
-      return extractedTodayBehavior.map((b) => ({
+      return newTodayBehaviors.map((b) => ({
         id: b.id,
-        title: b.title,
-        goalTitle: b.goal.title,
-        goalColor: b.goal.color,
-        difficulty: b.difficulty,
+        title: b.behavior.title,
+        goalTitle: b.behavior.goal.title,
+        goalColor: b.behavior.goal.color,
+        difficulty: b.behavior.difficulty,
         isChecked: false,
         isRecommended: false,
       }));

--- a/apps/backend/src/features/behavior/behavior.service.ts
+++ b/apps/backend/src/features/behavior/behavior.service.ts
@@ -1,10 +1,11 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
-import { Repository } from 'typeorm';
-import { InjectRepository } from '@nestjs/typeorm';
-import { randomInt } from 'node:crypto';
+import { DataSource, In, Not, Repository } from 'typeorm';
+import { InjectDataSource, InjectRepository } from '@nestjs/typeorm';
 import { TodayBehaviorStatus } from '@web24/shared';
+import { getKstDayKey } from '../../common/utils/time.utils';
 import { Behavior } from './behavior.entity';
 import { TodayBehavior } from './today-behavior.entity';
+import { User } from '../user/user.entity';
 
 @Injectable()
 export class BehaviorService {
@@ -13,29 +14,64 @@ export class BehaviorService {
     private readonly behaviorRepository: Repository<Behavior>,
     @InjectRepository(TodayBehavior)
     private readonly todayBehaviorRepository: Repository<TodayBehavior>,
+    @InjectDataSource()
+    private readonly dataSource: DataSource,
   ) {}
 
   async getTodayBehaviors() {
-    const MIN = 3;
-    const MAX = 12;
-    const count = randomInt(MIN, MAX + 1);
+    return this.dataSource.transaction(async (manager) => {
+      const todayDate = getKstDayKey();
 
-    const behaviors = await this.behaviorRepository
-      .createQueryBuilder('behavior')
-      .leftJoinAndSelect('behavior.goal', 'goal')
-      .orderBy('RANDOM()')
-      .limit(count)
-      .getMany();
+      const user = await manager.getRepository(User).findOne({ where: { nickname: '테스트유저' } });
+      if (!user) {
+        throw new NotFoundException('User not found');
+      }
 
-    return behaviors.map((b) => ({
-      id: b.id,
-      title: b.title,
-      goalTitle: b.goal.title,
-      goalColor: b.goal.color,
-      difficulty: b.difficulty,
-      isChecked: false,
-      isRecommended: false,
-    }));
+      const existingTodayBehavior = await manager.getRepository(TodayBehavior).find({
+        where: { date: todayDate, user: { id: user.id }, status: Not(In(['skipped', 'ignored'])) },
+        relations: { behavior: { goal: true }, user: true },
+      });
+
+      if (existingTodayBehavior.length > 0) {
+        return existingTodayBehavior.map((b) => ({
+          id: b.id,
+          title: b.behavior.title,
+          goalTitle: b.behavior.goal.title,
+          goalColor: b.behavior.goal.color,
+          difficulty: b.behavior.difficulty,
+          isChecked: b.status === 'completed',
+          isRecommended: false, // AI 추천 여부
+        }));
+      }
+
+      const behaviors = await manager.getRepository(Behavior).find({
+        relations: { goal: true },
+      });
+
+      const extractedTodayBehavior = this.extractTodayBehaviors(behaviors);
+
+      const toSave = extractedTodayBehavior.map((behavior) =>
+        manager.getRepository(TodayBehavior).create({
+          date: todayDate,
+          status: 'pending',
+          origin: 'system',
+          user,
+          behavior,
+        }),
+      );
+
+      await manager.getRepository(TodayBehavior).save(toSave);
+
+      return extractedTodayBehavior.map((b) => ({
+        id: b.id,
+        title: b.title,
+        goalTitle: b.goal.title,
+        goalColor: b.goal.color,
+        difficulty: b.difficulty,
+        isChecked: false,
+        isRecommended: false,
+      }));
+    });
   }
 
   async updateTodayBehaviorStatus(id: string, status: TodayBehaviorStatus) {

--- a/apps/backend/src/features/behavior/today-behavior.controller.spec.ts
+++ b/apps/backend/src/features/behavior/today-behavior.controller.spec.ts
@@ -4,10 +4,10 @@ import { BehaviorService } from './behavior.service';
 
 describe('TodayBehaviorController', () => {
   let controller: TodayBehaviorController;
-  let service: { updateTodayBehaviorStatus: jest.Mock };
+  let service: { updateTodayBehaviorStatus: jest.Mock; getTodayBehaviors: jest.Mock };
 
   beforeEach(async () => {
-    service = { updateTodayBehaviorStatus: jest.fn() };
+    service = { updateTodayBehaviorStatus: jest.fn(), getTodayBehaviors: jest.fn() };
 
     const module: TestingModule = await Test.createTestingModule({
       controllers: [TodayBehaviorController],
@@ -19,6 +19,16 @@ describe('TodayBehaviorController', () => {
 
   it('should be defined', () => {
     expect(controller).toBeDefined();
+  });
+
+  it('getTodayBehaviors가 서비스 결과를 반환한다', async () => {
+    const mock = [{ id: '1' }];
+    service.getTodayBehaviors.mockResolvedValue(mock);
+
+    const result = await controller.getTodayBehaviors();
+
+    expect(service.getTodayBehaviors).toHaveBeenCalledTimes(1);
+    expect(result).toBe(mock);
   });
 
   it('updateTodayBehaviorStatus가 서비스 결과를 반환한다', async () => {

--- a/apps/backend/src/features/behavior/today-behavior.controller.ts
+++ b/apps/backend/src/features/behavior/today-behavior.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Param, ParseUUIDPipe, Patch } from '@nestjs/common';
+import { Get, Body, Controller, Param, ParseUUIDPipe, Patch } from '@nestjs/common';
 import {
   type PatchTodayBehaviorStatusRequest,
   PatchTodayBehaviorStatusRequestSchema,
@@ -10,6 +10,11 @@ import { BehaviorService } from './behavior.service';
 @Controller('today-behaviors')
 export class TodayBehaviorController {
   constructor(private readonly behaviorService: BehaviorService) {}
+
+  @Get()
+  async getTodayBehaviors() {
+    return this.behaviorService.getTodayBehaviors();
+  }
 
   @Patch(':id/status')
   async updateTodayBehaviorStatus(

--- a/apps/frontend/src/features/behavior/apis/fetchBehaviors.api.spec.ts
+++ b/apps/frontend/src/features/behavior/apis/fetchBehaviors.api.spec.ts
@@ -41,7 +41,7 @@ describe('fetchTodayBehaviors', () => {
 
     const result = await fetchTodayBehaviors();
     expect(result).toEqual(mockBehaviors);
-    expect(fetch).toHaveBeenCalledWith('/api/behavior', expect.any(Object));
+    expect(fetch).toHaveBeenCalledWith('/api/behaviors', expect.any(Object));
   });
 
   it('throws error on fetch failure', async () => {

--- a/apps/frontend/src/features/behavior/apis/fetchBehaviors.api.spec.ts
+++ b/apps/frontend/src/features/behavior/apis/fetchBehaviors.api.spec.ts
@@ -41,7 +41,7 @@ describe('fetchTodayBehaviors', () => {
 
     const result = await fetchTodayBehaviors();
     expect(result).toEqual(mockBehaviors);
-    expect(fetch).toHaveBeenCalledWith('/api/behaviors', expect.any(Object));
+    expect(fetch).toHaveBeenCalledWith('/api/today-behaviors', expect.any(Object));
   });
 
   it('throws error on fetch failure', async () => {

--- a/apps/frontend/src/features/behavior/apis/fetchBehaviors.api.ts
+++ b/apps/frontend/src/features/behavior/apis/fetchBehaviors.api.ts
@@ -1,7 +1,7 @@
 import type { Behavior } from '@/shared/components/behavior/BehaviorCard.types';
 
 export async function fetchTodayBehaviors(): Promise<Behavior[]> {
-  const res = await fetch('/api/behaviors', {
+  const res = await fetch('/api/today-behaviors', {
     method: 'GET',
     headers: {
       'Content-Type': 'application/json',

--- a/apps/frontend/src/features/behavior/apis/fetchBehaviors.api.ts
+++ b/apps/frontend/src/features/behavior/apis/fetchBehaviors.api.ts
@@ -1,7 +1,7 @@
 import type { Behavior } from '@/shared/components/behavior/BehaviorCard.types';
 
 export async function fetchTodayBehaviors(): Promise<Behavior[]> {
-  const res = await fetch('/api/behavior', {
+  const res = await fetch('/api/behaviors', {
     method: 'GET',
     headers: {
       'Content-Type': 'application/json',

--- a/apps/frontend/src/features/goal/apis/fetchAllBehaviors.api.spec.ts
+++ b/apps/frontend/src/features/goal/apis/fetchAllBehaviors.api.spec.ts
@@ -24,7 +24,7 @@ describe('fetchAllBehaviors', () => {
 
     const result = await fetchAllBehaviors();
 
-    expect(fetch).toHaveBeenCalledWith('/api/behavior/all', {
+    expect(fetch).toHaveBeenCalledWith('/api/behaviors/all', {
       method: 'GET',
       headers: {
         'Content-Type': 'application/json',

--- a/apps/frontend/src/features/goal/apis/fetchAllBehaviors.api.ts
+++ b/apps/frontend/src/features/goal/apis/fetchAllBehaviors.api.ts
@@ -1,7 +1,7 @@
 import { GetAllBehaviorsResponseSchema, type Behavior } from '@web24/shared';
 
 export async function fetchAllBehaviors(): Promise<Behavior[]> {
-  const res = await fetch('/api/behavior/all', {
+  const res = await fetch('/api/behaviors/all', {
     method: 'GET',
     headers: {
       'Content-Type': 'application/json',

--- a/packages/shared/src/types/behavior.types.ts
+++ b/packages/shared/src/types/behavior.types.ts
@@ -12,7 +12,7 @@ export const TODAY_BEHAVIOR_STATUS = ['pending', 'completed', 'skipped', 'ignore
 
 export type TodayBehaviorStatus = (typeof TODAY_BEHAVIOR_STATUS)[number];
 
-export const TODAY_BEHAVIOR_ORIGIN = ['user', 'recommendation'] as const;
+export const TODAY_BEHAVIOR_ORIGIN = ['user', 'system'] as const;
 
 export type TodayBehaviorOrigin = (typeof TODAY_BEHAVIOR_ORIGIN)[number];
 


### PR DESCRIPTION
## 🔗 관련 이슈

- close: #138 

## ✅ 작업 내용
- behavior -> behaviors로 API URL 변경 (GET behavior/all -> behaviors/all)
- GET behavior -> GET today-behaviors로 URL 변경 및 로직 변경
  - 기존 랜덤 로직 삭제 후 extractTodayBehaviors 추출 로직으로 변경
  - API 요청 시 today_behaviors 테이블에서 해당 날짜의 행동을 로드하여 (오전 4시 기준)
    - 없는 경우 새롭게 추출하여 저장
    - 있는 경우 skipped, ignored 제외하고 반환
- GET today-behaviors 테스트 코드 및 문서화 추가

## 📸 스크린샷 / 데모

<img width="700" alt="image" src="https://github.com/user-attachments/assets/11b47a6a-9a85-496c-9411-095414eb35e9" />

- 전체 34개의 행동 중 0.8 비율로 27개 행동이 추출됨
- 새로고침할 때마다 달라지지 않음

## 🧪 테스트 방법
1. 메인페이지 접속
2. 행동이 추출되었는지 개수 확인
3. 새로고침 후 이전과 리스트가 동일한지 확인

## 💡 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (예: `feature/login` -> `develop`)
- [x] 테스트는 잘 통과했나요?
- [x] 빌드에 성공했나요?

## 💬 To Reviewers
- today_behaviors 테이블에 추가할 때 오전 4시 기준으로 날짜를 보정하여 넣고 있습니다. 관련 유틸함수 추가하였으니 확인 부탁드립니다.
- today_behaviors 테이블에 정의된 origin enum 값을 ['user', **'recommendation' -> 'system'**] 으로 변경하였습니다.
  - recommendation의 의미가 추출된 행동과 AI 추천의 의미가 불명확하여 추출된 행동을 강조하기 위해 변경하였습니다. (FE 용어와 중복)
  - 해당 변경점 반영 위해서 migration:run 필요합니다.