### PR TITLE
feat: 목표 추가 버튼 디자인 변경

### DIFF
--- a/apps/frontend/src/features/behavior/components/SwiperTabs.tsx
+++ b/apps/frontend/src/features/behavior/components/SwiperTabs.tsx
@@ -6,13 +6,19 @@ import 'swiper/css/free-mode';
 interface SwiperTabsProps {
   tabs: string[];
   onChange: (id: string) => void;
+  slideOffsetAfter?: number;
 }
 
-export function SwiperTabs({ tabs, onChange }: SwiperTabsProps) {
+export function SwiperTabs({ tabs, onChange, slideOffsetAfter }: SwiperTabsProps) {
   const [active, setActive] = useState(0);
 
   return (
-    <Swiper slidesPerView="auto" spaceBetween={24} className="relative pb-2">
+    <Swiper
+      slidesPerView="auto"
+      spaceBetween={24}
+      className="relative pb-2"
+      slidesOffsetAfter={slideOffsetAfter}
+    >
       {tabs.map((label, idx) => (
         <SwiperSlide key={label} className="w-auto!">
           <button

--- a/apps/frontend/src/features/behavior/components/TodayBehaviorList.tsx
+++ b/apps/frontend/src/features/behavior/components/TodayBehaviorList.tsx
@@ -28,7 +28,7 @@ export function TodayBahaviorList({ goals, behaviors, onToggle }: BehaviorListPr
       </h3>
 
       {/* 목표 필터 탭 스와이퍼 */}
-      <div className="relative mb-2 flex items-center justify-around gap-2">
+      <div className="relative mb-2 flex items-center gap-2">
         {/* Tabs */}
         <div className="relative flex-1 overflow-hidden">
           {/* slideOffsetAfter : 슬라이더 맨 오른쪽 여백으로 오른쪽 그라데이션 오버레이의 너비랑 맞춤 */}

--- a/apps/frontend/src/features/behavior/components/TodayBehaviorList.tsx
+++ b/apps/frontend/src/features/behavior/components/TodayBehaviorList.tsx
@@ -1,7 +1,7 @@
 import { useState, useMemo } from 'react';
 import { BehaviorCard } from '@/shared/components/behavior/BehaviorCard';
 import type { Behavior } from '@/shared/components/behavior/BehaviorCard.types';
-import { Plus, CirclePlus } from 'lucide-react';
+import { Plus } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import { SwiperTabs } from './SwiperTabs';
 
@@ -28,19 +28,23 @@ export function TodayBahaviorList({ goals, behaviors, onToggle }: BehaviorListPr
       </h3>
 
       {/* 목표 필터 탭 스와이퍼 */}
-      <div className="relative mb-2 flex items-center">
+      <div className="relative mb-2 flex items-center justify-around gap-2">
         {/* Tabs */}
-        <div className="flex-1 overflow-hidden pr-10">
-          <SwiperTabs tabs={goals} onChange={setActiveGoal} />
+        <div className="relative flex-1 overflow-hidden">
+          {/* slideOffsetAfter : 슬라이더 맨 오른쪽 여백으로 오른쪽 그라데이션 오버레이의 너비랑 맞춤 */}
+          <SwiperTabs tabs={goals} onChange={setActiveGoal} slideOffsetAfter={48} />
+          {/* 오른쪽 그라데이션 오버레이 */}
+          <div className="from-bg-normal via-bg-normal/80 pointer-events-none absolute top-0 right-0 z-10 h-full w-12 bg-linear-to-l to-transparent" />
         </div>
 
         {/* + Button */}
         <button
           type="button"
-          className="absolute top-1/2 right-0 flex h-8 w-8 -translate-y-1/2 items-center justify-center"
+          className="flex shrink-0 items-center justify-center gap-1 pb-1"
           onClick={() => navigate('/goals/new')}
         >
-          <CirclePlus className="text-label-disable" />
+          <Plus className="text-label-disable h-5 w-5" />
+          <span className="text-label-disable text-sm font-semibold">목표</span>
         </button>
       </div>
 


### PR DESCRIPTION
## 🔗 관련 이슈

- close: #103 

## ✅ 작업 내용
- 오른쪽 오버레이 추가
- '+ 목표'로 디자인 변경

## 📸 스크린샷 / 데모

<img width="378" height="341" alt="image" src="https://github.com/user-attachments/assets/2c512e12-0630-4b77-bc68-8f17da95bca0" />

<img width="700" alt="image" src="https://github.com/user-attachments/assets/5675ee2b-9019-40fe-ac8d-99dac925cfd2" />

## 💡 체크리스트
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (예: `feature/login` -> `develop`)
- [x] 테스트는 잘 통과했나요?
- [x] 빌드에 성공했나요?

## 💬 To Reviewers
목표 버튼 레이아웃 일부 변경 및 오버레이 추가하였습니다.