### PR TITLE
feat: 목표 상세페이지 누적 스탬프 기록 조회 기능 구현

### DIFF
--- a/apps/backend/src/features/behavior/behavior.entity.ts
+++ b/apps/backend/src/features/behavior/behavior.entity.ts
@@ -1,4 +1,4 @@
-import { Column, Entity, JoinColumn, ManyToOne } from 'typeorm';
+import { Column, Entity, JoinColumn, ManyToOne, OneToMany } from 'typeorm';
 import {
   BEHAVIOR_DIFFICULTIES,
   BEHAVIOR_TITLE_MAX_LENGTH,
@@ -6,6 +6,7 @@ import {
 } from '@web24/shared';
 import { BaseIdCreatedUpdatedDeletedEntity } from '../../common/entities/base.entity';
 import { Goal } from '../goal/goal.entity';
+import { TodayBehavior } from './today-behavior.entity';
 
 @Entity({ name: 'behaviors' })
 export class Behavior extends BaseIdCreatedUpdatedDeletedEntity {
@@ -20,4 +21,7 @@ export class Behavior extends BaseIdCreatedUpdatedDeletedEntity {
 
   @Column({ type: 'enum', enum: BEHAVIOR_DIFFICULTIES })
   difficulty!: BehaviorDifficulty;
+
+  @OneToMany(() => TodayBehavior, (tb) => tb.behavior)
+  todayBehaviors!: TodayBehavior[];
 }

--- a/apps/backend/src/features/behavior/today-behavior.entity.ts
+++ b/apps/backend/src/features/behavior/today-behavior.entity.ts
@@ -11,7 +11,7 @@ import { User } from '../user/user.entity';
 
 @Entity({ name: 'today_behaviors' })
 export class TodayBehavior extends BaseIdCreatedUpdatedDeletedEntity {
-  @ManyToOne(() => Behavior, {
+  @ManyToOne(() => Behavior, (behavior) => behavior.todayBehaviors, {
     createForeignKeyConstraints: false,
   })
   @JoinColumn({ name: 'behaviorId' })

--- a/apps/backend/src/features/goal/goal.controller.spec.ts
+++ b/apps/backend/src/features/goal/goal.controller.spec.ts
@@ -13,6 +13,7 @@ describe('GoalController', () => {
     createGoal: jest.Mock;
     getGoals: jest.Mock;
     getGoalBehaviors: jest.Mock;
+    getGoalStamps: jest.Mock;
   };
 
   beforeEach(async () => {
@@ -20,6 +21,7 @@ describe('GoalController', () => {
       createGoal: jest.fn(),
       getGoals: jest.fn(),
       getGoalBehaviors: jest.fn(),
+      getGoalStamps: jest.fn(),
     };
 
     const module: TestingModule = await Test.createTestingModule({
@@ -59,6 +61,23 @@ describe('GoalController', () => {
     ]);
 
     expect(goalService.getGoals).toHaveBeenCalledTimes(1);
+  });
+
+  it('id로 목표 스탬프 목록을 반환한다', async () => {
+    const mockStamps = [
+      { id: 's1', behavior: { difficulty: '몰입하기' } },
+      { id: 's2', behavior: { difficulty: '시작하기' } },
+    ];
+
+    goalService.getGoalStamps.mockResolvedValue(mockStamps);
+
+    await expect(controller.getGoalStamps('goal-abc')).resolves.toEqual([
+      { id: 's1', difficulty: '몰입하기' },
+      { id: 's2', difficulty: '시작하기' },
+    ]);
+
+    expect(goalService.getGoalStamps).toHaveBeenCalledWith('goal-abc');
+    expect(goalService.getGoalStamps).toHaveBeenCalledTimes(1);
   });
 
   it('템플릿 목록을 반환한다', async () => {

--- a/apps/backend/src/features/goal/goal.controller.ts
+++ b/apps/backend/src/features/goal/goal.controller.ts
@@ -40,6 +40,15 @@ export class GoalController {
     }));
   }
 
+  @Get(':id/stamps')
+  async getGoalStamps(@Param('id', ParseUUIDPipe) id: string) {
+    const goalStamps = await this.goalService.getGoalStamps(id);
+    return goalStamps.map((gs) => ({
+      id: gs.id,
+      difficulty: gs.behavior.difficulty,
+    }));
+  }
+
   @Get('templates')
   async getTemplates(): Promise<GoalTemplateListResponse> {
     const filePath = join(process.cwd(), 'src/features/goal/goal-templates.ndjson');

--- a/apps/backend/src/features/goal/goal.docs.ts
+++ b/apps/backend/src/features/goal/goal.docs.ts
@@ -5,6 +5,7 @@ import {
   CreateGoalResponseSchema,
   GoalTemplateListResponseSchema,
   GetGoalBehaviorsResponseSchema,
+  GetGoalStampsResponseSchema,
 } from '@web24/shared';
 
 export function registerGoalApi(registry: OpenAPIRegistry) {
@@ -18,6 +19,10 @@ export function registerGoalApi(registry: OpenAPIRegistry) {
   const getGoalBehaviorsResponse = registry.register(
     'GetGoalBehaviorsResponse',
     GetGoalBehaviorsResponseSchema,
+  );
+  const getGoalStampsResponse = registry.register(
+    'GetGoalStampsResponse',
+    GetGoalStampsResponseSchema,
   );
 
   registry.registerPath({
@@ -83,6 +88,21 @@ export function registerGoalApi(registry: OpenAPIRegistry) {
         content: {
           'application/json': {
             schema: getGoalBehaviorsResponse,
+          },
+        },
+      },
+    },
+  });
+
+  registry.registerPath({
+    method: 'get',
+    path: '/goals/{id}/stamps',
+    responses: {
+      200: {
+        description: 'List of stamps for a goal',
+        content: {
+          'application/json': {
+            schema: getGoalStampsResponse,
           },
         },
       },

--- a/apps/backend/src/features/goal/goal.module.ts
+++ b/apps/backend/src/features/goal/goal.module.ts
@@ -5,9 +5,10 @@ import { User } from '../user/user.entity';
 import { GoalController } from './goal.controller';
 import { Goal } from './goal.entity';
 import { GoalService } from './goal.service';
+import { TodayBehavior } from '../behavior/today-behavior.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Goal, Behavior, User])],
+  imports: [TypeOrmModule.forFeature([Goal, Behavior, TodayBehavior, User])],
   controllers: [GoalController],
   providers: [GoalService],
 })

--- a/apps/backend/src/features/goal/goal.service.spec.ts
+++ b/apps/backend/src/features/goal/goal.service.spec.ts
@@ -2,6 +2,7 @@ import { NotFoundException } from '@nestjs/common';
 import type { CreateGoalRequest } from '@web24/shared';
 import { DataSource } from 'typeorm';
 import { GoalService } from './goal.service';
+import { TodayBehavior } from '../behavior/today-behavior.entity';
 import { Behavior } from '../behavior/behavior.entity';
 import { Goal } from './goal.entity';
 import { User } from '../user/user.entity';
@@ -17,236 +18,237 @@ describe('GoalService', () => {
     behaviors: [{ title: '물 한 컵 마시기', difficulty: '마음열기' }],
   };
 
-  it('목표 목록을 반환한다', async () => {
-    const user = { id: 'user-1', nickname: '테스트유저' };
-    const userRepository = { findOne: jest.fn().mockResolvedValue(user) };
+  describe('getGoals', () => {
+    it('목표 목록을 반환한다', async () => {
+      const user = { id: 'user-1', nickname: '테스트유저' };
+      const userRepository = { findOne: jest.fn().mockResolvedValue(user) };
 
-    const goals = [
-      { id: 'goal-1', title: '건강', color: 'mint', user, behaviorCount: 0 },
-      { id: 'goal-2', title: '독서', color: 'beige', user, behaviorCount: 0 },
-    ];
-    const goalRepository = { find: jest.fn().mockResolvedValue(goals) };
+      const goals = [
+        { id: 'goal-1', title: '건강', color: 'mint', user, behaviorCount: 0 },
+        { id: 'goal-2', title: '독서', color: 'beige', user, behaviorCount: 0 },
+      ];
+      const goalRepository = { find: jest.fn().mockResolvedValue(goals) };
 
-    const dataSource = {
-      getRepository: jest.fn((entity: Function) => {
-        if (entity === User) return userRepository;
-        if (entity === Goal) return goalRepository;
-        return null;
-      }),
-    } as unknown as DataSource;
+      const dataSource = {
+        getRepository: jest.fn((entity: Function) => {
+          if (entity === User) return userRepository;
+          if (entity === Goal) return goalRepository;
+          return null;
+        }),
+      } as unknown as DataSource;
 
-    const service = new GoalService(dataSource);
+      const service = new GoalService(dataSource);
 
-    await expect(service.getGoals()).resolves.toEqual(goals);
-    expect(userRepository.findOne).toHaveBeenCalledWith({ where: { nickname: '테스트유저' } });
-    expect(goalRepository.find).toHaveBeenCalledWith(
-      expect.objectContaining({
-        where: { user: { id: user.id } },
-      }),
-    );
-  });
+      await expect(service.getGoals()).resolves.toEqual(goals);
+      expect(userRepository.findOne).toHaveBeenCalledWith({ where: { nickname: '테스트유저' } });
+      expect(goalRepository.find).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { user: { id: user.id } },
+        }),
+      );
+    });
 
-  it('유저가 없으면 getGoals가 NotFoundException을 던진다', async () => {
-    const userRepository = { findOne: jest.fn().mockResolvedValue(null) };
-    const goalRepository = { find: jest.fn() };
+    it('유저가 없으면 NotFoundException을 던진다', async () => {
+      const userRepository = { findOne: jest.fn().mockResolvedValue(null) };
+      const goalRepository = { find: jest.fn() };
 
-    const dataSource = {
-      getRepository: jest.fn((entity: Function) => {
-        if (entity === User) return userRepository;
-        if (entity === Goal) return goalRepository;
-        return null;
-      }),
-    } as unknown as DataSource;
+      const dataSource = {
+        getRepository: jest.fn((entity: Function) => {
+          if (entity === User) return userRepository;
+          if (entity === Goal) return goalRepository;
+          return null;
+        }),
+      } as unknown as DataSource;
 
-    const service = new GoalService(dataSource);
+      const service = new GoalService(dataSource);
 
-    await expect(service.getGoals()).rejects.toBeInstanceOf(NotFoundException);
-    expect(goalRepository.find).not.toHaveBeenCalled();
-  });
-
-  it('goalId로 완료된 TodayBehavior 목록만 반환한다', async () => {
-    const mockBehaviors = [
-      {
-        id: 'b1',
-        todayBehaviors: [
-          { id: 'tb1', status: 'completed', behavior: { id: 'b1' } },
-          { id: 'tb2', status: 'pending', behavior: { id: 'b1' } },
-        ],
-      },
-      {
-        id: 'b2',
-        todayBehaviors: [{ id: 'tb3', status: 'completed', behavior: { id: 'b2' } }],
-      },
-    ];
-
-    const behaviorRepository = {
-      find: jest.fn().mockResolvedValue(mockBehaviors),
-    };
-
-    const dataSource = {
-      getRepository: jest.fn((entity: Function) => {
-        if (entity === Behavior) return behaviorRepository;
-        return null;
-      }),
-    } as unknown as DataSource;
-
-    const service = new GoalService(dataSource);
-
-    await expect(service.getGoalStamps('goal-abc')).resolves.toEqual([
-      { id: 'tb1', status: 'completed', behavior: { id: 'b1' } },
-      { id: 'tb3', status: 'completed', behavior: { id: 'b2' } },
-    ]);
-
-    expect(dataSource.getRepository).toHaveBeenCalledWith(Behavior);
-    expect(behaviorRepository.find).toHaveBeenCalledWith({
-      where: { goal: { id: 'goal-abc' } },
-      relations: ['todayBehaviors', 'todayBehaviors.behavior'],
+      await expect(service.getGoals()).rejects.toBeInstanceOf(NotFoundException);
+      expect(goalRepository.find).not.toHaveBeenCalled();
     });
   });
 
-  it('유저가 없으면 NotFoundException을 던진다', async () => {
-    const userRepository = { findOne: jest.fn().mockResolvedValue(null) };
-    const goalRepository = { create: jest.fn(), save: jest.fn() };
-    const behaviorRepository = { create: jest.fn(), save: jest.fn() };
+  describe('getGoalStamps', () => {
+    it('goalId로 완료된 TodayBehavior 목록만 반환한다', async () => {
+      const todayBehaviors = [
+        { id: 'tb1', status: 'completed', behavior: { id: 'b1' } },
+        { id: 'tb3', status: 'completed', behavior: { id: 'b2' } },
+      ];
 
-    const manager = {
-      getRepository: jest.fn((entity: Function) => {
-        if (entity === User) return userRepository;
-        if (entity === Goal) return goalRepository;
-        if (entity === Behavior) return behaviorRepository;
-        return null;
-      }),
-    };
+      const todayBehaviorRepository = {
+        find: jest.fn().mockResolvedValue(todayBehaviors),
+      };
 
-    const dataSource = {
-      transaction: jest.fn((callback: (manager: TransactionManager) => Promise<unknown>) =>
-        callback(manager),
-      ),
-    } as unknown as DataSource;
+      const dataSource = {
+        getRepository: jest.fn((entity: Function) => {
+          if (entity === TodayBehavior) return todayBehaviorRepository;
+          return null;
+        }),
+      } as unknown as DataSource;
 
-    const service = new GoalService(dataSource);
+      const service = new GoalService(dataSource);
 
-    await expect(service.createGoal(request)).rejects.toBeInstanceOf(NotFoundException);
-    expect(goalRepository.save).not.toHaveBeenCalled();
-  });
+      await expect(service.getGoalStamps('goal-abc')).resolves.toEqual(todayBehaviors);
 
-  it('목표와 행동을 저장하고 응답을 반환한다', async () => {
-    const user = { id: 'user-1', nickname: '테스트유저' };
-    const userRepository = { findOne: jest.fn().mockResolvedValue(user) };
-
-    const goal = { title: request.goalTitle, color: request.goalColor, user };
-    const savedGoal = {
-      id: '01890fba-7e6a-7b6b-9e5d-0f3c9b8b4c6d',
-      ...goal,
-    };
-
-    const goalRepository = {
-      create: jest.fn().mockReturnValue(goal),
-      save: jest.fn().mockResolvedValue(savedGoal),
-    };
-
-    const behavior = {
-      title: request.behaviors[0].title,
-      difficulty: request.behaviors[0].difficulty,
-      goal: savedGoal,
-    };
-    const savedBehavior = {
-      id: '01890fba-7e6a-7b6c-9e5d-0f3c9b8b4c6e',
-      ...behavior,
-    };
-
-    const behaviorRepository = {
-      create: jest.fn().mockReturnValue(behavior),
-      save: jest.fn().mockResolvedValue([savedBehavior]),
-    };
-
-    const manager = {
-      getRepository: jest.fn((entity: Function) => {
-        if (entity === User) return userRepository;
-        if (entity === Goal) return goalRepository;
-        if (entity === Behavior) return behaviorRepository;
-        return null;
-      }),
-    };
-
-    const dataSource = {
-      transaction: jest.fn((callback: (manager: TransactionManager) => Promise<unknown>) =>
-        callback(manager),
-      ),
-    } as unknown as DataSource;
-
-    const service = new GoalService(dataSource);
-
-    await expect(service.createGoal(request)).resolves.toEqual({
-      id: '01890fba-7e6a-7b6b-9e5d-0f3c9b8b4c6d',
-      title: '건강',
-      color: 'blue',
-      behaviors: [
-        {
-          id: '01890fba-7e6a-7b6c-9e5d-0f3c9b8b4c6e',
-          title: '물 한 컵 마시기',
-          difficulty: '마음열기',
+      expect(dataSource.getRepository).toHaveBeenCalledWith(TodayBehavior);
+      expect(todayBehaviorRepository.find).toHaveBeenCalledWith({
+        where: {
+          behavior: {
+            goal: { id: 'goal-abc' },
+          },
+          status: 'completed',
         },
-      ],
-    });
-    expect(userRepository.findOne).toHaveBeenCalledWith({ where: { nickname: '테스트유저' } });
-    expect(goalRepository.create).toHaveBeenCalledWith({
-      title: request.goalTitle,
-      color: request.goalColor,
-      user,
-    });
-    expect(goalRepository.save).toHaveBeenCalledWith(goal);
-    expect(behaviorRepository.create).toHaveBeenCalledWith({
-      title: request.behaviors[0].title,
-      difficulty: request.behaviors[0].difficulty,
-      goal: savedGoal,
-    });
-    expect(behaviorRepository.save).toHaveBeenCalledWith([behavior]);
-  });
-
-  it('목표의 행동 목록을 반환한다', async () => {
-    const goalId = 'goal-1';
-    const behaviors = [
-      { id: 'b1', title: 'b1', difficulty: 'easy' },
-      { id: 'b2', title: 'b2', difficulty: 'hard' },
-    ];
-    const goal = { id: goalId, behaviors };
-
-    const goalRepository = {
-      findOne: jest.fn().mockResolvedValue(goal),
-    };
-
-    const dataSource = {
-      getRepository: jest.fn((entity: Function) => {
-        if (entity === Goal) return goalRepository;
-        return null;
-      }),
-    } as unknown as DataSource;
-
-    const service = new GoalService(dataSource);
-
-    await expect(service.getGoalBehaviors(goalId)).resolves.toEqual(behaviors);
-    expect(goalRepository.findOne).toHaveBeenCalledWith({
-      where: { id: goalId },
-      relations: ['behaviors'],
+        relations: ['behavior'],
+      });
     });
   });
 
-  it('존재하지 않는 목표의 행동 목록 조회 시 NotFoundException을 던진다', async () => {
-    const goalId = 'goal-1';
-    const goalRepository = {
-      findOne: jest.fn().mockResolvedValue(null),
-    };
+  describe('createGoal', () => {
+    it('유저가 없으면 NotFoundException을 던진다', async () => {
+      const userRepository = { findOne: jest.fn().mockResolvedValue(null) };
+      const goalRepository = { create: jest.fn(), save: jest.fn() };
+      const behaviorRepository = { create: jest.fn(), save: jest.fn() };
 
-    const dataSource = {
-      getRepository: jest.fn((entity: Function) => {
-        if (entity === Goal) return goalRepository;
-        return null;
-      }),
-    } as unknown as DataSource;
+      const manager = {
+        getRepository: jest.fn((entity: Function) => {
+          if (entity === User) return userRepository;
+          if (entity === Goal) return goalRepository;
+          if (entity === Behavior) return behaviorRepository;
+          return null;
+        }),
+      };
 
-    const service = new GoalService(dataSource);
+      const dataSource = {
+        transaction: jest.fn((callback: (manager: TransactionManager) => Promise<unknown>) =>
+          callback(manager),
+        ),
+      } as unknown as DataSource;
 
-    await expect(service.getGoalBehaviors(goalId)).rejects.toBeInstanceOf(NotFoundException);
+      const service = new GoalService(dataSource);
+
+      await expect(service.createGoal(request)).rejects.toBeInstanceOf(NotFoundException);
+      expect(goalRepository.save).not.toHaveBeenCalled();
+    });
+
+    it('목표와 행동을 저장하고 응답을 반환한다', async () => {
+      const user = { id: 'user-1', nickname: '테스트유저' };
+      const userRepository = { findOne: jest.fn().mockResolvedValue(user) };
+
+      const goal = { title: request.goalTitle, color: request.goalColor, user };
+      const savedGoal = {
+        id: '01890fba-7e6a-7b6b-9e5d-0f3c9b8b4c6d',
+        ...goal,
+      };
+
+      const goalRepository = {
+        create: jest.fn().mockReturnValue(goal),
+        save: jest.fn().mockResolvedValue(savedGoal),
+      };
+
+      const behavior = {
+        title: request.behaviors[0].title,
+        difficulty: request.behaviors[0].difficulty,
+        goal: savedGoal,
+      };
+      const savedBehavior = {
+        id: '01890fba-7e6a-7b6c-9e5d-0f3c9b8b4c6e',
+        ...behavior,
+      };
+
+      const behaviorRepository = {
+        create: jest.fn().mockReturnValue(behavior),
+        save: jest.fn().mockResolvedValue([savedBehavior]),
+      };
+
+      const manager = {
+        getRepository: jest.fn((entity: Function) => {
+          if (entity === User) return userRepository;
+          if (entity === Goal) return goalRepository;
+          if (entity === Behavior) return behaviorRepository;
+          return null;
+        }),
+      };
+
+      const dataSource = {
+        transaction: jest.fn((callback: (manager: TransactionManager) => Promise<unknown>) =>
+          callback(manager),
+        ),
+      } as unknown as DataSource;
+
+      const service = new GoalService(dataSource);
+
+      await expect(service.createGoal(request)).resolves.toEqual({
+        id: '01890fba-7e6a-7b6b-9e5d-0f3c9b8b4c6d',
+        title: '건강',
+        color: 'blue',
+        behaviors: [
+          {
+            id: '01890fba-7e6a-7b6c-9e5d-0f3c9b8b4c6e',
+            title: '물 한 컵 마시기',
+            difficulty: '마음열기',
+          },
+        ],
+      });
+      expect(userRepository.findOne).toHaveBeenCalledWith({ where: { nickname: '테스트유저' } });
+      expect(goalRepository.create).toHaveBeenCalledWith({
+        title: request.goalTitle,
+        color: request.goalColor,
+        user,
+      });
+      expect(goalRepository.save).toHaveBeenCalledWith(goal);
+      expect(behaviorRepository.create).toHaveBeenCalledWith({
+        title: request.behaviors[0].title,
+        difficulty: request.behaviors[0].difficulty,
+        goal: savedGoal,
+      });
+      expect(behaviorRepository.save).toHaveBeenCalledWith([behavior]);
+    });
+  });
+
+  describe('getGoalBehaviors', () => {
+    it('목표의 행동 목록을 반환한다', async () => {
+      const goalId = 'goal-1';
+      const behaviors = [
+        { id: 'b1', title: 'b1', difficulty: 'easy' },
+        { id: 'b2', title: 'b2', difficulty: 'hard' },
+      ];
+      const goal = { id: goalId, behaviors };
+
+      const goalRepository = {
+        findOne: jest.fn().mockResolvedValue(goal),
+      };
+
+      const dataSource = {
+        getRepository: jest.fn((entity: Function) => {
+          if (entity === Goal) return goalRepository;
+          return null;
+        }),
+      } as unknown as DataSource;
+
+      const service = new GoalService(dataSource);
+
+      await expect(service.getGoalBehaviors(goalId)).resolves.toEqual(behaviors);
+      expect(goalRepository.findOne).toHaveBeenCalledWith({
+        where: { id: goalId },
+        relations: ['behaviors'],
+      });
+    });
+
+    it('존재하지 않는 목표의 행동 목록 조회 시 NotFoundException을 던진다', async () => {
+      const goalId = 'goal-1';
+      const goalRepository = {
+        findOne: jest.fn().mockResolvedValue(null),
+      };
+
+      const dataSource = {
+        getRepository: jest.fn((entity: Function) => {
+          if (entity === Goal) return goalRepository;
+          return null;
+        }),
+      } as unknown as DataSource;
+
+      const service = new GoalService(dataSource);
+
+      await expect(service.getGoalBehaviors(goalId)).rejects.toBeInstanceOf(NotFoundException);
+    });
   });
 });

--- a/apps/backend/src/features/goal/goal.service.spec.ts
+++ b/apps/backend/src/features/goal/goal.service.spec.ts
@@ -64,6 +64,46 @@ describe('GoalService', () => {
     expect(goalRepository.find).not.toHaveBeenCalled();
   });
 
+  it('goalId로 완료된 TodayBehavior 목록만 반환한다', async () => {
+    const mockBehaviors = [
+      {
+        id: 'b1',
+        todayBehaviors: [
+          { id: 'tb1', status: 'completed', behavior: { id: 'b1' } },
+          { id: 'tb2', status: 'pending', behavior: { id: 'b1' } },
+        ],
+      },
+      {
+        id: 'b2',
+        todayBehaviors: [{ id: 'tb3', status: 'completed', behavior: { id: 'b2' } }],
+      },
+    ];
+
+    const behaviorRepository = {
+      find: jest.fn().mockResolvedValue(mockBehaviors),
+    };
+
+    const dataSource = {
+      getRepository: jest.fn((entity: Function) => {
+        if (entity === Behavior) return behaviorRepository;
+        return null;
+      }),
+    } as unknown as DataSource;
+
+    const service = new GoalService(dataSource);
+
+    await expect(service.getGoalStamps('goal-abc')).resolves.toEqual([
+      { id: 'tb1', status: 'completed', behavior: { id: 'b1' } },
+      { id: 'tb3', status: 'completed', behavior: { id: 'b2' } },
+    ]);
+
+    expect(dataSource.getRepository).toHaveBeenCalledWith(Behavior);
+    expect(behaviorRepository.find).toHaveBeenCalledWith({
+      where: { goal: { id: 'goal-abc' } },
+      relations: ['todayBehaviors', 'todayBehaviors.behavior'],
+    });
+  });
+
   it('유저가 없으면 NotFoundException을 던진다', async () => {
     const userRepository = { findOne: jest.fn().mockResolvedValue(null) };
     const goalRepository = { create: jest.fn(), save: jest.fn() };

--- a/apps/backend/src/features/goal/goal.service.ts
+++ b/apps/backend/src/features/goal/goal.service.ts
@@ -53,13 +53,15 @@ export class GoalService {
   }
 
   async getGoalStamps(goalId: string): Promise<TodayBehavior[]> {
-    const behaviors = await this.dataSource.getRepository(Behavior).find({
-      where: { goal: { id: goalId } },
-      relations: ['todayBehaviors', 'todayBehaviors.behavior'],
+    return this.dataSource.getRepository(TodayBehavior).find({
+      where: {
+        behavior: {
+          goal: { id: goalId },
+        },
+        status: 'completed',
+      },
+      relations: ['behavior'],
     });
-
-    const todayBehaviors = behaviors.flatMap((b) => b.todayBehaviors ?? []);
-    return todayBehaviors.filter((tb) => tb.status === 'completed');
   }
 
   async createGoal(request: CreateGoalRequest): Promise<CreateGoalResponse> {

--- a/apps/backend/src/features/goal/goal.service.ts
+++ b/apps/backend/src/features/goal/goal.service.ts
@@ -9,6 +9,7 @@ import { DataSource } from 'typeorm';
 import { Behavior } from '../behavior/behavior.entity';
 import { User } from '../user/user.entity';
 import { Goal } from './goal.entity';
+import { TodayBehavior } from '../behavior/today-behavior.entity';
 
 @Injectable()
 export class GoalService {
@@ -49,6 +50,16 @@ export class GoalService {
     }
 
     return goal.behaviors || [];
+  }
+
+  async getGoalStamps(goalId: string): Promise<TodayBehavior[]> {
+    const behaviors = await this.dataSource.getRepository(Behavior).find({
+      where: { goal: { id: goalId } },
+      relations: ['todayBehaviors', 'todayBehaviors.behavior'],
+    });
+
+    const todayBehaviors = behaviors.flatMap((b) => b.todayBehaviors ?? []);
+    return todayBehaviors.filter((tb) => tb.status === 'completed');
   }
 
   async createGoal(request: CreateGoalRequest): Promise<CreateGoalResponse> {

--- a/apps/frontend/src/features/goal/apis/fetchGoalStamps.api.ts
+++ b/apps/frontend/src/features/goal/apis/fetchGoalStamps.api.ts
@@ -1,0 +1,17 @@
+import { GetGoalStampsResponseSchema, type GetGoalStampsResponse } from '@web24/shared';
+
+export async function fetchGoalStamps(goalId: string): Promise<GetGoalStampsResponse> {
+  const res = await fetch(`/api/goals/${goalId}/stamps`, {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  });
+
+  if (!res.ok) {
+    throw new Error('Failed to fetch goal stamps');
+  }
+
+  const json = await res.json();
+  return GetGoalStampsResponseSchema.parse(json);
+}

--- a/apps/frontend/src/features/goal/components/GoalBehaviorList.tsx
+++ b/apps/frontend/src/features/goal/components/GoalBehaviorList.tsx
@@ -1,0 +1,3 @@
+export function GoalBehaviorList() {
+  return <div>목표 행동 리스트 컴포넌트</div>;
+}

--- a/apps/frontend/src/features/goal/components/GoalCard.tsx
+++ b/apps/frontend/src/features/goal/components/GoalCard.tsx
@@ -2,6 +2,7 @@ import { GOAL_COLOR_STYLES } from '@/shared/constants/goalColor';
 import type { GoalSummary, Behavior } from '@web24/shared';
 import { ChevronsUp, ChevronsDown, Trash2 } from 'lucide-react';
 import { ICON_SIZE } from '@/shared/constants/icon';
+import { useNavigate } from 'react-router-dom';
 import { DifficultyBadge } from '@/shared/components/behavior/DifficultyBadge';
 import { useGoalBehaviors } from '../hooks/useGoalBehaviors';
 
@@ -14,12 +15,20 @@ interface GoalCardProps {
 
 export function GoalCard({ goal, behaviors: propsBehaviors, isOpen, onToggle }: GoalCardProps) {
   const { behaviors: fetchedBehaviors } = useGoalBehaviors(goal.id, isOpen && !propsBehaviors);
-
+  const navigate = useNavigate();
   const behaviors = propsBehaviors || fetchedBehaviors;
 
   return (
     <div
+      role="link"
+      tabIndex={0}
       className={`relative mb-4 flex break-inside-avoid flex-col rounded-3xl px-7 py-5 transition-all duration-500 ${GOAL_COLOR_STYLES[goal.color].bg} shadow-sm`}
+      onClick={() => navigate(`/goals/${goal.id}`)}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          navigate(`/goals/${goal.id}`);
+        }
+      }}
     >
       {/* 카드 헤더 */}
       <div className="flex flex-row justify-between">
@@ -61,7 +70,10 @@ export function GoalCard({ goal, behaviors: propsBehaviors, isOpen, onToggle }: 
       <button
         type="button"
         className="mt-2 flex w-full justify-center opacity-80 transition-transform hover:animate-bounce hover:opacity-100"
-        onClick={onToggle}
+        onClick={(e) => {
+          e.stopPropagation();
+          onToggle();
+        }}
       >
         {isOpen ? <ChevronsUp size={ICON_SIZE.md} /> : <ChevronsDown size={ICON_SIZE.md} />}
       </button>

--- a/apps/frontend/src/features/goal/components/GoalCard.tsx
+++ b/apps/frontend/src/features/goal/components/GoalCard.tsx
@@ -2,7 +2,6 @@ import { GOAL_COLOR_STYLES } from '@/shared/constants/goalColor';
 import type { GoalSummary, Behavior } from '@web24/shared';
 import { ChevronsUp, ChevronsDown, Trash2 } from 'lucide-react';
 import { ICON_SIZE } from '@/shared/constants/icon';
-import { useNavigate } from 'react-router-dom';
 import { DifficultyBadge } from '@/shared/components/behavior/DifficultyBadge';
 import { useGoalBehaviors } from '../hooks/useGoalBehaviors';
 
@@ -11,11 +10,17 @@ interface GoalCardProps {
   behaviors?: Behavior[];
   isOpen: boolean;
   onToggle: () => void;
+  onNavigate?: (goalId: string) => void;
 }
 
-export function GoalCard({ goal, behaviors: propsBehaviors, isOpen, onToggle }: GoalCardProps) {
+export function GoalCard({
+  goal,
+  behaviors: propsBehaviors,
+  isOpen,
+  onToggle,
+  onNavigate,
+}: GoalCardProps) {
   const { behaviors: fetchedBehaviors } = useGoalBehaviors(goal.id, isOpen && !propsBehaviors);
-  const navigate = useNavigate();
   const behaviors = propsBehaviors || fetchedBehaviors;
 
   return (
@@ -23,10 +28,10 @@ export function GoalCard({ goal, behaviors: propsBehaviors, isOpen, onToggle }: 
       role="link"
       tabIndex={0}
       className={`relative mb-4 flex break-inside-avoid flex-col rounded-3xl px-7 py-5 transition-all duration-500 ${GOAL_COLOR_STYLES[goal.color].bg} shadow-sm`}
-      onClick={() => navigate(`/goals/${goal.id}`)}
+      onClick={() => onNavigate?.(goal.id)}
       onKeyDown={(e) => {
-        if (e.key === 'Enter' || e.key === ' ') {
-          navigate(`/goals/${goal.id}`);
+        if (e.key === 'Enter') {
+          onNavigate?.(goal.id);
         }
       }}
     >

--- a/apps/frontend/src/features/goal/components/GoalStampBoard.spec.tsx
+++ b/apps/frontend/src/features/goal/components/GoalStampBoard.spec.tsx
@@ -1,0 +1,52 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import type { GoalStamp } from '@web24/shared';
+import { GoalStampBoard } from './GoalStampBoard';
+
+describe('GoalStampBoard', () => {
+  const stamps: GoalStamp[] = [
+    { id: 'stamp-1', difficulty: '몰입하기' },
+    { id: 'stamp-2', difficulty: '이어가기' },
+    { id: 'stamp-3', difficulty: '마음열기' },
+    { id: 'stamp-4', difficulty: '시작하기' },
+  ];
+
+  it('스탬프 개수만큼 버튼을 렌더링한다', () => {
+    render(<GoalStampBoard stamps={stamps} />);
+
+    const buttons = screen.getAllByRole('button');
+    expect(buttons).toHaveLength(stamps.length);
+  });
+
+  it('초기 렌더 시 하나의 두두 스탬프만 존재한다', () => {
+    render(<GoalStampBoard stamps={stamps} />);
+
+    const dodos = screen.getAllByLabelText('dodo-stamp');
+    expect(dodos).toHaveLength(1);
+  });
+
+  it('두두 스탬프 클릭 시 두두 위치가 변경된다', () => {
+    render(<GoalStampBoard stamps={stamps} />);
+
+    const before = screen.getByLabelText('dodo-stamp');
+    fireEvent.click(before);
+
+    const after = screen.getByLabelText('dodo-stamp');
+    expect(after).not.toBe(before);
+  });
+
+  it('일반 스탬프 클릭 시 두두 위치는 변경되지 않는다', () => {
+    render(<GoalStampBoard stamps={stamps} />);
+
+    const before = screen.getByLabelText('dodo-stamp');
+
+    const normalStamp = screen
+      .getAllByRole('button')
+      .find((btn) => btn.getAttribute('aria-label') === 'stamp')!;
+
+    fireEvent.click(normalStamp);
+
+    const after = screen.getByLabelText('dodo-stamp');
+    expect(after).toBe(before);
+  });
+});

--- a/apps/frontend/src/features/goal/components/GoalStampBoard.tsx
+++ b/apps/frontend/src/features/goal/components/GoalStampBoard.tsx
@@ -20,6 +20,7 @@ function Stamp({ difficulty, isDodo, onSelect }: StampProps) {
   return (
     <button
       type="button"
+      aria-label={isDodo ? 'dodo-stamp' : 'stamp'}
       onClick={onSelect}
       className={`flex h-12 w-12 items-center justify-center rounded-full ${bg} scale-100 rotate-[-5deg] transform transition-transform duration-400 ease-out hover:scale-125 hover:rotate-12`}
     >
@@ -50,7 +51,7 @@ export function GoalStampBoard({ stamps }: GoalStampBoardProps) {
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const sendClickEvent = (_index: number) => {
-    // TODO: 시도 API 전송
+    // 시도 API 전송
   };
 
   useEffect(() => {

--- a/apps/frontend/src/features/goal/components/GoalStampBoard.tsx
+++ b/apps/frontend/src/features/goal/components/GoalStampBoard.tsx
@@ -63,7 +63,7 @@ export function GoalStampBoard({ stamps }: GoalStampBoardProps) {
   }, [stamps.length]);
 
   return (
-    <div className="bg-bg-light border-primary-strong scrollbar-pretty grid max-h-[60vh] min-h-[45vh] w-full grid-cols-[repeat(auto-fill,minmax(56px,1fr))] gap-2 overflow-y-scroll rounded-2xl p-4">
+    <div className="bg-bg-light border-primary-strong scrollbar-pretty grid max-h-[60vh] min-h-[45vh] w-full auto-rows-min grid-cols-[repeat(auto-fill,minmax(56px,1fr))] gap-2 overflow-y-scroll rounded-2xl p-4">
       {stamps.map((stamp, index) => (
         <Stamp
           key={stamp.id}

--- a/apps/frontend/src/features/goal/components/GoalStampBoard.tsx
+++ b/apps/frontend/src/features/goal/components/GoalStampBoard.tsx
@@ -38,11 +38,11 @@ export function GoalStampBoard({ stamps }: GoalStampBoardProps) {
 
   const getNewDodoIndex = () => {
     const MAX_ATTEMPT = 100;
-    let index = Math.floor(Math.random() * stamps.length);
+    let index = crypto.getRandomValues(new Uint32Array(1))[0] % stamps.length;
 
     let attempt = 0;
     while (index === dodoIndex && attempt < MAX_ATTEMPT) {
-      index = Math.floor(Math.random() * stamps.length);
+      index = crypto.getRandomValues(new Uint32Array(1))[0] % stamps.length;
       attempt += 1;
     }
 

--- a/apps/frontend/src/features/goal/components/GoalStampBoard.tsx
+++ b/apps/frontend/src/features/goal/components/GoalStampBoard.tsx
@@ -1,0 +1,79 @@
+import { DIFFICULTY_COLOR_STYLES } from '@/shared/constants/difficultyColor';
+import { ICON_SIZE } from '@/shared/constants/icon';
+import type { BehaviorDifficulty, GoalStamp } from '@web24/shared';
+import { Star } from 'lucide-react';
+import { useEffect, useState } from 'react';
+
+interface StampProps {
+  readonly difficulty: BehaviorDifficulty;
+  readonly isDodo: boolean;
+  readonly onSelect: () => void;
+}
+
+interface GoalStampBoardProps {
+  readonly stamps: GoalStamp[];
+}
+
+function Stamp({ difficulty, isDodo, onSelect }: StampProps) {
+  const { bg } = DIFFICULTY_COLOR_STYLES[difficulty];
+
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      className={`flex h-12 w-12 items-center justify-center rounded-full ${bg} scale-100 rotate-[-5deg] transform transition-transform duration-400 ease-out hover:scale-125 hover:rotate-12`}
+    >
+      {isDodo ? (
+        <img src="/DodoFace.png" width={ICON_SIZE.md} height={ICON_SIZE.md} alt="두두 얼굴" />
+      ) : (
+        <Star size={ICON_SIZE.md} className="text-white" />
+      )}
+    </button>
+  );
+}
+
+export function GoalStampBoard({ stamps }: GoalStampBoardProps) {
+  const [dodoIndex, setDodoIndex] = useState<number | null>(null);
+
+  const getNewDodoIndex = () => {
+    const MAX_ATTEMPT = 100;
+    let index = Math.floor(Math.random() * stamps.length);
+
+    let attempt = 0;
+    while (index === dodoIndex && attempt < MAX_ATTEMPT) {
+      index = Math.floor(Math.random() * stamps.length);
+      attempt += 1;
+    }
+
+    return index;
+  };
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const sendClickEvent = (_index: number) => {
+    // TODO: 시도 API 전송
+  };
+
+  useEffect(() => {
+    const newDodoIndex = getNewDodoIndex();
+    setDodoIndex(newDodoIndex);
+  }, []);
+
+  return (
+    <div className="bg-bg-light border-primary-strong grid max-h-[60vh] w-full grid-cols-[repeat(auto-fit,minmax(56px,1fr))] gap-2 overflow-y-scroll rounded-2xl p-4">
+      {stamps.map((stamp, index) => (
+        <Stamp
+          key={stamp.id}
+          difficulty={stamp.difficulty}
+          isDodo={index === dodoIndex}
+          onSelect={() => {
+            sendClickEvent(index);
+            if (index === dodoIndex) {
+              const newDodoIndex = getNewDodoIndex();
+              setDodoIndex(newDodoIndex);
+            }
+          }}
+        />
+      ))}
+    </div>
+  );
+}

--- a/apps/frontend/src/features/goal/components/GoalStampBoard.tsx
+++ b/apps/frontend/src/features/goal/components/GoalStampBoard.tsx
@@ -58,7 +58,7 @@ export function GoalStampBoard({ stamps }: GoalStampBoardProps) {
       setDodoIndex(null);
       return;
     }
-    const newDodoIndex = Math.floor(Math.random() * stamps.length);
+    const newDodoIndex = crypto.getRandomValues(new Uint32Array(1))[0] % stamps.length;
     setDodoIndex(newDodoIndex);
   }, [stamps.length]);
 

--- a/apps/frontend/src/features/goal/components/GoalStampBoard.tsx
+++ b/apps/frontend/src/features/goal/components/GoalStampBoard.tsx
@@ -34,19 +34,18 @@ function Stamp({ difficulty, isDodo, onSelect }: StampProps) {
 }
 
 export function GoalStampBoard({ stamps }: GoalStampBoardProps) {
+  const MIN_LENGTH_TO_ACTIVE_DODO_GAME = 1;
   const [dodoIndex, setDodoIndex] = useState<number | null>(null);
 
   const getNewDodoIndex = () => {
-    const MAX_ATTEMPT = 100;
-    let index = crypto.getRandomValues(new Uint32Array(1))[0] % stamps.length;
+    if (stamps.length <= MIN_LENGTH_TO_ACTIVE_DODO_GAME) return null;
 
-    let attempt = 0;
-    while (index === dodoIndex && attempt < MAX_ATTEMPT) {
-      index = crypto.getRandomValues(new Uint32Array(1))[0] % stamps.length;
-      attempt += 1;
-    }
+    let newIndex: number;
+    do {
+      newIndex = crypto.getRandomValues(new Uint32Array(1))[0] % stamps.length;
+    } while (newIndex === dodoIndex);
 
-    return index;
+    return newIndex;
   };
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -55,9 +54,13 @@ export function GoalStampBoard({ stamps }: GoalStampBoardProps) {
   };
 
   useEffect(() => {
-    const newDodoIndex = getNewDodoIndex();
+    if (stamps.length <= MIN_LENGTH_TO_ACTIVE_DODO_GAME) {
+      setDodoIndex(null);
+      return;
+    }
+    const newDodoIndex = Math.floor(Math.random() * stamps.length);
     setDodoIndex(newDodoIndex);
-  }, []);
+  }, [stamps.length]);
 
   return (
     <div className="bg-bg-light border-primary-strong grid max-h-[60vh] w-full grid-cols-[repeat(auto-fit,minmax(56px,1fr))] gap-2 overflow-y-scroll rounded-2xl p-4">

--- a/apps/frontend/src/features/goal/components/GoalStampBoard.tsx
+++ b/apps/frontend/src/features/goal/components/GoalStampBoard.tsx
@@ -63,7 +63,7 @@ export function GoalStampBoard({ stamps }: GoalStampBoardProps) {
   }, [stamps.length]);
 
   return (
-    <div className="bg-bg-light border-primary-strong grid max-h-[60vh] w-full grid-cols-[repeat(auto-fit,minmax(56px,1fr))] gap-2 overflow-y-scroll rounded-2xl p-4">
+    <div className="bg-bg-light border-primary-strong scrollbar-pretty grid max-h-[60vh] min-h-[45vh] w-full grid-cols-[repeat(auto-fill,minmax(56px,1fr))] gap-2 overflow-y-scroll rounded-2xl p-4">
       {stamps.map((stamp, index) => (
         <Stamp
           key={stamp.id}

--- a/apps/frontend/src/pages/AllGoalsPage.tsx
+++ b/apps/frontend/src/pages/AllGoalsPage.tsx
@@ -171,6 +171,7 @@ export function AllGoalsPage() {
                 behaviors={behaviorsByGoal?.[goal.id]}
                 isOpen={expandedGoalIds.has(goal.id)}
                 onToggle={() => handleToggleGoal(goal.id)}
+                onNavigate={() => navigate(`/goals/${goal.id}`)}
               />
             ))}
           </div>

--- a/apps/frontend/src/pages/GoalDetailPage.spec.tsx
+++ b/apps/frontend/src/pages/GoalDetailPage.spec.tsx
@@ -1,0 +1,80 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { fetchGoalStamps } from '@/features/goal/apis/fetchGoalStamps.api';
+import { GoalDetailPage } from './GoalDetailPage';
+
+// fetchGoalStamps mock
+vi.mock('@/features/goal/apis/fetchGoalStamps.api', () => ({
+  fetchGoalStamps: vi.fn(),
+}));
+
+// GoalStampBoard, GoalBehaviorList mock
+vi.mock('@/features/goal/components/GoalStampBoard', () => ({
+  GoalStampBoard: ({ stamps }: { stamps: unknown[] }) => (
+    <div data-testid="goal-stamp-board">stamps:{stamps.length}</div>
+  ),
+}));
+
+vi.mock('@/features/goal/components/GoalBehaviorList', () => ({
+  GoalBehaviorList: () => <div data-testid="goal-behavior-list" />,
+}));
+
+describe('GoalDetailPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    // GoalDetailPage에서 현재는 mockGoal 사용, title만 교체
+    // 필요한 경우 goalId로 가져오는 API도 Mock 가능
+    (fetchGoalStamps as any).mockResolvedValue([]);
+  });
+
+  function renderPage(goalId = 'goal-abc') {
+    return render(
+      <MemoryRouter initialEntries={[`/goals/${goalId}`]}>
+        <Routes>
+          <Route path="/goals/:goalId" element={<GoalDetailPage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+  }
+
+  it('goalId로 스탬프 API를 호출한다', async () => {
+    (fetchGoalStamps as any).mockResolvedValueOnce([]);
+    renderPage('goal-abc');
+
+    await waitFor(() => {
+      expect(fetchGoalStamps).toHaveBeenCalledWith('goal-abc');
+    });
+  });
+
+  it('가져온 스탬프 개수를 표시한다', async () => {
+    (fetchGoalStamps as any).mockResolvedValueOnce([
+      { id: 's1', difficulty: '몰입하기' },
+      { id: 's2', difficulty: '시작하기' },
+    ]);
+
+    renderPage();
+
+    const text = await screen.findByText(/달성한 스탬프/);
+    expect(text).toHaveTextContent('2');
+  });
+
+  it('GoalStampBoard에 stamps를 전달한다', async () => {
+    (fetchGoalStamps as any).mockResolvedValueOnce([
+      { id: 's1', difficulty: '시작하기' },
+      { id: 's2', difficulty: '몰입하기' },
+      { id: 's3', difficulty: '이어가기' },
+    ]);
+
+    renderPage();
+
+    const board = await screen.findByTestId('goal-stamp-board');
+    expect(board).toHaveTextContent('stamps:3');
+  });
+
+  it('GoalBehaviorList를 렌더링한다', () => {
+    renderPage();
+    expect(screen.getByTestId('goal-behavior-list')).toBeInTheDocument();
+  });
+});

--- a/apps/frontend/src/pages/GoalDetailPage.tsx
+++ b/apps/frontend/src/pages/GoalDetailPage.tsx
@@ -17,8 +17,10 @@ export function GoalDetailPage() {
   const [stamps, setStamps] = useState<GoalStamp[]>([]);
 
   useEffect(() => {
-    // goalId가 null이면 에러페이지로 이동로직 추가
-    fetchGoalStamps(goalId!).then((s) => {
+    // MEMO: goalId가 null이면 에러페이지로 이동로직 추가
+    if (!goalId) return;
+
+    fetchGoalStamps(goalId).then((s) => {
       setStamps(s);
     });
   }, [goalId]);

--- a/apps/frontend/src/pages/GoalDetailPage.tsx
+++ b/apps/frontend/src/pages/GoalDetailPage.tsx
@@ -17,7 +17,7 @@ export function GoalDetailPage() {
   const [stamps, setStamps] = useState<GoalStamp[]>([]);
 
   useEffect(() => {
-    // TODO: goalId가 null이면 에러페이지로 이동로직 추가
+    // goalId가 null이면 에러페이지로 이동로직 추가
     fetchGoalStamps(goalId!).then((s) => {
       setStamps(s);
     });

--- a/apps/frontend/src/pages/GoalDetailPage.tsx
+++ b/apps/frontend/src/pages/GoalDetailPage.tsx
@@ -1,0 +1,53 @@
+import { GoalBehaviorList } from '@/features/goal/components/GoalBehaviorList';
+import { GoalStampBoard } from '@/features/goal/components/GoalStampBoard';
+import { type Goal, type GoalStamp } from '@web24/shared';
+import { useState } from 'react';
+
+const generateMockStamps = (cnt: number): GoalStamp[] => {
+  const difficulties: GoalStamp['difficulty'][] = [
+    '마음열기',
+    '시작하기',
+    '이어가기',
+    '몰입하기',
+    'AI',
+  ];
+
+  return Array.from({ length: cnt }, (_, i) => ({
+    id: String(i + 1),
+    difficulty: difficulties[Math.floor(Math.random() * difficulties.length)],
+  }));
+};
+
+const mockGoal: Goal = {
+  id: 'goal-1',
+  title: '건강 목표',
+  color: 'pink',
+};
+
+export function GoalDetailPage() {
+  const [goal] = useState<Goal>(mockGoal);
+  const mockStamps: GoalStamp[] = generateMockStamps(100);
+
+  return (
+    <div className="p-4 sm:px-6 lg:px-8">
+      {/* 목표 헤더 */}
+      <header className="mb-4 flex flex-col items-start justify-between gap-4 sm:flex-row sm:items-center">
+        <h1 className="text-label-normal text-title-1 font-bold">{goal.title}</h1>
+      </header>
+
+      {/* 목표 본문 */}
+      <div className="flex flex-row gap-12">
+        <div className="w-full max-w-1/2">
+          <p className="mb-4 text-sm">
+            달성한 스탬프 <span className="text-primary-strong font-bold">{mockStamps.length}</span>{' '}
+            개
+          </p>
+          <GoalStampBoard stamps={mockStamps} />
+        </div>
+        <div className="w-full max-w-1/2">
+          <GoalBehaviorList />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/pages/GoalDetailPage.tsx
+++ b/apps/frontend/src/pages/GoalDetailPage.tsx
@@ -1,32 +1,27 @@
+import { fetchGoalStamps } from '@/features/goal/apis/fetchGoalStamps.api';
 import { GoalBehaviorList } from '@/features/goal/components/GoalBehaviorList';
 import { GoalStampBoard } from '@/features/goal/components/GoalStampBoard';
 import { type Goal, type GoalStamp } from '@web24/shared';
-import { useState } from 'react';
-
-const generateMockStamps = (cnt: number): GoalStamp[] => {
-  const difficulties: GoalStamp['difficulty'][] = [
-    '마음열기',
-    '시작하기',
-    '이어가기',
-    '몰입하기',
-    'AI',
-  ];
-
-  return Array.from({ length: cnt }, (_, i) => ({
-    id: String(i + 1),
-    difficulty: difficulties[Math.floor(Math.random() * difficulties.length)],
-  }));
-};
+import { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
 
 const mockGoal: Goal = {
-  id: 'goal-1',
+  id: '019bba2d-6702-79f4-b5f9-ee83fa4729f6',
   title: '건강 목표',
   color: 'pink',
 };
 
 export function GoalDetailPage() {
   const [goal] = useState<Goal>(mockGoal);
-  const mockStamps: GoalStamp[] = generateMockStamps(100);
+  const { goalId } = useParams<{ goalId: string }>();
+  const [stamps, setStamps] = useState<GoalStamp[]>([]);
+
+  useEffect(() => {
+    // TODO: goalId가 null이면 에러페이지로 이동로직 추가
+    fetchGoalStamps(goalId!).then((s) => {
+      setStamps(s);
+    });
+  }, [goalId]);
 
   return (
     <div className="p-4 sm:px-6 lg:px-8">
@@ -39,10 +34,9 @@ export function GoalDetailPage() {
       <div className="flex flex-row gap-12">
         <div className="w-full max-w-1/2">
           <p className="mb-4 text-sm">
-            달성한 스탬프 <span className="text-primary-strong font-bold">{mockStamps.length}</span>{' '}
-            개
+            달성한 스탬프 <span className="text-primary-strong font-bold">{stamps.length}</span> 개
           </p>
-          <GoalStampBoard stamps={mockStamps} />
+          <GoalStampBoard stamps={stamps} />
         </div>
         <div className="w-full max-w-1/2">
           <GoalBehaviorList />

--- a/apps/frontend/src/routes/index.tsx
+++ b/apps/frontend/src/routes/index.tsx
@@ -2,6 +2,7 @@ import { NewGoalPage } from '@/pages/NewGoalPage';
 import { Route, Routes } from 'react-router-dom';
 import { IndexPage } from '@/pages/IndexPage';
 import { AllGoalsPage } from '@/pages/AllGoalsPage';
+import { GoalDetailPage } from '@/pages/GoalDetailPage';
 
 export function AppRoutes() {
   return (
@@ -9,6 +10,7 @@ export function AppRoutes() {
       <Route element={<IndexPage />} index />
       <Route element={<NewGoalPage />} path="/goals/new" />
       <Route element={<AllGoalsPage />} path="/all-goals" />
+      <Route element={<GoalDetailPage />} path="/goals/:goalId" />
       <Route element={<div className="text-label-disable">Not Found</div>} path="*" />
     </Routes>
   );

--- a/apps/frontend/src/shared/constants/difficultyColor.ts
+++ b/apps/frontend/src/shared/constants/difficultyColor.ts
@@ -3,4 +3,5 @@ export const DIFFICULTY_COLOR_STYLES: Record<string, { bg: string; txt: string }
   시작하기: { bg: 'bg-difficulty-2', txt: 'text-bg-light' },
   이어가기: { bg: 'bg-difficulty-3', txt: 'text-bg-light' },
   몰입하기: { bg: 'bg-difficulty-4', txt: 'text-bg-light' },
+  AI: { bg: 'bg-difficulty-ai', txt: 'text-bg-light' },
 };

--- a/packages/shared/src/schemas/goal.schemas.ts
+++ b/packages/shared/src/schemas/goal.schemas.ts
@@ -62,40 +62,10 @@ export const GetGoalsResponseSchema = z.array(GetGoalSummarySchema);
 export type GetGoalSummary = z.infer<typeof GetGoalSummarySchema>;
 export type GetGoalsResponse = z.infer<typeof GetGoalsResponseSchema>;
 
-// Uncaught (in promise) ZodError: [
-//   {
-//     "origin": "string",
-//     "code": "invalid_format",
-//     "format": "uuid",
-//     "pattern": "/^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-7[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})$/",
-//     "path": [
-//       0,
-//       "id"
-//     ],
-//     "message": "Invalid UUID"
-//   },
-//   {
-//     "origin": "string",
-//     "code": "invalid_format",
-//     "format": "uuid",
-//     "pattern": "/^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-7[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})$/",
-//     "path": [
-//       1,
-//       "id"
-//     ],
-//     "message": "Invalid UUID"
-//   },
-//   {
-//     "origin": "string",
-//     "code": "invalid_format",
-//     "format": "uuid",
-//     "pattern": "/^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-7[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})$/",
-//     "path": [
-//       2,
-//       "id"
-//     ],
-//     "message": "Invalid UUID"
-//   }
-// ]
-//     at fetchGoals (fetchGoals.api.ts:16:33)
-//     at async Promise.all (:5173/index 1)
+export const GoalStampSchema = z.object({
+  id: z.uuid({ version: 'v7' }),
+  difficulty: z.enum(BEHAVIOR_DIFFICULTIES),
+});
+
+export const GetGoalStampsResponseSchema = z.array(GoalStampSchema);
+export type GetGoalStampsResponse = z.infer<typeof GetGoalStampsResponseSchema>;

--- a/packages/shared/src/types/goal.types.ts
+++ b/packages/shared/src/types/goal.types.ts
@@ -1,3 +1,5 @@
+import { BehaviorDifficulty } from './behavior.types';
+
 export const GOAL_COLORS = [
   'light-pink',
   'pink',
@@ -21,4 +23,9 @@ export interface Goal {
 
 export interface GoalSummary extends Goal {
   behaviorCount: number;
+}
+
+export interface GoalStamp {
+  id: string;
+  difficulty: BehaviorDifficulty;
 }


### PR DESCRIPTION
## 🔗 관련 이슈

- close: #16 
- close: #20 

## ✅ 작업 내용
- FE: 목표 상세페이지 레이아웃, GoalStampBoad(도장판) UI 구현
   - 전체 목표에서 목표 카드 누르면 목표 상세페이지(`/goals/:goalId`)로 이동하도록 navigate 밒 라우터 설정
- BE: 특정 목표의 누적 도장을 불러오는 API 구현 (`/api/goals/;id/stamps`)
   - Behavior <-> TodayBehavior 양방향 매핑
- DOCS: `/api/goals/:id/stamps` OpenAPI 추가 

## 📸 스크린샷 / 데모 (옵션)

<img width="150" alt="stamp" src="https://github.com/user-attachments/assets/c28d6bd3-bd8a-4593-81e4-1e65bd37feeb" />

> 오늘 행동에 쌓인 데이터가 거의 없어서 도장이 나오는지 우선적으로 체크

## 💡 체크리스트

- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (예: `feature/login` -> `develop`)
- [x] 테스트는 잘 통과했나요?
- [x] 빌드에 성공했나요?

## 💬 To Reviewers

- TODO
   - 목표 행동 리스트 컴포넌트 구현
   - 기본 도장판 최소 높이 설정
