### PR TITLE
feat: AI 추천 행동 생성 및 관리 기능 구현

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -79,6 +79,7 @@ jobs:
             export DB_USER="${{ secrets.STAGING_DB_USER }}"
             export DB_PASS="${{ secrets.STAGING_DB_PASS }}"
             export DB_NAME="${{ secrets.STAGING_DB_NAME }}"
+            export CLOVA_API_KEY="${{ secrets.STAGING_CLOVA_API_KEY }}"
             echo "${{ secrets.GHCR_TOKEN }}" | docker login ghcr.io -u "${{ secrets.GHCR_USERNAME }}" --password-stdin
             docker compose -f infra/staging/docker-compose.staging.yml pull
             docker compose -f infra/staging/docker-compose.staging.yml run --rm backend node ./node_modules/typeorm/cli.js -d ./dist/common/database/data-source.js migration:run
@@ -109,6 +110,7 @@ jobs:
             export DB_USER="${{ secrets.PROD_DB_USER }}"
             export DB_PASS="${{ secrets.PROD_DB_PASS }}"
             export DB_NAME="${{ secrets.PROD_DB_NAME }}"
+            export CLOVA_API_KEY="${{ secrets.PROD_CLOVA_API_KEY }}"
             echo "${{ secrets.GHCR_TOKEN }}" | docker login ghcr.io -u "${{ secrets.GHCR_USERNAME }}" --password-stdin
             docker compose -f infra/prod/docker-compose.prod.yml pull
             docker compose -f infra/prod/docker-compose.prod.yml run --rm backend node ./node_modules/typeorm/cli.js -d ./dist/common/database/data-source.js migration:run

--- a/apps/backend/.env.template
+++ b/apps/backend/.env.template
@@ -9,3 +9,5 @@ DB_PORT=rdb port, 거의 5432
 DB_USER=rdb user, 거의 devuser
 DB_PASS=rdb password, 거의 devpass
 DB_NAME=rdb name, 거의 doowelldevdb
+
+CLOVA_API_KEY=clova api

--- a/apps/backend/src/app.module.ts
+++ b/apps/backend/src/app.module.ts
@@ -24,6 +24,7 @@ import { AIModule } from './features/ai/ai.module';
         DB_USER: Joi.string().required(),
         DB_PASS: Joi.string().required(),
         DB_NAME: Joi.string().required(),
+        CLOVA_API_KEY: Joi.string().required(),
       }),
     }),
     TypeOrmModule.forRootAsync({

--- a/apps/backend/src/app.module.ts
+++ b/apps/backend/src/app.module.ts
@@ -9,6 +9,7 @@ import { AppService } from './app.service';
 import { User } from './features/user/user.entity';
 import { GoalModule } from './features/goal/goal.module';
 import { BehaviorModule } from './features/behavior/behavior.module';
+import { AIModule } from './features/ai/ai.module';
 
 @Module({
   imports: [
@@ -45,6 +46,7 @@ import { BehaviorModule } from './features/behavior/behavior.module';
     TypeOrmModule.forFeature([AppEntitySample, User]),
     GoalModule,
     BehaviorModule,
+    AIModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/apps/backend/src/common/database/migrations/1768453911160-auto.ts
+++ b/apps/backend/src/common/database/migrations/1768453911160-auto.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class Auto1768453911160 implements MigrationInterface {
+  name = 'Auto1768453911160';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TYPE "public"."ai_behaviors_status_enum" AS ENUM('pending', 'completed')`,
+    );
+    await queryRunner.query(
+      `CREATE TABLE "ai_behaviors" ("id" uuid NOT NULL DEFAULT uuidv7(), "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "deletedAt" TIMESTAMP WITH TIME ZONE, "title" character varying(30) NOT NULL, "date" date NOT NULL, "status" "public"."ai_behaviors_status_enum" NOT NULL, "goalId" uuid, "userId" uuid, CONSTRAINT "PK_3ffef2471f4bd43f7bae32418ce" PRIMARY KEY ("id"))`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP TABLE "ai_behaviors"`);
+    await queryRunner.query(`DROP TYPE "public"."ai_behaviors_status_enum"`);
+  }
+}

--- a/apps/backend/src/features/ai/ai.module.ts
+++ b/apps/backend/src/features/ai/ai.module.ts
@@ -3,6 +3,6 @@ import { AIService } from './ai.service';
 
 @Module({
   providers: [AIService],
-  exports: [AIModule],
+  exports: [AIService],
 })
 export class AIModule {}

--- a/apps/backend/src/features/ai/ai.module.ts
+++ b/apps/backend/src/features/ai/ai.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { AIService } from './ai.service';
+
+@Module({
+  providers: [AIService],
+  exports: [AIModule],
+})
+export class AIModule {}

--- a/apps/backend/src/features/ai/ai.service.spec.ts
+++ b/apps/backend/src/features/ai/ai.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AIService } from './ai.service';
+
+describe('AIService', () => {
+  let service: AIService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [AIService],
+    }).compile();
+
+    service = module.get<AIService>(AIService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/apps/backend/src/features/ai/ai.service.spec.ts
+++ b/apps/backend/src/features/ai/ai.service.spec.ts
@@ -1,4 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
 import { AIService } from './ai.service';
 
 describe('AIService', () => {
@@ -6,7 +7,13 @@ describe('AIService', () => {
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [AIService],
+      providers: [
+        AIService,
+        {
+          provide: ConfigService,
+          useValue: { getOrThrow: jest.fn() },
+        },
+      ],
     }).compile();
 
     service = module.get<AIService>(AIService);

--- a/apps/backend/src/features/ai/ai.service.ts
+++ b/apps/backend/src/features/ai/ai.service.ts
@@ -1,13 +1,137 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { Goal } from '../goal/goal.entity';
+
+type ClovaChatResponse = {
+  status: {
+    code: string;
+    message: string;
+  };
+  result: {
+    created: number;
+    usage: {
+      completionTokens: number;
+      promptTokens: number;
+      totalTokens: number;
+    };
+    message: {
+      role: 'assistant' | 'user' | 'system';
+      content: string;
+    };
+    seed?: number;
+    aiFilter?: Array<{
+      groupName: string;
+      name: string;
+      score: string; // 응답 예시가 string이므로 string
+    }>;
+  };
+};
+
+type AIBehaviorRecommendation = {
+  마음열기: string;
+  시작하기: string;
+  이어가기: string;
+  몰입하기: string;
+};
 
 @Injectable()
 export class AIService {
+  constructor(private readonly configService: ConfigService) {}
+
   async getAIBehaviorTitles(goal: Goal): Promise<string[]> {
-    await new Promise((resolve) => {
-      setTimeout(resolve, 1000);
+    const logger = new Logger();
+
+    const goalTitle = goal.title;
+    const openBehaivors = goal.behaviors
+      .filter((b) => b.difficulty === '마음열기')
+      .map((b) => b.title);
+    const startBehaivors = goal.behaviors
+      .filter((b) => b.difficulty === '시작하기')
+      .map((b) => b.title);
+    const continueBehaivors = goal.behaviors
+      .filter((b) => b.difficulty === '이어가기')
+      .map((b) => b.title);
+    const deepBehaivors = goal.behaviors
+      .filter((b) => b.difficulty === '몰입하기')
+      .map((b) => b.title);
+
+    const systemPrompt = `최근 사용자가 관심을 가지고 있는 목표는 ${goalTitle}이다.
+
+사용자는 이 목표를 이루기 위한 행동을 4단계로 구분했다.
+각 단계의 이름과 정의는 다음과 같다.
+
+1. 마음열기  
+- 목표와 직접적인 관련이 없어도 된다.  
+- “해볼까?”라는 생각이 떠오르거나, 심리적 저항을 낮추는 행동이면 충분하다.  
+- 판단 기준: 목표를 떠올리는 데 부담이 거의 없는가?
+
+2. 시작하기  
+- 목표에 다가가기 위한 아주 작은 첫 행동이다.  
+- 5~10분 이내에 끝낼 수 있고, 미루기 어려운 행동이 적합하다.  
+- 판단 기준: 오늘 당장 해도 부담이 없는가?
+
+3. 이어가기  
+- 시작하기를 자주 반복하여 루틴으로 만든 행동이다.  
+- 목표 달성에 직접적으로 기여하는 핵심 습관이면 좋다.  
+- 판단 기준: 꾸준히 반복할 수 있는가?
+
+4. 몰입하기  
+- 항상 해야 할 필요는 없지만, 하면 목표에 크게 가까워지는 행동이다.  
+- 끝내고 나면 성취감이나 뿌듯함을 느낄 수 있어야 한다.  
+- 판단 기준: 완료 후 “잘했다”는 감정이 드는가?
+
+현재 사용자가 지정한 각 단계별 행동 목록은 다음과 같다.
+- 마음열기: ${openBehaivors.join(', ')}
+- 시작하기: ${startBehaivors.join(', ')}
+- 이어가기: ${continueBehaivors.join(', ')}
+- 몰입하기: ${deepBehaivors.join(', ')}
+
+
+행동 생성 가이드라인
+- 위에 제시된 행동과 **의미적으로 중복되지 않아야 함**  
+- 각 단계별로 **정확히 1개씩이어야 함**
+- 목표를 이루기 위해 도움이 되는 행동이어야 함
+- 사용자가 쉽게 생각할 수 있거나 유사한 행동보다는 방향성은 같지만 뜬금 없는 행동이 더 좋음
+- 문장부호 금지
+
+출력 형식은 반드시 **유효한 JSON**이어야 하며,
+아래 형식을 정확히 지켜야 한다.
+
+{
+  "마음열기": "...",
+  "시작하기": "...",
+  "이어가기": "...",
+  "몰입하기": "..."
+}
+
+JSON 외의 설명, 문장, 코드블록, 주석은 **절대 출력하지 마**.
+`;
+
+    const modelName = 'HCX-005';
+    const clovaApiUrl = `https://clovastudio.stream.ntruss.com/v3/chat-completions/${modelName}`;
+
+    const messages = [{ role: 'user', content: [{ type: 'text', text: systemPrompt }] }];
+
+    const body = { messages };
+
+    logger.log(`send Clova API with title:${goal.title} id: ${goal.id}`);
+
+    const clovaApiKey = this.configService.getOrThrow<string>('CLOVA_API_KEY');
+    const response = await fetch(clovaApiUrl, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${clovaApiKey}`,
+      },
+      body: JSON.stringify(body),
     });
 
-    return [`AI가 만든 새 행동 이름 ${goal.title}`];
+    const responseJson = (await response.json()) as ClovaChatResponse;
+
+    const aiResult = responseJson.result.message.content.replaceAll('`', '').replaceAll('json', '');
+    const aiResultObject = JSON.parse(aiResult) as AIBehaviorRecommendation;
+    logger.log(`Response of Clova API:: ${aiResult}`);
+
+    return [aiResultObject.몰입하기];
   }
 }

--- a/apps/backend/src/features/ai/ai.service.ts
+++ b/apps/backend/src/features/ai/ai.service.ts
@@ -128,10 +128,28 @@ JSON 외의 설명, 문장, 코드블록, 주석은 **절대 출력하지 마**.
 
     const responseJson = (await response.json()) as ClovaChatResponse;
 
-    const aiResult = responseJson.result.message.content.replaceAll('`', '').replaceAll('json', '');
-    const aiResultObject = JSON.parse(aiResult) as AIBehaviorRecommendation;
-    logger.log(`Response of Clova API:: ${aiResult}`);
+    const { content } = responseJson.result.message;
+    const startIndex = content.indexOf('{');
+    const endIndex = content.lastIndexOf('}');
 
-    return [aiResultObject.몰입하기];
+    if (startIndex === -1 || endIndex === -1 || startIndex >= endIndex) {
+      logger.error(`Failed to find JSON object in Clova API response: ${content}`);
+      throw new Error('Failed to parse JSON from Clova API response');
+    }
+
+    const jsonStr = content.substring(startIndex, endIndex + 1);
+
+    try {
+      const aiResultObject = JSON.parse(jsonStr) as AIBehaviorRecommendation;
+      logger.log(`Response of Clova API:: ${jsonStr}`);
+      return [aiResultObject.몰입하기];
+    } catch (error) {
+      if (error instanceof Error) {
+        logger.error(`Failed to parse JSON: ${error.message}`, error.stack, jsonStr);
+      } else {
+        logger.error('Failed to parse JSON: Unknown error', String(error), jsonStr);
+      }
+      throw new Error('AI 응답 JSON 파싱에 실패했습니다.');
+    }
   }
 }

--- a/apps/backend/src/features/ai/ai.service.ts
+++ b/apps/backend/src/features/ai/ai.service.ts
@@ -1,0 +1,13 @@
+import { Injectable } from '@nestjs/common';
+import { Goal } from '../goal/goal.entity';
+
+@Injectable()
+export class AIService {
+  async getAIBehaviorTitles(goal: Goal): Promise<string[]> {
+    await new Promise((resolve) => {
+      setTimeout(resolve, 1000);
+    });
+
+    return [`AI가 만든 새 행동 이름 ${goal.title}`];
+  }
+}

--- a/apps/backend/src/features/behavior/ai-behavior.entity.spec.ts
+++ b/apps/backend/src/features/behavior/ai-behavior.entity.spec.ts
@@ -1,0 +1,37 @@
+import { getMetadataArgsStorage } from 'typeorm';
+import { AIBehavior } from './ai-behavior.entity';
+
+const storage = getMetadataArgsStorage();
+
+const getTableName = (target: Function): string | undefined =>
+  storage.tables.find((table) => table.target === target)?.name;
+
+const getColumnNames = (target: Function): string[] =>
+  storage.columns.filter((column) => column.target === target).map((column) => column.propertyName);
+
+const getRelation = (target: Function, propertyName: string) =>
+  storage.relations.find(
+    (relation) => relation.target === target && relation.propertyName === propertyName,
+  );
+
+const getJoinColumn = (target: Function, propertyName: string) =>
+  storage.joinColumns.find(
+    (joinColumn) => joinColumn.target === target && joinColumn.propertyName === propertyName,
+  );
+
+describe('AIBehavior', () => {
+  it('테이블과 컬럼 매핑을 가진다', () => {
+    expect(getTableName(AIBehavior)).toBe('ai_behaviors');
+    expect(getColumnNames(AIBehavior)).toEqual(expect.arrayContaining(['title', 'date', 'status']));
+  });
+
+  it('Goal, User 관계 매핑을 가진다', () => {
+    const goalRelation = getRelation(AIBehavior, 'goal');
+    expect(goalRelation?.relationType).toBe('many-to-one');
+    expect(getJoinColumn(AIBehavior, 'goal')?.name).toBe('goalId');
+
+    const userRelation = getRelation(AIBehavior, 'user');
+    expect(userRelation?.relationType).toBe('many-to-one');
+    expect(getJoinColumn(AIBehavior, 'user')?.name).toBe('userId');
+  });
+});

--- a/apps/backend/src/features/behavior/ai-behavior.entity.ts
+++ b/apps/backend/src/features/behavior/ai-behavior.entity.ts
@@ -1,0 +1,33 @@
+import { Column, Entity, JoinColumn, ManyToOne } from 'typeorm';
+import {
+  AI_BEHAVIOR_STATUS,
+  BEHAVIOR_TITLE_MAX_LENGTH,
+  type AIBehaviorStatus,
+} from '@web24/shared';
+import { BaseIdCreatedUpdatedDeletedEntity } from '../../common/entities/base.entity';
+import { User } from '../user/user.entity';
+import { Goal } from '../goal/goal.entity';
+
+@Entity({ name: 'ai_behaviors' })
+export class AIBehavior extends BaseIdCreatedUpdatedDeletedEntity {
+  @ManyToOne(() => Goal, (goal) => goal.behaviors, {
+    createForeignKeyConstraints: false,
+  })
+  @JoinColumn({ name: 'goalId' })
+  goal!: Goal;
+
+  @Column({ type: 'varchar', length: BEHAVIOR_TITLE_MAX_LENGTH })
+  title!: string;
+
+  @ManyToOne(() => User, {
+    createForeignKeyConstraints: false,
+  })
+  @JoinColumn({ name: 'userId' })
+  user!: User;
+
+  @Column({ type: 'date' })
+  date!: string; // YYYY-MM-DD
+
+  @Column({ type: 'enum', enum: AI_BEHAVIOR_STATUS })
+  status!: AIBehaviorStatus;
+}

--- a/apps/backend/src/features/behavior/behavior.docs.ts
+++ b/apps/backend/src/features/behavior/behavior.docs.ts
@@ -2,7 +2,11 @@ import { OpenAPIRegistry } from '@asteasolutions/zod-to-openapi';
 import { z } from 'zod';
 import {
   GetAllBehaviorsResponseSchema,
+  GetAIBehaviorResponseSchema,
   GetTodayBehaviorsResponseSchema,
+  PatchAIBehaviorStatusRequestSchema,
+  PatchAIBehaviorStatusResponseSchema,
+  PostAIBehaviorResponseSchema,
   PatchTodayBehaviorStatusRequestSchema,
   PatchTodayBehaviorStatusResponseSchema,
 } from '@web24/shared';
@@ -24,6 +28,22 @@ export function registerBehaviorApi(registry: OpenAPIRegistry) {
     'GetAllBehaviorsResponse',
     GetAllBehaviorsResponseSchema,
   );
+  const getAIBehaviorsResponse = registry.register(
+    'GetAIBehaviorResponse',
+    GetAIBehaviorResponseSchema,
+  );
+  const postAIBehaviorsResponse = registry.register(
+    'PostAIBehaviorResponse',
+    PostAIBehaviorResponseSchema,
+  );
+  const patchAIBehaviorStatusRequest = registry.register(
+    'PatchAIBehaviorStatusRequest',
+    PatchAIBehaviorStatusRequestSchema,
+  );
+  const patchAIBehaviorStatusResponse = registry.register(
+    'PatchAIBehaviorStatusResponse',
+    PatchAIBehaviorStatusResponseSchema,
+  );
   const errorResponse = registry.register(
     'ErrorResponse',
     z.object({
@@ -44,6 +64,69 @@ export function registerBehaviorApi(registry: OpenAPIRegistry) {
         content: {
           'application/json': {
             schema: getTodayBehaviorsResponse,
+          },
+        },
+      },
+    },
+  });
+
+  registry.registerPath({
+    method: 'get',
+    path: '/today-behaviors/ai',
+    responses: {
+      200: {
+        description: '오늘 AI 행동 목록을 반환, 없으면 빈 리스트',
+        content: {
+          'application/json': {
+            schema: getAIBehaviorsResponse,
+          },
+        },
+      },
+    },
+  });
+
+  registry.registerPath({
+    method: 'post',
+    path: '/today-behaviors/ai',
+    responses: {
+      200: {
+        description:
+          '오늘 AI 행동을 생성하고 반환, 추후 여러 AIBehavior 생성 가능성을 염두하여 현재는 하나의 값을 리스트에 담아서 반환',
+        content: {
+          'application/json': {
+            schema: postAIBehaviorsResponse,
+          },
+        },
+      },
+    },
+  });
+
+  registry.registerPath({
+    method: 'patch',
+    path: '/today-behaviors/ai/{id}/status',
+    request: {
+      body: {
+        content: {
+          'application/json': {
+            schema: patchAIBehaviorStatusRequest,
+          },
+        },
+      },
+    },
+    responses: {
+      200: {
+        description: 'AI behavior status updated',
+        content: {
+          'application/json': {
+            schema: patchAIBehaviorStatusResponse,
+          },
+        },
+      },
+      404: {
+        description: 'AI behavior not found',
+        content: {
+          'application/json': {
+            schema: errorResponse,
           },
         },
       },

--- a/apps/backend/src/features/behavior/behavior.module.ts
+++ b/apps/backend/src/features/behavior/behavior.module.ts
@@ -6,9 +6,10 @@ import { BehaviorService } from './behavior.service';
 import { Behavior } from './behavior.entity';
 import { Goal } from '../goal/goal.entity';
 import { TodayBehavior } from './today-behavior.entity';
+import { AIBehavior } from './ai-behavior.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Behavior, Goal, TodayBehavior])],
+  imports: [TypeOrmModule.forFeature([Behavior, Goal, TodayBehavior, AIBehavior])],
   controllers: [BehaviorController, TodayBehaviorController],
   providers: [BehaviorService],
 })

--- a/apps/backend/src/features/behavior/behavior.module.ts
+++ b/apps/backend/src/features/behavior/behavior.module.ts
@@ -7,10 +7,11 @@ import { Behavior } from './behavior.entity';
 import { Goal } from '../goal/goal.entity';
 import { TodayBehavior } from './today-behavior.entity';
 import { AIBehavior } from './ai-behavior.entity';
+import { AIService } from '../ai/ai.service';
 
 @Module({
   imports: [TypeOrmModule.forFeature([Behavior, Goal, TodayBehavior, AIBehavior])],
   controllers: [BehaviorController, TodayBehaviorController],
-  providers: [BehaviorService],
+  providers: [BehaviorService, AIService],
 })
 export class BehaviorModule {}

--- a/apps/backend/src/features/behavior/behavior.module.ts
+++ b/apps/backend/src/features/behavior/behavior.module.ts
@@ -1,5 +1,6 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { AIModule } from '../ai/ai.module';
 import { BehaviorController } from './behavior.controller';
 import { TodayBehaviorController } from './today-behavior.controller';
 import { BehaviorService } from './behavior.service';
@@ -7,11 +8,10 @@ import { Behavior } from './behavior.entity';
 import { Goal } from '../goal/goal.entity';
 import { TodayBehavior } from './today-behavior.entity';
 import { AIBehavior } from './ai-behavior.entity';
-import { AIService } from '../ai/ai.service';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Behavior, Goal, TodayBehavior, AIBehavior])],
+  imports: [TypeOrmModule.forFeature([Behavior, Goal, TodayBehavior, AIBehavior]), AIModule],
   controllers: [BehaviorController, TodayBehaviorController],
-  providers: [BehaviorService, AIService],
+  providers: [BehaviorService],
 })
 export class BehaviorModule {}

--- a/apps/backend/src/features/behavior/behavior.service.spec.ts
+++ b/apps/backend/src/features/behavior/behavior.service.spec.ts
@@ -2,12 +2,13 @@ import { In, Not } from 'typeorm';
 import { NotFoundException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { getDataSourceToken, getRepositoryToken } from '@nestjs/typeorm';
-import { TodayBehaviorStatus } from '@web24/shared';
+import { type AIBehaviorStatus, BEHAVIOR_DIFFICULTIES, TodayBehaviorStatus } from '@web24/shared';
 import { BehaviorService } from './behavior.service';
 import { Behavior } from './behavior.entity';
 import { TodayBehavior } from './today-behavior.entity';
 import { AIBehavior } from './ai-behavior.entity';
 import { AIService } from '../ai/ai.service';
+import { Goal } from '../goal/goal.entity';
 
 jest.mock('crypto', () => ({ randomInt: jest.fn() }));
 
@@ -18,8 +19,8 @@ describe('BehaviorService', () => {
     find: jest.Mock;
   };
   let todayBehaviorRepository: { update: jest.Mock };
-  let aiBehaviorRepository: { find: jest.Mock };
-  let aiService: { createAIBehaviors: jest.Mock };
+  let aiBehaviorRepository: { find: jest.Mock; update: jest.Mock };
+  let aiService: { createAIBehaviors: jest.Mock; getAIBehaviorTitles: jest.Mock };
   let dataSource: { transaction: jest.Mock };
   let queryBuilder: {
     leftJoinAndSelect: jest.Mock;
@@ -40,8 +41,8 @@ describe('BehaviorService', () => {
       find: jest.fn(),
     };
     todayBehaviorRepository = { update: jest.fn() };
-    aiBehaviorRepository = { find: jest.fn() };
-    aiService = { createAIBehaviors: jest.fn() };
+    aiBehaviorRepository = { find: jest.fn(), update: jest.fn() };
+    aiService = { createAIBehaviors: jest.fn(), getAIBehaviorTitles: jest.fn() };
     dataSource = { transaction: jest.fn() };
 
     const module: TestingModule = await Test.createTestingModule({
@@ -58,150 +59,156 @@ describe('BehaviorService', () => {
     service = module.get<BehaviorService>(BehaviorService);
   });
 
-  it('should be defined', () => {
-    expect(service).toBeDefined();
+  describe('init', () => {
+    it('should be defined', () => {
+      expect(service).toBeDefined();
+    });
   });
 
-  it('today behavior 상태를 업데이트한다', async () => {
-    todayBehaviorRepository.update.mockResolvedValue({ affected: 1 });
+  describe('updateTodayBehaviorStatus', () => {
+    it('today behavior 상태를 업데이트한다', async () => {
+      todayBehaviorRepository.update.mockResolvedValue({ affected: 1 });
 
-    const result = await service.updateTodayBehaviorStatus(
-      'tb-1',
-      'completed' as TodayBehaviorStatus,
-    );
+      const result = await service.updateTodayBehaviorStatus(
+        'tb-1',
+        'completed' as TodayBehaviorStatus,
+      );
 
-    expect(todayBehaviorRepository.update).toHaveBeenCalledWith(
-      { id: 'tb-1' },
-      { status: 'completed' },
-    );
-    expect(result).toEqual({ id: 'tb-1', status: 'completed' });
+      expect(todayBehaviorRepository.update).toHaveBeenCalledWith(
+        { id: 'tb-1' },
+        { status: 'completed' },
+      );
+      expect(result).toEqual({ id: 'tb-1', status: 'completed' });
+    });
+
+    it('대상이 없으면 NotFoundException을 던진다', async () => {
+      todayBehaviorRepository.update.mockResolvedValue({ affected: 0 });
+
+      await expect(
+        service.updateTodayBehaviorStatus('tb-404', 'completed' as TodayBehaviorStatus),
+      ).rejects.toBeInstanceOf(NotFoundException);
+    });
   });
 
-  it('대상이 없으면 NotFoundException을 던진다', async () => {
-    todayBehaviorRepository.update.mockResolvedValue({ affected: 0 });
+  describe('getTodayBehaviors', () => {
+    it('기존 오늘 행동이 있으면 매핑해서 반환한다', async () => {
+      const user = { id: 'user-1', nickname: '테스트유저' };
+      const existing = [
+        {
+          id: 'tb-1',
+          status: 'completed',
+          behavior: {
+            title: '물 1컵 마시기',
+            difficulty: '마음열기',
+            goal: { title: '건강한 생활', color: 'mint' },
+          },
+          user,
+        },
+      ] as TodayBehavior[];
 
-    await expect(
-      service.updateTodayBehaviorStatus('tb-404', 'completed' as TodayBehaviorStatus),
-    ).rejects.toBeInstanceOf(NotFoundException);
-  });
+      const userRepository = { findOne: jest.fn().mockResolvedValue(user) };
+      const todayRepository = { find: jest.fn().mockResolvedValue(existing) };
+      const behaviorRepository = { find: jest.fn() };
+      const manager = {
+        getRepository: (entity: unknown) => {
+          if (entity === (Behavior as unknown)) return behaviorRepository;
+          if (entity === (TodayBehavior as unknown)) return todayRepository;
+          return userRepository;
+        },
+      };
 
-  it('getTodayBehaviors가 기존 오늘 행동이 있으면 매핑해서 반환한다', async () => {
-    const user = { id: 'user-1', nickname: '테스트유저' };
-    const existing = [
-      {
-        id: 'tb-1',
-        status: 'completed',
-        behavior: {
+      dataSource.transaction.mockImplementation(async (work: (m: typeof manager) => unknown) =>
+        work(manager),
+      );
+
+      const result = await service.getTodayBehaviors();
+
+      expect(userRepository.findOne).toHaveBeenCalledWith({ where: { nickname: '테스트유저' } });
+      expect(todayRepository.find).toHaveBeenCalledWith({
+        where: {
+          date: expect.any(String),
+          user: { id: user.id },
+          status: Not(In(['skipped', 'ignored'])),
+        },
+        relations: { behavior: { goal: true }, user: true },
+      });
+      expect(behaviorRepository.find).not.toHaveBeenCalled();
+      expect(result).toEqual([
+        {
+          id: 'tb-1',
+          title: '물 1컵 마시기',
+          goalTitle: '건강한 생활',
+          goalColor: 'mint',
+          difficulty: '마음열기',
+          isChecked: true,
+          isRecommended: false,
+        },
+      ]);
+    });
+
+    it('기존 오늘 행동이 없으면 추출 후 저장하고 반환한다', async () => {
+      const user = { id: 'user-1', nickname: '테스트유저' };
+      const behaviors = [
+        {
+          id: 'b-1',
           title: '물 1컵 마시기',
           difficulty: '마음열기',
           goal: { title: '건강한 생활', color: 'mint' },
         },
-        user,
-      },
-    ] as TodayBehavior[];
+      ] as Behavior[];
 
-    const userRepository = { findOne: jest.fn().mockResolvedValue(user) };
-    const todayRepository = { find: jest.fn().mockResolvedValue(existing) };
-    const behaviorRepository = { find: jest.fn() };
-    const manager = {
-      getRepository: (entity: unknown) => {
-        if (entity === (Behavior as unknown)) return behaviorRepository;
-        if (entity === (TodayBehavior as unknown)) return todayRepository;
-        return userRepository;
-      },
-    };
+      const todayRepository = {
+        find: jest.fn().mockResolvedValue([]),
+        create: jest.fn((value) => value),
+        save: jest.fn().mockResolvedValue([
+          {
+            id: 'b-1',
+            behavior: behaviors[0],
+          },
+        ]),
+      };
+      const userRepository = { findOne: jest.fn().mockResolvedValue(user) };
+      const behaviorRepository = { find: jest.fn().mockResolvedValue(behaviors) };
+      const manager = {
+        getRepository: (entity: unknown) => {
+          if (entity === (Behavior as unknown)) return behaviorRepository;
+          if (entity === (TodayBehavior as unknown)) return todayRepository;
+          return userRepository;
+        },
+      };
 
-    dataSource.transaction.mockImplementation(async (work: (m: typeof manager) => unknown) =>
-      work(manager),
-    );
+      dataSource.transaction.mockImplementation(async (work: (m: typeof manager) => unknown) =>
+        work(manager),
+      );
+      const extractSpy = jest.spyOn(service, 'extractTodayBehaviors').mockReturnValue(behaviors);
 
-    const result = await service.getTodayBehaviors();
+      const result = await service.getTodayBehaviors();
 
-    expect(userRepository.findOne).toHaveBeenCalledWith({ where: { nickname: '테스트유저' } });
-    expect(todayRepository.find).toHaveBeenCalledWith({
-      where: {
-        date: expect.any(String),
-        user: { id: user.id },
-        status: Not(In(['skipped', 'ignored'])),
-      },
-      relations: { behavior: { goal: true }, user: true },
-    });
-    expect(behaviorRepository.find).not.toHaveBeenCalled();
-    expect(result).toEqual([
-      {
-        id: 'tb-1',
-        title: '물 1컵 마시기',
-        goalTitle: '건강한 생활',
-        goalColor: 'mint',
-        difficulty: '마음열기',
-        isChecked: true,
-        isRecommended: false,
-      },
-    ]);
-  });
-
-  it('getTodayBehaviors가 기존 오늘 행동이 없으면 추출 후 저장하고 반환한다', async () => {
-    const user = { id: 'user-1', nickname: '테스트유저' };
-    const behaviors = [
-      {
-        id: 'b-1',
-        title: '물 1컵 마시기',
-        difficulty: '마음열기',
-        goal: { title: '건강한 생활', color: 'mint' },
-      },
-    ] as Behavior[];
-
-    const todayRepository = {
-      find: jest.fn().mockResolvedValue([]),
-      create: jest.fn((value) => value),
-      save: jest.fn().mockResolvedValue([
+      expect(userRepository.findOne).toHaveBeenCalledWith({ where: { nickname: '테스트유저' } });
+      expect(todayRepository.find).toHaveBeenCalledWith({
+        where: {
+          date: expect.any(String),
+          user: { id: user.id },
+          status: Not(In(['skipped', 'ignored'])),
+        },
+        relations: { behavior: { goal: true }, user: true },
+      });
+      expect(behaviorRepository.find).toHaveBeenCalledWith({ relations: { goal: true } });
+      expect(extractSpy).toHaveBeenCalledWith(behaviors);
+      expect(todayRepository.save).toHaveBeenCalledTimes(1);
+      expect(result).toEqual([
         {
           id: 'b-1',
-          behavior: behaviors[0],
+          title: '물 1컵 마시기',
+          goalTitle: '건강한 생활',
+          goalColor: 'mint',
+          difficulty: '마음열기',
+          isChecked: false,
+          isRecommended: false,
         },
-      ]),
-    };
-    const userRepository = { findOne: jest.fn().mockResolvedValue(user) };
-    const behaviorRepository = { find: jest.fn().mockResolvedValue(behaviors) };
-    const manager = {
-      getRepository: (entity: unknown) => {
-        if (entity === (Behavior as unknown)) return behaviorRepository;
-        if (entity === (TodayBehavior as unknown)) return todayRepository;
-        return userRepository;
-      },
-    };
-
-    dataSource.transaction.mockImplementation(async (work: (m: typeof manager) => unknown) =>
-      work(manager),
-    );
-    const extractSpy = jest.spyOn(service, 'extractTodayBehaviors').mockReturnValue(behaviors);
-
-    const result = await service.getTodayBehaviors();
-
-    expect(userRepository.findOne).toHaveBeenCalledWith({ where: { nickname: '테스트유저' } });
-    expect(todayRepository.find).toHaveBeenCalledWith({
-      where: {
-        date: expect.any(String),
-        user: { id: user.id },
-        status: Not(In(['skipped', 'ignored'])),
-      },
-      relations: { behavior: { goal: true }, user: true },
+      ]);
+      extractSpy.mockRestore();
     });
-    expect(behaviorRepository.find).toHaveBeenCalledWith({ relations: { goal: true } });
-    expect(extractSpy).toHaveBeenCalledWith(behaviors);
-    expect(todayRepository.save).toHaveBeenCalledTimes(1);
-    expect(result).toEqual([
-      {
-        id: 'b-1',
-        title: '물 1컵 마시기',
-        goalTitle: '건강한 생활',
-        goalColor: 'mint',
-        difficulty: '마음열기',
-        isChecked: false,
-        isRecommended: false,
-      },
-    ]);
-    extractSpy.mockRestore();
   });
 
   describe('extractTodayBehaviors', () => {
@@ -334,30 +341,191 @@ describe('BehaviorService', () => {
     });
   });
 
-  it('전체 행동 목록을 반환한다', async () => {
-    const behaviors = [
-      {
-        id: 'b1',
-        title: 'b1',
-        difficulty: 'easy',
-        goal: { id: 'g1' },
-      },
-    ];
-    repository.find.mockResolvedValue(behaviors);
+  describe('getAllBehaviors', () => {
+    it('전체 행동 목록을 반환한다', async () => {
+      const behaviors = [
+        {
+          id: 'b1',
+          title: 'b1',
+          difficulty: 'easy',
+          goal: { id: 'g1' },
+        },
+      ];
+      repository.find.mockResolvedValue(behaviors);
 
-    const result = await service.getAllBehaviors();
+      const result = await service.getAllBehaviors();
 
-    expect(repository.find).toHaveBeenCalledWith({
-      relations: ['goal'],
+      expect(repository.find).toHaveBeenCalledWith({
+        relations: ['goal'],
+      });
+
+      expect(result).toEqual([
+        {
+          id: 'b1',
+          goalId: 'g1',
+          title: 'b1',
+          difficulty: 'easy',
+        },
+      ]);
+    });
+  });
+
+  describe('getAIBehaviors', () => {
+    it('AI 행동 목록을 매핑해서 반환한다', async () => {
+      const user = { id: 'user-1', nickname: '테스트유저' };
+      const aiBehaviors = [
+        {
+          id: 'ai-1',
+          title: 'AI 행동',
+          status: 'completed',
+          goal: { title: '건강한 생활', color: 'mint' },
+        },
+      ] as AIBehavior[];
+
+      const userRepository = { findOne: jest.fn().mockResolvedValue(user) };
+      const aiBehaviorRepo = { find: jest.fn().mockResolvedValue(aiBehaviors) };
+      const manager = {
+        getRepository: (entity: unknown) => {
+          if (entity === (AIBehavior as unknown)) return aiBehaviorRepo;
+          return userRepository;
+        },
+      };
+
+      dataSource.transaction.mockImplementation(async (work: (m: typeof manager) => unknown) =>
+        work(manager),
+      );
+
+      const result = await service.getAIBehaviors();
+
+      expect(userRepository.findOne).toHaveBeenCalledWith({ where: { nickname: '테스트유저' } });
+      expect(aiBehaviorRepo.find).toHaveBeenCalledWith({
+        where: { date: expect.any(String), user: { id: user.id } },
+        relations: { goal: true },
+      });
+      expect(result).toEqual([
+        {
+          id: 'ai-1',
+          title: 'AI 행동',
+          goalTitle: '건강한 생활',
+          goalColor: 'mint',
+          difficulty: BEHAVIOR_DIFFICULTIES[4],
+          isChecked: true,
+          isRecommended: true,
+        },
+      ]);
+    });
+  });
+
+  describe('createAIBhaviors', () => {
+    it('AI 행동을 생성하고 매핑해서 반환한다', async () => {
+      const user = { id: 'user-1', nickname: '테스트유저' };
+      const bestGoal = {
+        id: 'goal-1',
+        title: '건강한 생활',
+        color: 'mint',
+        behaviors: [],
+      };
+      const weekTodayBehaviors = [
+        { behavior: { goal: { id: 'goal-1' } }, status: 'completed' },
+        { behavior: { goal: { id: 'goal-1' } }, status: 'pending' },
+      ] as TodayBehavior[];
+
+      const userRepository = { findOne: jest.fn().mockResolvedValue(user) };
+      const todayRepository = { find: jest.fn().mockResolvedValue(weekTodayBehaviors) };
+      const goalRepository = { findOne: jest.fn().mockResolvedValue(bestGoal) };
+      const aiBehaviorRepo = {
+        create: jest.fn((value) => value),
+        save: jest.fn().mockResolvedValue([
+          { id: 'ai-1', title: 'AI 행동1', goal: bestGoal },
+          { id: 'ai-2', title: 'AI 행동2', goal: bestGoal },
+        ]),
+      };
+
+      const manager = {
+        getRepository: (entity: unknown) => {
+          if (entity === (TodayBehavior as unknown)) return todayRepository;
+          if (entity === (Goal as unknown)) return goalRepository;
+          if (entity === (AIBehavior as unknown)) return aiBehaviorRepo;
+          return userRepository;
+        },
+      };
+
+      dataSource.transaction.mockImplementation(async (work: (m: typeof manager) => unknown) =>
+        work(manager),
+      );
+      aiService.getAIBehaviorTitles.mockResolvedValue(['AI 행동1', 'AI 행동2']);
+
+      const result = await service.createAIBhaviors();
+
+      expect(userRepository.findOne).toHaveBeenCalledWith({ where: { nickname: '테스트유저' } });
+      expect(todayRepository.find).toHaveBeenCalledWith({
+        where: expect.objectContaining({ user: { id: user.id } }),
+        relations: { behavior: { goal: true } },
+      });
+      expect(goalRepository.findOne).toHaveBeenCalledWith({
+        where: { id: 'goal-1' },
+        relations: { behaviors: true },
+      });
+      expect(aiService.getAIBehaviorTitles).toHaveBeenCalledWith(bestGoal);
+      expect(aiBehaviorRepo.create).toHaveBeenCalledTimes(2);
+      expect(aiBehaviorRepo.save).toHaveBeenCalledWith(
+        expect.arrayContaining([
+          expect.objectContaining({
+            title: 'AI 행동1',
+            goal: bestGoal,
+            user,
+            status: 'pending',
+          }),
+          expect.objectContaining({
+            title: 'AI 행동2',
+            goal: bestGoal,
+            user,
+            status: 'pending',
+          }),
+        ]),
+      );
+      expect(result).toEqual([
+        {
+          id: 'ai-1',
+          title: 'AI 행동1',
+          goalTitle: '건강한 생활',
+          goalColor: 'mint',
+          difficulty: BEHAVIOR_DIFFICULTIES[4],
+          isChecked: false,
+          isRecommended: true,
+        },
+        {
+          id: 'ai-2',
+          title: 'AI 행동2',
+          goalTitle: '건강한 생활',
+          goalColor: 'mint',
+          difficulty: BEHAVIOR_DIFFICULTIES[4],
+          isChecked: false,
+          isRecommended: true,
+        },
+      ]);
+    });
+  });
+
+  describe('updateAIBehaviorStatus', () => {
+    it('ai behavior 상태를 업데이트한다', async () => {
+      aiBehaviorRepository.update.mockResolvedValue({ affected: 1 });
+
+      const result = await service.updateAIBehaviorStatus('ai-1', 'completed' as AIBehaviorStatus);
+
+      expect(aiBehaviorRepository.update).toHaveBeenCalledWith(
+        { id: 'ai-1' },
+        { status: 'completed' },
+      );
+      expect(result).toEqual({ id: 'ai-1', status: 'completed' });
     });
 
-    expect(result).toEqual([
-      {
-        id: 'b1',
-        goalId: 'g1',
-        title: 'b1',
-        difficulty: 'easy',
-      },
-    ]);
+    it('대상이 없으면 NotFoundException을 던진다', async () => {
+      aiBehaviorRepository.update.mockResolvedValue({ affected: 0 });
+
+      await expect(
+        service.updateAIBehaviorStatus('ai-404', 'completed' as AIBehaviorStatus),
+      ).rejects.toBeInstanceOf(NotFoundException);
+    });
   });
 });

--- a/apps/backend/src/features/behavior/behavior.service.spec.ts
+++ b/apps/backend/src/features/behavior/behavior.service.spec.ts
@@ -434,6 +434,7 @@ describe('BehaviorService', () => {
       const todayRepository = { find: jest.fn().mockResolvedValue(weekTodayBehaviors) };
       const goalRepository = { findOne: jest.fn().mockResolvedValue(bestGoal) };
       const aiBehaviorRepo = {
+        find: jest.fn().mockResolvedValue([]),
         create: jest.fn((value) => value),
         save: jest.fn().mockResolvedValue([
           { id: 'ai-1', title: 'AI 행동1', goal: bestGoal },

--- a/apps/backend/src/features/behavior/behavior.service.spec.ts
+++ b/apps/backend/src/features/behavior/behavior.service.spec.ts
@@ -6,6 +6,8 @@ import { TodayBehaviorStatus } from '@web24/shared';
 import { BehaviorService } from './behavior.service';
 import { Behavior } from './behavior.entity';
 import { TodayBehavior } from './today-behavior.entity';
+import { AIBehavior } from './ai-behavior.entity';
+import { AIService } from '../ai/ai.service';
 
 jest.mock('crypto', () => ({ randomInt: jest.fn() }));
 
@@ -16,6 +18,8 @@ describe('BehaviorService', () => {
     find: jest.Mock;
   };
   let todayBehaviorRepository: { update: jest.Mock };
+  let aiBehaviorRepository: { find: jest.Mock };
+  let aiService: { createAIBehaviors: jest.Mock };
   let dataSource: { transaction: jest.Mock };
   let queryBuilder: {
     leftJoinAndSelect: jest.Mock;
@@ -36,6 +40,8 @@ describe('BehaviorService', () => {
       find: jest.fn(),
     };
     todayBehaviorRepository = { update: jest.fn() };
+    aiBehaviorRepository = { find: jest.fn() };
+    aiService = { createAIBehaviors: jest.fn() };
     dataSource = { transaction: jest.fn() };
 
     const module: TestingModule = await Test.createTestingModule({
@@ -43,7 +49,9 @@ describe('BehaviorService', () => {
         BehaviorService,
         { provide: getRepositoryToken(Behavior), useValue: repository },
         { provide: getRepositoryToken(TodayBehavior), useValue: todayBehaviorRepository },
+        { provide: getRepositoryToken(AIBehavior), useValue: aiBehaviorRepository },
         { provide: getDataSourceToken(), useValue: dataSource },
+        { provide: AIService, useValue: aiService },
       ],
     }).compile();
 

--- a/apps/backend/src/features/behavior/behavior.service.spec.ts
+++ b/apps/backend/src/features/behavior/behavior.service.spec.ts
@@ -416,7 +416,7 @@ describe('BehaviorService', () => {
     });
   });
 
-  describe('createAIBhaviors', () => {
+  describe('createAIBehaviors', () => {
     it('AI 행동을 생성하고 매핑해서 반환한다', async () => {
       const user = { id: 'user-1', nickname: '테스트유저' };
       const bestGoal = {
@@ -455,7 +455,7 @@ describe('BehaviorService', () => {
       );
       aiService.getAIBehaviorTitles.mockResolvedValue(['AI 행동1', 'AI 행동2']);
 
-      const result = await service.createAIBhaviors();
+      const result = await service.createAIBehaviors();
 
       expect(userRepository.findOne).toHaveBeenCalledWith({ where: { nickname: '테스트유저' } });
       expect(todayRepository.find).toHaveBeenCalledWith({

--- a/apps/backend/src/features/behavior/behavior.service.ts
+++ b/apps/backend/src/features/behavior/behavior.service.ts
@@ -186,7 +186,7 @@ export class BehaviorService {
     });
   }
 
-  async createAIBhaviors() {
+  async createAIBehaviors() {
     const now = new Date();
     const weekBefore = new Date(now);
     weekBefore.setDate(now.getDate() - 7);
@@ -221,7 +221,7 @@ export class BehaviorService {
           id,
           completed,
           total,
-          rate: completed / total,
+          rate: total > 0 ? completed / total : 0,
         }))
         .sort((a, b) => {
           // 1순위: 완료율 내림차순
@@ -232,11 +232,22 @@ export class BehaviorService {
           return b.total - a.total;
         });
 
-      const bestGoal = await manager.getRepository(Goal).findOne({
-        where: { id: sortedGoals[0].id }, // 가장 첫 번째 요소가 최고점
-        relations: { behaviors: true },
-      });
-      if (!bestGoal) throw new NotFoundException('Goal');
+      let bestGoal: Goal | null = null;
+
+      if (sortedGoals.length > 0) {
+        bestGoal = await manager.getRepository(Goal).findOne({
+          where: { id: sortedGoals[0].id },
+          relations: { behaviors: true },
+        });
+      } else {
+        bestGoal = await manager.getRepository(Goal).findOne({
+          where: { user: { id: user.id } },
+          order: { createdAt: 'DESC' },
+          relations: { behaviors: true },
+        });
+      }
+
+      if (!bestGoal) return [];
 
       const aiBehaviorTitles = await this.aiService.getAIBehaviorTitles(bestGoal);
 

--- a/apps/backend/src/features/behavior/behavior.service.ts
+++ b/apps/backend/src/features/behavior/behavior.service.ts
@@ -1,11 +1,12 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { DataSource, In, Not, Repository } from 'typeorm';
 import { InjectDataSource, InjectRepository } from '@nestjs/typeorm';
-import { TodayBehaviorStatus } from '@web24/shared';
+import { BEHAVIOR_DIFFICULTIES, TodayBehaviorStatus } from '@web24/shared';
 import { getKstDayKey } from '../../common/utils/time.utils';
 import { Behavior } from './behavior.entity';
 import { TodayBehavior } from './today-behavior.entity';
 import { User } from '../user/user.entity';
+import { AIBehavior } from './ai-behavior.entity';
 
 @Injectable()
 export class BehaviorService {
@@ -152,5 +153,31 @@ export class BehaviorService {
       title: b.title,
       difficulty: b.difficulty,
     }));
+  }
+
+  async getAIBehaviors() {
+    return this.dataSource.transaction(async (manager) => {
+      const todayDate = getKstDayKey();
+
+      const user = await manager.getRepository(User).findOne({ where: { nickname: '테스트유저' } });
+      if (!user) {
+        throw new NotFoundException('User not found');
+      }
+
+      const aiBehaviors = await manager.getRepository(AIBehavior).find({
+        where: { date: todayDate, user: { id: user.id } },
+        relations: { goal: true },
+      });
+
+      return aiBehaviors.map((b) => ({
+        id: b.id,
+        title: b.title,
+        goalTitle: b.goal.title,
+        goalColor: b.goal.color,
+        difficulty: BEHAVIOR_DIFFICULTIES[4],
+        isChecked: b.status === 'completed',
+        isRecommended: true,
+      }));
+    });
   }
 }

--- a/apps/backend/src/features/behavior/behavior.service.ts
+++ b/apps/backend/src/features/behavior/behavior.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { Between, DataSource, In, Not, Repository } from 'typeorm';
 import { InjectDataSource, InjectRepository } from '@nestjs/typeorm';
-import { BEHAVIOR_DIFFICULTIES, TodayBehaviorStatus } from '@web24/shared';
+import { AIBehaviorStatus, BEHAVIOR_DIFFICULTIES, TodayBehaviorStatus } from '@web24/shared';
 import { getKstDayKey } from '../../common/utils/time.utils';
 import { Behavior } from './behavior.entity';
 import { TodayBehavior } from './today-behavior.entity';
@@ -17,6 +17,8 @@ export class BehaviorService {
     private readonly behaviorRepository: Repository<Behavior>,
     @InjectRepository(TodayBehavior)
     private readonly todayBehaviorRepository: Repository<TodayBehavior>,
+    @InjectRepository(AIBehavior)
+    private readonly aiBehaviorRepository: Repository<AIBehavior>,
     @InjectDataSource()
     private readonly dataSource: DataSource,
     private readonly aiService: AIService,
@@ -259,5 +261,13 @@ export class BehaviorService {
         isRecommended: true,
       }));
     });
+  }
+
+  async updateAIBehaviorStatus(id: string, status: AIBehaviorStatus) {
+    const result = await this.aiBehaviorRepository.update({ id }, { status });
+    if (result.affected === 0) {
+      throw new NotFoundException('AIBehavior not found');
+    }
+    return { id, status };
   }
 }

--- a/apps/backend/src/features/behavior/behavior.service.ts
+++ b/apps/backend/src/features/behavior/behavior.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
-import { DataSource, In, Not, Repository } from 'typeorm';
+import { Between, DataSource, In, Not, Repository } from 'typeorm';
 import { InjectDataSource, InjectRepository } from '@nestjs/typeorm';
 import { BEHAVIOR_DIFFICULTIES, TodayBehaviorStatus } from '@web24/shared';
 import { getKstDayKey } from '../../common/utils/time.utils';
@@ -7,6 +7,8 @@ import { Behavior } from './behavior.entity';
 import { TodayBehavior } from './today-behavior.entity';
 import { User } from '../user/user.entity';
 import { AIBehavior } from './ai-behavior.entity';
+import { Goal } from '../goal/goal.entity';
+import { AIService } from '../ai/ai.service';
 
 @Injectable()
 export class BehaviorService {
@@ -17,6 +19,7 @@ export class BehaviorService {
     private readonly todayBehaviorRepository: Repository<TodayBehavior>,
     @InjectDataSource()
     private readonly dataSource: DataSource,
+    private readonly aiService: AIService,
   ) {}
 
   async getTodayBehaviors() {
@@ -176,6 +179,83 @@ export class BehaviorService {
         goalColor: b.goal.color,
         difficulty: BEHAVIOR_DIFFICULTIES[4],
         isChecked: b.status === 'completed',
+        isRecommended: true,
+      }));
+    });
+  }
+
+  async createAIBhaviors() {
+    const now = new Date();
+    const weekBefore = new Date(now);
+    weekBefore.setDate(now.getDate() - 7);
+
+    const nowDate = getKstDayKey(now);
+    const weekBeforeDate = getKstDayKey(weekBefore);
+
+    return this.dataSource.transaction(async (manager) => {
+      const user = await manager.getRepository(User).findOne({ where: { nickname: '테스트유저' } });
+      if (!user) {
+        throw new NotFoundException('User not found');
+      }
+
+      const weekTodayBehaviors = await manager.getRepository(TodayBehavior).find({
+        where: { date: Between(weekBeforeDate, nowDate), user: { id: user.id } },
+        relations: { behavior: { goal: true } },
+      });
+
+      // key: goalId, value: [goal 별 completed, goal 별 전체 갯수]
+      const goalCompletionCountMap = weekTodayBehaviors.reduce((acc, tb) => {
+        const goalId = tb.behavior.goal.id;
+
+        const [completed, total] = acc.get(goalId) ?? [0, 0];
+        const completedDelta = tb.status === 'completed' ? 1 : 0;
+
+        acc.set(goalId, [completed + completedDelta, total + 1]);
+        return acc;
+      }, new Map<string, [number, number]>());
+
+      const sortedGoals = Array.from(goalCompletionCountMap.entries())
+        .map(([id, [completed, total]]) => ({
+          id,
+          completed,
+          total,
+          rate: completed / total,
+        }))
+        .sort((a, b) => {
+          // 1순위: 완료율 내림차순
+          if (b.rate !== a.rate) {
+            return b.rate - a.rate;
+          }
+          // 2순위: 완료율이 같으면 전체 횟수(total) 내림차순
+          return b.total - a.total;
+        });
+
+      const bestGoal = await manager.getRepository(Goal).findOne({
+        where: { id: sortedGoals[0].id }, // 가장 첫 번째 요소가 최고점
+        relations: { behaviors: true },
+      });
+      if (!bestGoal) throw new NotFoundException('Goal');
+
+      const aiBehaviorTitles = await this.aiService.getAIBehaviorTitles(bestGoal);
+
+      const toSave = aiBehaviorTitles.map((title) =>
+        manager.getRepository(AIBehavior).create({
+          goal: bestGoal,
+          title,
+          user,
+          date: nowDate,
+          status: 'pending',
+        }),
+      );
+
+      const aiBehaviors = await manager.getRepository(AIBehavior).save(toSave);
+      return aiBehaviors.map((b) => ({
+        id: b.id,
+        title: b.title,
+        goalTitle: b.goal.title,
+        goalColor: b.goal.color,
+        difficulty: BEHAVIOR_DIFFICULTIES[4],
+        isChecked: false,
         isRecommended: true,
       }));
     });

--- a/apps/backend/src/features/behavior/behavior.service.ts
+++ b/apps/backend/src/features/behavior/behavior.service.ts
@@ -200,6 +200,23 @@ export class BehaviorService {
         throw new NotFoundException('User not found');
       }
 
+      const existingAIBehaviors = await manager.getRepository(AIBehavior).find({
+        where: { date: nowDate, user: { id: user.id } },
+        relations: { goal: true },
+      });
+
+      if (existingAIBehaviors.length > 0) {
+        return existingAIBehaviors.map((b) => ({
+          id: b.id,
+          title: b.title,
+          goalTitle: b.goal.title,
+          goalColor: b.goal.color,
+          difficulty: BEHAVIOR_DIFFICULTIES[4],
+          isChecked: b.status === 'completed',
+          isRecommended: true,
+        }));
+      }
+
       const weekTodayBehaviors = await manager.getRepository(TodayBehavior).find({
         where: { date: Between(weekBeforeDate, nowDate), user: { id: user.id } },
         relations: { behavior: { goal: true } },

--- a/apps/backend/src/features/behavior/today-behavior.controller.spec.ts
+++ b/apps/backend/src/features/behavior/today-behavior.controller.spec.ts
@@ -4,10 +4,22 @@ import { BehaviorService } from './behavior.service';
 
 describe('TodayBehaviorController', () => {
   let controller: TodayBehaviorController;
-  let service: { updateTodayBehaviorStatus: jest.Mock; getTodayBehaviors: jest.Mock };
+  let service: {
+    updateTodayBehaviorStatus: jest.Mock;
+    getTodayBehaviors: jest.Mock;
+    getAIBehaviors: jest.Mock;
+    createAIBhaviors: jest.Mock;
+    updateAIBehaviorStatus: jest.Mock;
+  };
 
   beforeEach(async () => {
-    service = { updateTodayBehaviorStatus: jest.fn(), getTodayBehaviors: jest.fn() };
+    service = {
+      updateTodayBehaviorStatus: jest.fn(),
+      getTodayBehaviors: jest.fn(),
+      getAIBehaviors: jest.fn(),
+      createAIBhaviors: jest.fn(),
+      updateAIBehaviorStatus: jest.fn(),
+    };
 
     const module: TestingModule = await Test.createTestingModule({
       controllers: [TodayBehaviorController],
@@ -17,29 +29,73 @@ describe('TodayBehaviorController', () => {
     controller = module.get<TodayBehaviorController>(TodayBehaviorController);
   });
 
-  it('should be defined', () => {
-    expect(controller).toBeDefined();
+  describe('init', () => {
+    it('should be defined', () => {
+      expect(controller).toBeDefined();
+    });
   });
 
-  it('getTodayBehaviors가 서비스 결과를 반환한다', async () => {
-    const mock = [{ id: '1' }];
-    service.getTodayBehaviors.mockResolvedValue(mock);
+  describe('getTodayBehaviors', () => {
+    it('서비스 결과를 반환한다', async () => {
+      const mock = [{ id: '1' }];
+      service.getTodayBehaviors.mockResolvedValue(mock);
 
-    const result = await controller.getTodayBehaviors();
+      const result = await controller.getTodayBehaviors();
 
-    expect(service.getTodayBehaviors).toHaveBeenCalledTimes(1);
-    expect(result).toBe(mock);
+      expect(service.getTodayBehaviors).toHaveBeenCalledTimes(1);
+      expect(result).toBe(mock);
+    });
   });
 
-  it('updateTodayBehaviorStatus가 서비스 결과를 반환한다', async () => {
-    const id = '01890fba-7e6a-7b6b-9e5d-0f3c9b8b4c6d';
-    const body = { status: 'completed' as const };
-    const mock = { id, status: body.status };
-    service.updateTodayBehaviorStatus.mockResolvedValue(mock);
+  describe('updateTodayBehaviorStatus', () => {
+    it('서비스 결과를 반환한다', async () => {
+      const id = '01890fba-7e6a-7b6b-9e5d-0f3c9b8b4c6d';
+      const body = { status: 'completed' as const };
+      const mock = { id, status: body.status };
+      service.updateTodayBehaviorStatus.mockResolvedValue(mock);
 
-    const result = await controller.updateTodayBehaviorStatus(id, body);
+      const result = await controller.updateTodayBehaviorStatus(id, body);
 
-    expect(service.updateTodayBehaviorStatus).toHaveBeenCalledWith(id, body.status);
-    expect(result).toBe(mock);
+      expect(service.updateTodayBehaviorStatus).toHaveBeenCalledWith(id, body.status);
+      expect(result).toBe(mock);
+    });
+  });
+
+  describe('getTodayAIBehaviors', () => {
+    it('서비스 결과를 반환한다', async () => {
+      const mock = [{ id: 'ai-1' }];
+      service.getAIBehaviors.mockResolvedValue(mock);
+
+      const result = await controller.getTodayAIBehaviors();
+
+      expect(service.getAIBehaviors).toHaveBeenCalledTimes(1);
+      expect(result).toBe(mock);
+    });
+  });
+
+  describe('createAIBehaviors', () => {
+    it('서비스 결과를 반환한다', async () => {
+      const mock = [{ id: 'ai-1' }];
+      service.createAIBhaviors.mockResolvedValue(mock);
+
+      const result = await controller.createAIBehaviors();
+
+      expect(service.createAIBhaviors).toHaveBeenCalledTimes(1);
+      expect(result).toBe(mock);
+    });
+  });
+
+  describe('updateAIBehaviorStatus', () => {
+    it('서비스 결과를 반환한다', async () => {
+      const id = '01890fba-7e6a-7b6b-9e5d-0f3c9b8b4c6d';
+      const body = { status: 'completed' as const };
+      const mock = { id, status: body.status };
+      service.updateAIBehaviorStatus.mockResolvedValue(mock);
+
+      const result = await controller.updateAIBehaviorStatus(id, body);
+
+      expect(service.updateAIBehaviorStatus).toHaveBeenCalledWith(id, body.status);
+      expect(result).toBe(mock);
+    });
   });
 });

--- a/apps/backend/src/features/behavior/today-behavior.controller.spec.ts
+++ b/apps/backend/src/features/behavior/today-behavior.controller.spec.ts
@@ -8,7 +8,7 @@ describe('TodayBehaviorController', () => {
     updateTodayBehaviorStatus: jest.Mock;
     getTodayBehaviors: jest.Mock;
     getAIBehaviors: jest.Mock;
-    createAIBhaviors: jest.Mock;
+    createAIBehaviors: jest.Mock;
     updateAIBehaviorStatus: jest.Mock;
   };
 
@@ -17,7 +17,7 @@ describe('TodayBehaviorController', () => {
       updateTodayBehaviorStatus: jest.fn(),
       getTodayBehaviors: jest.fn(),
       getAIBehaviors: jest.fn(),
-      createAIBhaviors: jest.fn(),
+      createAIBehaviors: jest.fn(),
       updateAIBehaviorStatus: jest.fn(),
     };
 
@@ -76,11 +76,11 @@ describe('TodayBehaviorController', () => {
   describe('createAIBehaviors', () => {
     it('서비스 결과를 반환한다', async () => {
       const mock = [{ id: 'ai-1' }];
-      service.createAIBhaviors.mockResolvedValue(mock);
+      service.createAIBehaviors.mockResolvedValue(mock);
 
       const result = await controller.createAIBehaviors();
 
-      expect(service.createAIBhaviors).toHaveBeenCalledTimes(1);
+      expect(service.createAIBehaviors).toHaveBeenCalledTimes(1);
       expect(result).toBe(mock);
     });
   });

--- a/apps/backend/src/features/behavior/today-behavior.controller.ts
+++ b/apps/backend/src/features/behavior/today-behavior.controller.ts
@@ -28,7 +28,7 @@ export class TodayBehaviorController {
 
   @Post('/ai')
   async createAIBehaviors(): Promise<PostAIBehaviorResponse> {
-    return this.behaviorService.createAIBhaviors();
+    return this.behaviorService.createAIBehaviors();
   }
 
   @Patch('/ai/:id/status')

--- a/apps/backend/src/features/behavior/today-behavior.controller.ts
+++ b/apps/backend/src/features/behavior/today-behavior.controller.ts
@@ -1,9 +1,10 @@
-import { Get, Body, Controller, Param, ParseUUIDPipe, Patch } from '@nestjs/common';
+import { Get, Body, Controller, Param, ParseUUIDPipe, Patch, Post } from '@nestjs/common';
 import {
   type GetAIBehaviorResponse,
   type PatchTodayBehaviorStatusRequest,
   PatchTodayBehaviorStatusRequestSchema,
   PatchTodayBehaviorStatusResponse,
+  type PostAIBehaviorResponse,
 } from '@web24/shared';
 import { ZodValidationPipe } from '../../common/pipes/zod-validation.pipe';
 import { BehaviorService } from './behavior.service';
@@ -20,6 +21,11 @@ export class TodayBehaviorController {
   @Get('/ai')
   async getTodayAIBehaviors(): Promise<GetAIBehaviorResponse> {
     return this.behaviorService.getAIBehaviors();
+  }
+
+  @Post('/ai')
+  async createAIBehaviors(): Promise<PostAIBehaviorResponse> {
+    return this.behaviorService.createAIBhaviors();
   }
 
   @Patch(':id/status')

--- a/apps/backend/src/features/behavior/today-behavior.controller.ts
+++ b/apps/backend/src/features/behavior/today-behavior.controller.ts
@@ -1,6 +1,9 @@
 import { Get, Body, Controller, Param, ParseUUIDPipe, Patch, Post } from '@nestjs/common';
 import {
   type GetAIBehaviorResponse,
+  type PatchAIBehaviorStatusRequest,
+  PatchAIBehaviorStatusRequestSchema,
+  PatchAIBehaviorStatusResponse,
   type PatchTodayBehaviorStatusRequest,
   PatchTodayBehaviorStatusRequestSchema,
   PatchTodayBehaviorStatusResponse,
@@ -26,6 +29,15 @@ export class TodayBehaviorController {
   @Post('/ai')
   async createAIBehaviors(): Promise<PostAIBehaviorResponse> {
     return this.behaviorService.createAIBhaviors();
+  }
+
+  @Patch('/ai/:id/status')
+  async updateAIBehaviorStatus(
+    @Param('id', new ParseUUIDPipe()) id: string,
+    @Body(new ZodValidationPipe(PatchAIBehaviorStatusRequestSchema))
+    body: PatchAIBehaviorStatusRequest,
+  ): Promise<PatchAIBehaviorStatusResponse> {
+    return this.behaviorService.updateAIBehaviorStatus(id, body.status);
   }
 
   @Patch(':id/status')

--- a/apps/backend/src/features/behavior/today-behavior.controller.ts
+++ b/apps/backend/src/features/behavior/today-behavior.controller.ts
@@ -1,5 +1,6 @@
 import { Get, Body, Controller, Param, ParseUUIDPipe, Patch } from '@nestjs/common';
 import {
+  type GetAIBehaviorResponse,
   type PatchTodayBehaviorStatusRequest,
   PatchTodayBehaviorStatusRequestSchema,
   PatchTodayBehaviorStatusResponse,
@@ -14,6 +15,11 @@ export class TodayBehaviorController {
   @Get()
   async getTodayBehaviors() {
     return this.behaviorService.getTodayBehaviors();
+  }
+
+  @Get('/ai')
+  async getTodayAIBehaviors(): Promise<GetAIBehaviorResponse> {
+    return this.behaviorService.getAIBehaviors();
   }
 
   @Patch(':id/status')

--- a/apps/backend/src/features/goal/goal.controller.spec.ts
+++ b/apps/backend/src/features/goal/goal.controller.spec.ts
@@ -65,16 +65,13 @@ describe('GoalController', () => {
 
   it('id로 목표 스탬프 목록을 반환한다', async () => {
     const mockStamps = [
-      { id: 's1', behavior: { difficulty: '몰입하기' } },
-      { id: 's2', behavior: { difficulty: '시작하기' } },
+      { id: 's1', title: '행동 1', difficulty: '몰입하기', source: 'today' },
+      { id: 's2', title: 'AI 행동', difficulty: 'AI', source: 'ai' },
     ];
 
     goalService.getGoalStamps.mockResolvedValue(mockStamps);
 
-    await expect(controller.getGoalStamps('goal-abc')).resolves.toEqual([
-      { id: 's1', difficulty: '몰입하기' },
-      { id: 's2', difficulty: '시작하기' },
-    ]);
+    await expect(controller.getGoalStamps('goal-abc')).resolves.toEqual(mockStamps);
 
     expect(goalService.getGoalStamps).toHaveBeenCalledWith('goal-abc');
     expect(goalService.getGoalStamps).toHaveBeenCalledTimes(1);

--- a/apps/backend/src/features/goal/goal.controller.spec.ts
+++ b/apps/backend/src/features/goal/goal.controller.spec.ts
@@ -142,11 +142,15 @@ describe('GoalController', () => {
   it('목표의 행동 목록을 반환한다', async () => {
     const goalId = '01890fba-7e6a-7b6b-9e5d-0f3c9b8b4c6d';
     const behaviorId = '01890fba-7e6a-7b6c-9e5d-0f3c9b8b4c6e';
-    const behaviors = [{ id: behaviorId, title: 'b1', difficulty: 'easy', extra: 'ignored' }];
+    const behaviors = [
+      { id: behaviorId, title: 'b1', difficulty: '몰입하기', extra: 'ignored' },
+      { id: 'ai-1', title: 'ai 1', difficulty: 'AI' },
+    ];
     goalService.getGoalBehaviors.mockResolvedValue(behaviors);
 
     await expect(controller.getGoalBehaviors(goalId)).resolves.toEqual([
-      { id: behaviorId, title: 'b1', difficulty: 'easy' },
+      { id: behaviorId, title: 'b1', difficulty: '몰입하기' },
+      { id: 'ai-1', title: 'ai 1', difficulty: 'AI' },
     ]);
     expect(goalService.getGoalBehaviors).toHaveBeenCalledWith(goalId);
   });

--- a/apps/backend/src/features/goal/goal.controller.spec.ts
+++ b/apps/backend/src/features/goal/goal.controller.spec.ts
@@ -65,8 +65,18 @@ describe('GoalController', () => {
 
   it('id로 목표 스탬프 목록을 반환한다', async () => {
     const mockStamps = [
-      { id: 's1', title: '행동 1', difficulty: '몰입하기', source: 'today' },
-      { id: 's2', title: 'AI 행동', difficulty: 'AI', source: 'ai' },
+      {
+        id: 's1',
+        title: '행동 1',
+        difficulty: '몰입하기',
+        updatedAt: '2024-01-01T00:00:00.000Z',
+      },
+      {
+        id: 's2',
+        title: 'AI 행동',
+        difficulty: 'AI',
+        updatedAt: '2024-01-02T00:00:00.000Z',
+      },
     ];
 
     goalService.getGoalStamps.mockResolvedValue(mockStamps);

--- a/apps/backend/src/features/goal/goal.controller.ts
+++ b/apps/backend/src/features/goal/goal.controller.ts
@@ -5,6 +5,7 @@ import { join } from 'node:path';
 import {
   CreateGoalRequestSchema,
   GetGoalsResponse,
+  type GetGoalStampsResponse,
   type GetGoalResponse,
   GoalTemplateListResponseSchema,
   type CreateGoalRequest,
@@ -52,12 +53,8 @@ export class GoalController {
   }
 
   @Get(':id/stamps')
-  async getGoalStamps(@Param('id', ParseUUIDPipe) id: string) {
-    const goalStamps = await this.goalService.getGoalStamps(id);
-    return goalStamps.map((gs) => ({
-      id: gs.id,
-      difficulty: gs.behavior.difficulty,
-    }));
+  async getGoalStamps(@Param('id', ParseUUIDPipe) id: string): Promise<GetGoalStampsResponse> {
+    return this.goalService.getGoalStamps(id);
   }
 
   @Get('templates')

--- a/apps/backend/src/features/goal/goal.module.ts
+++ b/apps/backend/src/features/goal/goal.module.ts
@@ -6,9 +6,10 @@ import { GoalController } from './goal.controller';
 import { Goal } from './goal.entity';
 import { GoalService } from './goal.service';
 import { TodayBehavior } from '../behavior/today-behavior.entity';
+import { AIBehavior } from '../behavior/ai-behavior.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Goal, Behavior, TodayBehavior, User])],
+  imports: [TypeOrmModule.forFeature([Goal, Behavior, TodayBehavior, AIBehavior, User])],
   controllers: [GoalController],
   providers: [GoalService],
 })

--- a/apps/backend/src/features/goal/goal.service.spec.ts
+++ b/apps/backend/src/features/goal/goal.service.spec.ts
@@ -7,6 +7,7 @@ import { TodayBehavior } from '../behavior/today-behavior.entity';
 import { Behavior } from '../behavior/behavior.entity';
 import { Goal } from './goal.entity';
 import { User } from '../user/user.entity';
+import { AIBehavior } from '../behavior/ai-behavior.entity';
 
 describe('GoalService', () => {
   type TransactionManager = {
@@ -17,11 +18,13 @@ describe('GoalService', () => {
     goalRepository: goalRepositoryOverride,
     behaviorRepository: behaviorRepositoryOverride,
     todayBehaviorRepository: todayBehaviorRepositoryOverride,
+    aiBehaviorRepository: aiBehaviorRepositoryOverride,
     userRepository: userRepositoryOverride,
   }: {
     goalRepository?: Record<string, unknown>;
     behaviorRepository?: Record<string, unknown>;
     todayBehaviorRepository?: Record<string, unknown>;
+    aiBehaviorRepository?: Record<string, unknown>;
     userRepository?: Record<string, unknown>;
   } = {}) => {
     const goalRepository = {
@@ -42,6 +45,10 @@ describe('GoalService', () => {
       find: jest.fn(),
       ...todayBehaviorRepositoryOverride,
     };
+    const aiBehaviorRepository = {
+      find: jest.fn(),
+      ...aiBehaviorRepositoryOverride,
+    };
     const userRepository = {
       findOne: jest.fn(),
       ...userRepositoryOverride,
@@ -53,6 +60,7 @@ describe('GoalService', () => {
         { provide: getRepositoryToken(Goal), useValue: goalRepository },
         { provide: getRepositoryToken(Behavior), useValue: behaviorRepository },
         { provide: getRepositoryToken(TodayBehavior), useValue: todayBehaviorRepository },
+        { provide: getRepositoryToken(AIBehavior), useValue: aiBehaviorRepository },
         { provide: getRepositoryToken(User), useValue: userRepository },
       ],
     }).compile();
@@ -62,6 +70,7 @@ describe('GoalService', () => {
       goalRepository,
       behaviorRepository,
       todayBehaviorRepository,
+      aiBehaviorRepository,
       userRepository,
     };
   };
@@ -106,19 +115,39 @@ describe('GoalService', () => {
   });
 
   describe('getGoalStamps', () => {
-    it('goalId로 완료된 TodayBehavior 목록만 반환한다', async () => {
+    it('goalId로 완료된 TodayBehavior와 AIBehavior 목록을 반환한다', async () => {
       const todayBehaviors = [
-        { id: 'tb1', status: 'completed', behavior: { id: 'b1' } },
-        { id: 'tb3', status: 'completed', behavior: { id: 'b2' } },
+        {
+          id: 'tb1',
+          status: 'completed',
+          behavior: { id: 'b1', title: '행동 1', difficulty: '몰입하기' },
+        },
+        {
+          id: 'tb3',
+          status: 'completed',
+          behavior: { id: 'b2', title: '행동 2', difficulty: '시작하기' },
+        },
+      ];
+      const aiBehaviors = [
+        { id: 'ai1', status: 'completed', title: 'AI 행동 1' },
+        { id: 'ai2', status: 'completed', title: 'AI 행동 2' },
       ];
 
       const todayBehaviorRepository = {
         find: jest.fn().mockResolvedValue(todayBehaviors),
       };
+      const aiBehaviorRepository = {
+        find: jest.fn().mockResolvedValue(aiBehaviors),
+      };
 
-      const { service } = await createService({ todayBehaviorRepository });
+      const { service } = await createService({ todayBehaviorRepository, aiBehaviorRepository });
 
-      await expect(service.getGoalStamps('goal-abc')).resolves.toEqual(todayBehaviors);
+      await expect(service.getGoalStamps('goal-abc')).resolves.toEqual([
+        { id: 'tb1', title: '행동 1', difficulty: '몰입하기', source: 'today' },
+        { id: 'tb3', title: '행동 2', difficulty: '시작하기', source: 'today' },
+        { id: 'ai1', title: 'AI 행동 1', difficulty: 'AI', source: 'ai' },
+        { id: 'ai2', title: 'AI 행동 2', difficulty: 'AI', source: 'ai' },
+      ]);
 
       expect(todayBehaviorRepository.find).toHaveBeenCalledWith({
         where: {
@@ -128,6 +157,12 @@ describe('GoalService', () => {
           status: 'completed',
         },
         relations: ['behavior'],
+      });
+      expect(aiBehaviorRepository.find).toHaveBeenCalledWith({
+        where: {
+          goal: { id: 'goal-abc' },
+          status: 'completed',
+        },
       });
     });
   });

--- a/apps/backend/src/features/goal/goal.service.spec.ts
+++ b/apps/backend/src/features/goal/goal.service.spec.ts
@@ -121,16 +121,28 @@ describe('GoalService', () => {
           id: 'tb1',
           status: 'completed',
           behavior: { id: 'b1', title: '행동 1', difficulty: '몰입하기' },
+          updatedAt: new Date('2024-01-01T00:00:00.000Z'),
         },
         {
           id: 'tb3',
           status: 'completed',
           behavior: { id: 'b2', title: '행동 2', difficulty: '시작하기' },
+          updatedAt: new Date('2024-01-02T00:00:00.000Z'),
         },
       ];
       const aiBehaviors = [
-        { id: 'ai1', status: 'completed', title: 'AI 행동 1' },
-        { id: 'ai2', status: 'completed', title: 'AI 행동 2' },
+        {
+          id: 'ai1',
+          status: 'completed',
+          title: 'AI 행동 1',
+          updatedAt: new Date('2024-01-03T00:00:00.000Z'),
+        },
+        {
+          id: 'ai2',
+          status: 'completed',
+          title: 'AI 행동 2',
+          updatedAt: new Date('2024-01-04T00:00:00.000Z'),
+        },
       ];
 
       const todayBehaviorRepository = {
@@ -143,10 +155,30 @@ describe('GoalService', () => {
       const { service } = await createService({ todayBehaviorRepository, aiBehaviorRepository });
 
       await expect(service.getGoalStamps('goal-abc')).resolves.toEqual([
-        { id: 'tb1', title: '행동 1', difficulty: '몰입하기', source: 'today' },
-        { id: 'tb3', title: '행동 2', difficulty: '시작하기', source: 'today' },
-        { id: 'ai1', title: 'AI 행동 1', difficulty: 'AI', source: 'ai' },
-        { id: 'ai2', title: 'AI 행동 2', difficulty: 'AI', source: 'ai' },
+        {
+          id: 'tb1',
+          title: '행동 1',
+          difficulty: '몰입하기',
+          updatedAt: '2024-01-01T00:00:00.000Z',
+        },
+        {
+          id: 'tb3',
+          title: '행동 2',
+          difficulty: '시작하기',
+          updatedAt: '2024-01-02T00:00:00.000Z',
+        },
+        {
+          id: 'ai1',
+          title: 'AI 행동 1',
+          difficulty: 'AI',
+          updatedAt: '2024-01-03T00:00:00.000Z',
+        },
+        {
+          id: 'ai2',
+          title: 'AI 행동 2',
+          difficulty: 'AI',
+          updatedAt: '2024-01-04T00:00:00.000Z',
+        },
       ]);
 
       expect(todayBehaviorRepository.find).toHaveBeenCalledWith({

--- a/apps/backend/src/features/goal/goal.service.spec.ts
+++ b/apps/backend/src/features/goal/goal.service.spec.ts
@@ -274,24 +274,39 @@ describe('GoalService', () => {
   });
 
   describe('getGoalBehaviors', () => {
-    it('목표의 행동 목록을 반환한다', async () => {
+    it('목표의 행동과 AI 행동 목록을 반환한다', async () => {
       const goalId = 'goal-1';
       const behaviors = [
-        { id: 'b1', title: 'b1', difficulty: 'easy' },
-        { id: 'b2', title: 'b2', difficulty: 'hard' },
+        { id: 'b1', title: 'b1', difficulty: '몰입하기' },
+        { id: 'b2', title: 'b2', difficulty: '시작하기' },
       ];
       const goal = { id: goalId, behaviors };
+      const aiBehaviors = [
+        { id: 'ai-1', title: 'ai 1' },
+        { id: 'ai-2', title: 'ai 2' },
+      ];
 
       const goalRepository = {
         findOne: jest.fn().mockResolvedValue(goal),
       };
+      const aiBehaviorRepository = {
+        find: jest.fn().mockResolvedValue(aiBehaviors),
+      };
 
-      const { service } = await createService({ goalRepository });
+      const { service } = await createService({ goalRepository, aiBehaviorRepository });
 
-      await expect(service.getGoalBehaviors(goalId)).resolves.toEqual(behaviors);
+      await expect(service.getGoalBehaviors(goalId)).resolves.toEqual([
+        { id: 'b1', goalId, title: 'b1', difficulty: '몰입하기' },
+        { id: 'b2', goalId, title: 'b2', difficulty: '시작하기' },
+        { id: 'ai-1', goalId, title: 'ai 1', difficulty: 'AI' },
+        { id: 'ai-2', goalId, title: 'ai 2', difficulty: 'AI' },
+      ]);
       expect(goalRepository.findOne).toHaveBeenCalledWith({
         where: { id: goalId },
         relations: ['behaviors'],
+      });
+      expect(aiBehaviorRepository.find).toHaveBeenCalledWith({
+        where: { goal: { id: goalId } },
       });
     });
 

--- a/apps/backend/src/features/goal/goal.service.ts
+++ b/apps/backend/src/features/goal/goal.service.ts
@@ -112,14 +112,14 @@ export class GoalService {
       id: todayBehavior.id,
       title: todayBehavior.behavior.title,
       difficulty: todayBehavior.behavior.difficulty,
-      source: 'today',
+      updatedAt: todayBehavior.updatedAt.toISOString(),
     }));
 
     const aiStamps: GoalStamp[] = aiBehaviors.map((aiBehavior) => ({
       id: aiBehavior.id,
       title: aiBehavior.title,
       difficulty: 'AI',
-      source: 'ai',
+      updatedAt: aiBehavior.updatedAt.toISOString(),
     }));
 
     return [...todayStamps, ...aiStamps];

--- a/apps/backend/src/features/goal/goal.service.ts
+++ b/apps/backend/src/features/goal/goal.service.ts
@@ -4,12 +4,14 @@ import {
   CreateGoalResponseSchema,
   type CreateGoalRequest,
   type CreateGoalResponse,
+  type GoalStamp,
 } from '@web24/shared';
 import { Repository } from 'typeorm';
 import { Behavior } from '../behavior/behavior.entity';
 import { User } from '../user/user.entity';
 import { Goal } from './goal.entity';
 import { TodayBehavior } from '../behavior/today-behavior.entity';
+import { AIBehavior } from '../behavior/ai-behavior.entity';
 
 @Injectable()
 export class GoalService {
@@ -18,6 +20,8 @@ export class GoalService {
     private readonly goalRepository: Repository<Goal>,
     @InjectRepository(TodayBehavior)
     private readonly todayBehaviorRepository: Repository<TodayBehavior>,
+    @InjectRepository(AIBehavior)
+    private readonly aiBehaviorRepository: Repository<AIBehavior>,
     @InjectRepository(User)
     private readonly userRepository: Repository<User>,
   ) {}
@@ -66,16 +70,40 @@ export class GoalService {
     return goal.behaviors || [];
   }
 
-  async getGoalStamps(goalId: string): Promise<TodayBehavior[]> {
-    return this.todayBehaviorRepository.find({
-      where: {
-        behavior: {
-          goal: { id: goalId },
+  async getGoalStamps(goalId: string): Promise<GoalStamp[]> {
+    const [todayBehaviors, aiBehaviors] = await Promise.all([
+      this.todayBehaviorRepository.find({
+        where: {
+          behavior: {
+            goal: { id: goalId },
+          },
+          status: 'completed',
         },
-        status: 'completed',
-      },
-      relations: ['behavior'],
-    });
+        relations: ['behavior'],
+      }),
+      this.aiBehaviorRepository.find({
+        where: {
+          goal: { id: goalId },
+          status: 'completed',
+        },
+      }),
+    ]);
+
+    const todayStamps: GoalStamp[] = todayBehaviors.map((todayBehavior) => ({
+      id: todayBehavior.id,
+      title: todayBehavior.behavior.title,
+      difficulty: todayBehavior.behavior.difficulty,
+      source: 'today',
+    }));
+
+    const aiStamps: GoalStamp[] = aiBehaviors.map((aiBehavior) => ({
+      id: aiBehavior.id,
+      title: aiBehavior.title,
+      difficulty: 'AI',
+      source: 'ai',
+    }));
+
+    return [...todayStamps, ...aiStamps];
   }
 
   async createGoal(request: CreateGoalRequest): Promise<CreateGoalResponse> {

--- a/apps/backend/src/features/goal/goal.service.ts
+++ b/apps/backend/src/features/goal/goal.service.ts
@@ -4,10 +4,11 @@ import {
   CreateGoalResponseSchema,
   type CreateGoalRequest,
   type CreateGoalResponse,
+  type Behavior as BehaviorResponse,
   type GoalStamp,
 } from '@web24/shared';
 import { Repository } from 'typeorm';
-import { Behavior } from '../behavior/behavior.entity';
+import { Behavior as BehaviorEntity } from '../behavior/behavior.entity';
 import { User } from '../user/user.entity';
 import { Goal } from './goal.entity';
 import { TodayBehavior } from '../behavior/today-behavior.entity';
@@ -57,7 +58,7 @@ export class GoalService {
     return goal;
   }
 
-  async getGoalBehaviors(goalId: string): Promise<Behavior[]> {
+  async getGoalBehaviors(goalId: string): Promise<BehaviorResponse[]> {
     const goal = await this.goalRepository.findOne({
       where: { id: goalId },
       relations: ['behaviors'],
@@ -67,7 +68,25 @@ export class GoalService {
       throw new NotFoundException('Goal not found');
     }
 
-    return goal.behaviors || [];
+    const behaviors: BehaviorResponse[] = (goal.behaviors || []).map((behavior) => ({
+      id: behavior.id,
+      goalId,
+      title: behavior.title,
+      difficulty: behavior.difficulty,
+    }));
+
+    const aiBehaviors = await this.aiBehaviorRepository.find({
+      where: { goal: { id: goalId } },
+    });
+
+    const aiMapped: BehaviorResponse[] = aiBehaviors.map((behavior) => ({
+      id: behavior.id,
+      goalId,
+      title: behavior.title,
+      difficulty: 'AI',
+    }));
+
+    return [...behaviors, ...aiMapped];
   }
 
   async getGoalStamps(goalId: string): Promise<GoalStamp[]> {
@@ -123,13 +142,13 @@ export class GoalService {
       const savedGoal = await manager.getRepository(Goal).save(goal);
 
       const behaviors = request.behaviors.map((behavior) =>
-        manager.getRepository(Behavior).create({
+        manager.getRepository(BehaviorEntity).create({
           title: behavior.title,
           difficulty: behavior.difficulty,
           goal: savedGoal,
         }),
       );
-      const savedBehaviors = await manager.getRepository(Behavior).save(behaviors);
+      const savedBehaviors = await manager.getRepository(BehaviorEntity).save(behaviors);
 
       return CreateGoalResponseSchema.parse({
         id: savedGoal.id,

--- a/apps/frontend/src/features/behavior/apis/createAIBehaviors.api.spec.ts
+++ b/apps/frontend/src/features/behavior/apis/createAIBehaviors.api.spec.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { createAIBehaviors } from './createAIBehaviors.api';
+
+describe('createAIBehaviors', () => {
+  const mockBehaviors = [
+    {
+      id: '01946777-7000-7000-8000-000000000000',
+      title: '행동 1',
+      goalTitle: '목표 A',
+      goalColor: 'mint',
+      isChecked: false,
+      difficulty: '시작하기',
+      isRecommended: true,
+    },
+  ];
+
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('성공 시 생성된 행동 리스트를 반환한다', async () => {
+    (fetch as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockBehaviors,
+    });
+
+    const result = await createAIBehaviors();
+    expect(result).toEqual(mockBehaviors);
+    expect(fetch).toHaveBeenCalledWith(
+      '/api/today-behaviors/ai',
+      expect.objectContaining({
+        method: 'POST',
+      }),
+    );
+  });
+
+  it('응답이 ok가 아니면 에러를 던진다', async () => {
+    (fetch as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: false,
+    });
+
+    await expect(createAIBehaviors()).rejects.toThrow('Failed to fetch');
+  });
+
+  it('데이터가 스키마에 맞지 않으면 에러를 던진다', async () => {
+    (fetch as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      json: async () => [{ invalid: 'data' }],
+    });
+
+    await expect(createAIBehaviors()).rejects.toThrow();
+  });
+});

--- a/apps/frontend/src/features/behavior/apis/createAIBehaviors.api.ts
+++ b/apps/frontend/src/features/behavior/apis/createAIBehaviors.api.ts
@@ -1,0 +1,18 @@
+import type { Behavior } from '@/shared/components/behavior/BehaviorCard.types';
+import { PostAIBehaviorResponseSchema } from '@web24/shared';
+
+export async function createAIBehaviors(): Promise<Behavior[]> {
+  const res = await fetch('/api/today-behaviors/ai', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  });
+
+  if (!res.ok) {
+    throw new Error('Failed to fetch');
+  }
+
+  const json = await res.json();
+  return PostAIBehaviorResponseSchema.parse(json);
+}

--- a/apps/frontend/src/features/behavior/apis/fetchAIBehaviors.api.spec.ts
+++ b/apps/frontend/src/features/behavior/apis/fetchAIBehaviors.api.spec.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { fetchAIBehaviors } from './fetchAIBehaviors.api';
+
+describe('fetchAIBehaviors', () => {
+  const mockBehaviors = [
+    {
+      id: '01946777-7000-7000-8000-000000000000',
+      title: '행동 1',
+      goalTitle: '목표 A',
+      goalColor: 'mint',
+      isChecked: false,
+      difficulty: '시작하기',
+      isRecommended: true,
+    },
+  ];
+
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('성공 시 추천 행동 리스트를 반환한다', async () => {
+    (fetch as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockBehaviors,
+    });
+
+    const result = await fetchAIBehaviors();
+    expect(result).toEqual(mockBehaviors);
+    expect(fetch).toHaveBeenCalledWith(
+      '/api/today-behaviors/ai',
+      expect.objectContaining({
+        method: 'GET',
+      }),
+    );
+  });
+
+  it('응답이 ok가 아니면 에러를 던진다', async () => {
+    (fetch as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: false,
+    });
+
+    await expect(fetchAIBehaviors()).rejects.toThrow('Failed to fetch');
+  });
+});

--- a/apps/frontend/src/features/behavior/apis/fetchAIBehaviors.api.ts
+++ b/apps/frontend/src/features/behavior/apis/fetchAIBehaviors.api.ts
@@ -1,0 +1,18 @@
+import type { Behavior } from '@/shared/components/behavior/BehaviorCard.types';
+import { GetAIBehaviorResponseSchema } from '@web24/shared';
+
+export async function fetchAIBehaviors(): Promise<Behavior[]> {
+  const res = await fetch('/api/today-behaviors/ai', {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  });
+
+  if (!res.ok) {
+    throw new Error('Failed to fetch');
+  }
+
+  const json = await res.json();
+  return GetAIBehaviorResponseSchema.parse(json);
+}

--- a/apps/frontend/src/features/behavior/apis/updateAIBehaviorStatus.api.spec.ts
+++ b/apps/frontend/src/features/behavior/apis/updateAIBehaviorStatus.api.spec.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { updateAIBehaviorStatus } from './updateAIBehaviorStatus.api';
+
+describe('updateAIBehaviorStatus', () => {
+  const mockId = '01946777-7000-7000-8000-000000000000';
+  const mockResponse = {
+    id: mockId,
+    status: 'completed',
+  };
+
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('성공 시 업데이트된 상태를 반환한다', async () => {
+    (fetch as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockResponse,
+    });
+
+    const result = await updateAIBehaviorStatus(mockId, 'completed');
+    expect(result).toEqual(mockResponse);
+    expect(fetch).toHaveBeenCalledWith(
+      `/api/today-behaviors/ai/${mockId}/status`,
+      expect.objectContaining({
+        method: 'PATCH',
+        body: JSON.stringify({ status: 'completed' }),
+      }),
+    );
+  });
+
+  it('응답이 ok가 아니면 에러를 던진다', async () => {
+    (fetch as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: false,
+    });
+
+    await expect(updateAIBehaviorStatus(mockId, 'completed')).rejects.toThrow('Failed to fetch');
+  });
+});

--- a/apps/frontend/src/features/behavior/apis/updateAIBehaviorStatus.api.ts
+++ b/apps/frontend/src/features/behavior/apis/updateAIBehaviorStatus.api.ts
@@ -1,0 +1,25 @@
+import {
+  PatchAIBehaviorStatusResponseSchema,
+  type PatchAIBehaviorStatusResponse,
+  type AIBehaviorStatus,
+} from '@web24/shared';
+
+export async function updateAIBehaviorStatus(
+  id: string,
+  status: AIBehaviorStatus,
+): Promise<PatchAIBehaviorStatusResponse> {
+  const res = await fetch(`/api/today-behaviors/ai/${id}/status`, {
+    method: 'PATCH',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ status }),
+  });
+
+  if (!res.ok) {
+    throw new Error('Failed to fetch');
+  }
+
+  const json = await res.json();
+  return PatchAIBehaviorStatusResponseSchema.parse(json);
+}

--- a/apps/frontend/src/features/behavior/components/AIBehaviorContainer.spec.tsx
+++ b/apps/frontend/src/features/behavior/components/AIBehaviorContainer.spec.tsx
@@ -1,0 +1,74 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import type { Behavior } from '@/shared/components/behavior/BehaviorCard.types';
+import { AIBehaviorContainer } from './AIBehaviorContainer';
+
+describe('AIBehaviorContainer', () => {
+  const mockBehaviors: Behavior[] = [
+    {
+      id: '1',
+      title: 'Behavior 1',
+      goalTitle: 'Goal 1',
+      goalColor: 'mint',
+      isChecked: false,
+      difficulty: '몰입하기',
+      isRecommended: false,
+    },
+    {
+      id: '2',
+      title: 'Behavior 2',
+      goalTitle: 'Goal 2',
+      goalColor: 'blue',
+      isChecked: true,
+      difficulty: '마음열기',
+      isRecommended: true,
+    },
+  ];
+
+  it('로딩 중이거나 데이터가 없으면 빈 컨테이너를 렌더링한다', () => {
+    const { container } = render(
+      <AIBehaviorContainer behaviors={[]} onToggle={vi.fn()} isLoading isMaking={false} />,
+    );
+    // containerClassName defines the visible empty state
+    expect(container.firstChild).toHaveClass('min-h-55');
+    expect(screen.queryByText('AI 맞춤 추천')).not.toBeInTheDocument();
+  });
+
+  it('isMaking 상태일 때 MakingIndicator를 보여준다', () => {
+    render(
+      <AIBehaviorContainer behaviors={[]} onToggle={vi.fn()} isLoading={false} isMaking />,
+    );
+    expect(screen.getByText('두두가 주머니를 뒤지는 중...')).toBeInTheDocument();
+    expect(screen.getByAltText('두두 얼굴')).toBeInTheDocument();
+  });
+
+  it('추천 행동 리스트를 올바르게 렌더링한다', () => {
+    render(
+      <AIBehaviorContainer
+        behaviors={mockBehaviors}
+        onToggle={vi.fn()}
+        isLoading={false}
+        isMaking={false}
+      />,
+    );
+    expect(screen.getByText('AI 맞춤 추천')).toBeInTheDocument();
+    expect(screen.getByText('Behavior 1')).toBeInTheDocument();
+    expect(screen.getByText('Behavior 2')).toBeInTheDocument();
+  });
+
+  it('행동 카드를 클릭하면 onToggle이 호출된다', () => {
+    const onToggleMock = vi.fn();
+    render(
+      <AIBehaviorContainer
+        behaviors={mockBehaviors}
+        onToggle={onToggleMock}
+        isLoading={false}
+        isMaking={false}
+      />,
+    );
+
+    const toggleButton = screen.getByLabelText('Behavior 1 완료 토글');
+    fireEvent.click(toggleButton);
+    expect(onToggleMock).toHaveBeenCalledWith('1');
+  });
+});

--- a/apps/frontend/src/features/behavior/components/AIBehaviorContainer.spec.tsx
+++ b/apps/frontend/src/features/behavior/components/AIBehaviorContainer.spec.tsx
@@ -35,9 +35,7 @@ describe('AIBehaviorContainer', () => {
   });
 
   it('isMaking 상태일 때 MakingIndicator를 보여준다', () => {
-    render(
-      <AIBehaviorContainer behaviors={[]} onToggle={vi.fn()} isLoading={false} isMaking />,
-    );
+    render(<AIBehaviorContainer behaviors={[]} onToggle={vi.fn()} isLoading={false} isMaking />);
     expect(screen.getByText('두두가 주머니를 뒤지는 중...')).toBeInTheDocument();
     expect(screen.getByAltText('두두 얼굴')).toBeInTheDocument();
   });

--- a/apps/frontend/src/features/behavior/components/AIBehaviorContainer.tsx
+++ b/apps/frontend/src/features/behavior/components/AIBehaviorContainer.tsx
@@ -3,7 +3,7 @@ import type { Behavior } from '@/shared/components/behavior/BehaviorCard.types';
 import { ICON_SIZE } from '@/shared/constants/icon';
 
 interface AIBehaviorContainerProps {
-  behavior: Behavior;
+  behaviors: Behavior[];
   onToggle: (id: string) => void;
   isLoading: boolean;
   isMaking: boolean;
@@ -19,16 +19,18 @@ function MakingIndicator() {
 }
 
 export function AIBehaviorContainer({
-  behavior,
+  behaviors,
   onToggle,
   isLoading = true,
   isMaking = false,
 }: AIBehaviorContainerProps) {
   const containerClassName =
     'animate-in fade-in slide-in-from-top-4 border-primary-weak/60 bg-primary-weak/30 relative mb-10 overflow-hidden rounded-4xl border p-6 duration-500 min-h-55';
-  if (isLoading) {
+
+  if ((behaviors.length === 0 || isLoading) && !isMaking) {
     return <div className={containerClassName} />;
   }
+
   return (
     <div className={containerClassName}>
       {isMaking ? (
@@ -49,7 +51,13 @@ export function AIBehaviorContainer({
           </div>
 
           <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
-            <BehaviorCard behavior={behavior} onToggle={() => onToggle(behavior.id)} />
+            {behaviors.map((behavior) => (
+              <BehaviorCard
+                key={behavior.id}
+                behavior={behavior}
+                onToggle={() => onToggle(behavior.id)}
+              />
+            ))}
           </div>
         </div>
       )}

--- a/apps/frontend/src/features/behavior/components/AIBehaviorContainer.tsx
+++ b/apps/frontend/src/features/behavior/components/AIBehaviorContainer.tsx
@@ -1,30 +1,58 @@
 import { BehaviorCard } from '@/shared/components/behavior/BehaviorCard';
 import type { Behavior } from '@/shared/components/behavior/BehaviorCard.types';
+import { ICON_SIZE } from '@/shared/constants/icon';
 
-interface BehaviorProps {
+interface AIBehaviorContainerProps {
   behavior: Behavior;
   onToggle: (id: string) => void;
+  isLoading: boolean;
+  isMaking: boolean;
 }
 
-export function AIBehaviorContainer({ behavior, onToggle }: BehaviorProps) {
+function MakingIndicator() {
   return (
-    <div className="animate-in fade-in slide-in-from-top-4 border-primary-weak/60 bg-primary-weak/30 relative mb-10 overflow-hidden rounded-4xl border p-6 duration-500">
-      <div className="relative z-10">
-        <div className="mb-4 flex items-center justify-between px-1">
-          <div className="flex items-center gap-2">
-            <div>
-              <h3 className="text-label-normal text-lg leading-none font-bold">AI 맞춤 추천</h3>
-              <p className="text-label-disable mt-1 text-xs font-medium">
-                회원님의 목표 달성을 위해 찾았어요
-              </p>
+    <div className="flex h-full w-full items-center justify-center gap-5">
+      <img src="/DodoFace.png" alt="두두 얼굴" width={ICON_SIZE['3xl']} />
+      <p>두두가 주머니를 뒤지는 중...</p>
+    </div>
+  );
+}
+
+export function AIBehaviorContainer({
+  behavior,
+  onToggle,
+  isLoading = true,
+  isMaking = false,
+}: AIBehaviorContainerProps) {
+  const containerClassName =
+    'animate-in fade-in slide-in-from-top-4 border-primary-weak/60 bg-primary-weak/30 relative mb-10 overflow-hidden rounded-4xl border p-6 duration-500 min-h-55';
+  if (isLoading) {
+    return <div className={containerClassName} />;
+  }
+  return (
+    <div className={containerClassName}>
+      {isMaking ? (
+        <div className="absolute inset-0 flex items-center justify-center">
+          <MakingIndicator />
+        </div>
+      ) : (
+        <div className="relative z-10">
+          <div className="mb-4 flex items-center justify-between px-1">
+            <div className="flex items-center gap-2">
+              <div>
+                <h3 className="text-label-normal text-lg leading-none font-bold">AI 맞춤 추천</h3>
+                <p className="text-label-disable mt-1 text-xs font-medium">
+                  회원님의 목표 달성을 위해 찾았어요
+                </p>
+              </div>
             </div>
           </div>
-        </div>
 
-        <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
-          <BehaviorCard behavior={behavior} onToggle={() => onToggle(behavior.id)} />
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
+            <BehaviorCard behavior={behavior} onToggle={() => onToggle(behavior.id)} />
+          </div>
         </div>
-      </div>
+      )}
     </div>
   );
 }

--- a/apps/frontend/src/features/behavior/components/TodayBehaviorList.spec.tsx
+++ b/apps/frontend/src/features/behavior/components/TodayBehaviorList.spec.tsx
@@ -1,0 +1,94 @@
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { BrowserRouter } from 'react-router-dom';
+import type { Behavior } from '@/shared/components/behavior/BehaviorCard.types';
+import { TodayBahaviorList } from './TodayBehaviorList';
+
+// Mock SwiperTabs
+vi.mock('./SwiperTabs', () => ({
+  SwiperTabs: ({ tabs, onChange }: { tabs: string[]; onChange: (val: string) => void }) => (
+    <div data-testid="swiper-tabs">
+      {tabs.map((tab) => (
+        <button type="button" key={tab} onClick={() => onChange(tab)}>
+          {tab}
+        </button>
+      ))}
+    </div>
+  ),
+}));
+
+const renderWithRouter = (ui: React.ReactElement) => render(ui, { wrapper: BrowserRouter });
+
+describe('TodayBehaviorList', () => {
+  const mockBehaviors: Behavior[] = [
+    {
+      id: '1',
+      title: 'Behavior 1',
+      goalTitle: '운동',
+      goalColor: 'mint',
+      isChecked: false,
+      difficulty: '몰입하기',
+      isRecommended: false,
+    },
+    {
+      id: '2',
+      title: 'Behavior 2',
+      goalTitle: '독서',
+      goalColor: 'blue',
+      isChecked: true,
+      difficulty: '마음열기',
+      isRecommended: false,
+    },
+  ];
+  const mockGoals = ['운동', '독서'];
+
+  it('헤더에 올바른 제목과 행동 개수를 표시한다', () => {
+    renderWithRouter(
+      <TodayBahaviorList goals={mockGoals} behaviors={mockBehaviors} onToggle={vi.fn()} />,
+    );
+    expect(screen.getByText('오늘의 행동')).toBeInTheDocument();
+    expect(screen.getByText('2')).toBeInTheDocument();
+  });
+
+  it('전체 행동 리스트를 기본으로 렌더링한다', () => {
+    renderWithRouter(
+      <TodayBahaviorList goals={mockGoals} behaviors={mockBehaviors} onToggle={vi.fn()} />,
+    );
+    expect(screen.getByText('Behavior 1')).toBeInTheDocument();
+    expect(screen.getByText('Behavior 2')).toBeInTheDocument();
+  });
+
+  it('목표 탭을 클릭하면 필터링된 행동 리스트를 보여준다', () => {
+    renderWithRouter(
+      <TodayBahaviorList goals={mockGoals} behaviors={mockBehaviors} onToggle={vi.fn()} />,
+    );
+
+    const swiperTabs = screen.getByTestId('swiper-tabs');
+    const exerciseTab = within(swiperTabs).getByText('운동');
+    fireEvent.click(exerciseTab);
+
+    expect(screen.getByText('Behavior 1')).toBeInTheDocument();
+    expect(screen.queryByText('Behavior 2')).not.toBeInTheDocument();
+  });
+
+  it('행동 카드를 클릭하면 onToggle이 호출된다', () => {
+    const onToggleMock = vi.fn();
+    renderWithRouter(
+      <TodayBahaviorList goals={mockGoals} behaviors={mockBehaviors} onToggle={onToggleMock} />,
+    );
+
+    const toggleButton = screen.getByLabelText('Behavior 1 완료 토글');
+    fireEvent.click(toggleButton);
+
+    expect(onToggleMock).toHaveBeenCalledWith('1');
+  });
+
+  it('추가 버튼 클릭 시 새 목표 페이지로 이동한다', () => {
+    renderWithRouter(
+      <TodayBahaviorList goals={mockGoals} behaviors={mockBehaviors} onToggle={vi.fn()} />,
+    );
+
+    const addButton = screen.getByRole('button', { name: '' });
+    expect(addButton).toBeInTheDocument();
+  });
+});

--- a/apps/frontend/src/features/behavior/components/TodayBehaviorList.spec.tsx
+++ b/apps/frontend/src/features/behavior/components/TodayBehaviorList.spec.tsx
@@ -1,8 +1,18 @@
 import { render, screen, fireEvent, within } from '@testing-library/react';
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { BrowserRouter } from 'react-router-dom';
 import type { Behavior } from '@/shared/components/behavior/BehaviorCard.types';
 import { TodayBahaviorList } from './TodayBehaviorList';
+
+const mockNavigate = vi.fn();
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
 
 // Mock SwiperTabs
 vi.mock('./SwiperTabs', () => ({
@@ -41,6 +51,10 @@ describe('TodayBehaviorList', () => {
     },
   ];
   const mockGoals = ['운동', '독서'];
+
+  beforeEach(() => {
+    mockNavigate.mockClear();
+  });
 
   it('헤더에 올바른 제목과 행동 개수를 표시한다', () => {
     renderWithRouter(
@@ -88,7 +102,9 @@ describe('TodayBehaviorList', () => {
       <TodayBahaviorList goals={mockGoals} behaviors={mockBehaviors} onToggle={vi.fn()} />,
     );
 
-    const addButton = screen.getByRole('button', { name: '' });
-    expect(addButton).toBeInTheDocument();
+    const addButton = screen.getByRole('button', { name: '목표' });
+    fireEvent.click(addButton);
+
+    expect(mockNavigate).toHaveBeenCalledWith('/goals/new');
   });
 });

--- a/apps/frontend/src/features/behavior/hooks/useAIBehaviors.spec.ts
+++ b/apps/frontend/src/features/behavior/hooks/useAIBehaviors.spec.ts
@@ -1,0 +1,82 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { useAIBehaviors } from './useAIBehaviors';
+import { fetchAIBehaviors } from '../apis/fetchAIBehaviors.api';
+import { createAIBehaviors } from '../apis/createAIBehaviors.api';
+
+vi.mock('../apis/fetchAIBehaviors.api', () => ({
+  fetchAIBehaviors: vi.fn(),
+}));
+
+vi.mock('../apis/createAIBehaviors.api', () => ({
+  createAIBehaviors: vi.fn(),
+}));
+
+describe('useAIBehaviors', () => {
+  const mockBehaviors = [
+    {
+      id: '1',
+      title: 'Behavior 1',
+      goalTitle: 'Goal 1',
+      goalColor: 'mint',
+      isChecked: false,
+      difficulty: '몰입하기',
+      isRecommended: false,
+    },
+  ];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('초기 상태를 올바르게 반환한다', () => {
+    vi.mocked(fetchAIBehaviors).mockReturnValue(new Promise(() => {}));
+    const { result } = renderHook(() => useAIBehaviors());
+
+    expect(result.current.behaviors).toEqual([]);
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.isMaking).toBe(false);
+    expect(result.current.isError).toBe(null);
+  });
+
+  it('데이터 페칭이 성공하면 행동 리스트를 업데이트한다', async () => {
+    vi.mocked(fetchAIBehaviors).mockResolvedValue(mockBehaviors as any);
+
+    const { result } = renderHook(() => useAIBehaviors());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.behaviors).toEqual(mockBehaviors);
+    expect(result.current.isMaking).toBe(false);
+  });
+
+  it('기존 추천 행동이 없으면 새로운 행동을 생성한다', async () => {
+    vi.mocked(fetchAIBehaviors).mockResolvedValue([]);
+    vi.mocked(createAIBehaviors).mockResolvedValue(mockBehaviors as any);
+
+    const { result } = renderHook(() => useAIBehaviors());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(createAIBehaviors).toHaveBeenCalled();
+    expect(result.current.behaviors).toEqual(mockBehaviors);
+    expect(result.current.isMaking).toBe(false);
+  });
+
+  it('페칭 중 에러가 발생하면 에러 상태를 업데이트한다', async () => {
+    const error = new Error('Fetch failed');
+    vi.mocked(fetchAIBehaviors).mockRejectedValue(error);
+
+    const { result } = renderHook(() => useAIBehaviors());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.isError).toEqual(error);
+  });
+});

--- a/apps/frontend/src/features/behavior/hooks/useAIBehaviors.ts
+++ b/apps/frontend/src/features/behavior/hooks/useAIBehaviors.ts
@@ -1,5 +1,5 @@
 import type { Behavior } from '@/shared/components/behavior/BehaviorCard.types';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { fetchAIBehaviors } from '../apis/fetchAIBehaviors.api';
 import { createAIBehaviors } from '../apis/createAIBehaviors.api';
 
@@ -9,7 +9,12 @@ export function useAIBehaviors() {
   const [isMaking, setIsMaking] = useState(false);
   const [isError, setIsError] = useState<Error | null>(null);
 
+  const isRequested = useRef(false);
+
   useEffect(() => {
+    if (isRequested.current) return;
+    isRequested.current = true;
+
     setIsLoading(true);
 
     const getAIBehaviors = async () => {

--- a/apps/frontend/src/features/behavior/hooks/useAIBehaviors.ts
+++ b/apps/frontend/src/features/behavior/hooks/useAIBehaviors.ts
@@ -1,0 +1,39 @@
+import type { Behavior } from '@/shared/components/behavior/BehaviorCard.types';
+import { useEffect, useState } from 'react';
+import { fetchAIBehaviors } from '../apis/fetchAIBehaviors.api';
+import { createAIBehaviors } from '../apis/createAIBehaviors.api';
+
+export function useAIBehaviors() {
+  const [behaviors, setBehaviors] = useState<Behavior[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isMaking, setIsMaking] = useState(false);
+  const [isError, setIsError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    setIsLoading(true);
+
+    const getAIBehaviors = async () => {
+      try {
+        const fetched = await fetchAIBehaviors();
+        setBehaviors(fetched);
+
+        if (fetched.length === 0) {
+          setIsMaking(true);
+          const created = await createAIBehaviors();
+          setBehaviors(created);
+          setIsMaking(false);
+        }
+
+        setIsError(null);
+      } catch (err) {
+        setIsError(err instanceof Error ? err : new Error('Failed to fetch ai behaviors'));
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    getAIBehaviors();
+  }, []);
+
+  return { behaviors, setBehaviors, isLoading, isMaking, isError };
+}

--- a/apps/frontend/src/features/goal/apis/fetchGoalStamps.api.ts
+++ b/apps/frontend/src/features/goal/apis/fetchGoalStamps.api.ts
@@ -13,5 +13,7 @@ export async function fetchGoalStamps(goalId: string): Promise<GetGoalStampsResp
   }
 
   const json = await res.json();
-  return GetGoalStampsResponseSchema.parse(json);
+  const stamps = GetGoalStampsResponseSchema.parse(json);
+  // updatedAt 기준 최신순(내림차순) 정렬
+  return [...stamps].sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
 }

--- a/apps/frontend/src/features/goal/components/GoalStampBoard.spec.tsx
+++ b/apps/frontend/src/features/goal/components/GoalStampBoard.spec.tsx
@@ -5,10 +5,10 @@ import { GoalStampBoard } from './GoalStampBoard';
 
 describe('GoalStampBoard', () => {
   const stamps: GoalStamp[] = [
-    { id: 'stamp-1', difficulty: '몰입하기' },
-    { id: 'stamp-2', difficulty: '이어가기' },
-    { id: 'stamp-3', difficulty: '마음열기' },
-    { id: 'stamp-4', difficulty: '시작하기' },
+    { id: 'stamp-1', title: '행동 1', difficulty: '몰입하기', source: 'today' },
+    { id: 'stamp-2', title: '행동 2', difficulty: '이어가기', source: 'today' },
+    { id: 'stamp-3', title: '행동 3', difficulty: '마음열기', source: 'today' },
+    { id: 'stamp-4', title: '행동 4', difficulty: '시작하기', source: 'today' },
   ];
 
   it('스탬프 개수만큼 버튼을 렌더링한다', () => {

--- a/apps/frontend/src/features/goal/components/GoalStampBoard.spec.tsx
+++ b/apps/frontend/src/features/goal/components/GoalStampBoard.spec.tsx
@@ -5,10 +5,30 @@ import { GoalStampBoard } from './GoalStampBoard';
 
 describe('GoalStampBoard', () => {
   const stamps: GoalStamp[] = [
-    { id: 'stamp-1', title: '행동 1', difficulty: '몰입하기', source: 'today' },
-    { id: 'stamp-2', title: '행동 2', difficulty: '이어가기', source: 'today' },
-    { id: 'stamp-3', title: '행동 3', difficulty: '마음열기', source: 'today' },
-    { id: 'stamp-4', title: '행동 4', difficulty: '시작하기', source: 'today' },
+    {
+      id: 'stamp-1',
+      title: '행동 1',
+      difficulty: '몰입하기',
+      updatedAt: '2024-01-01T00:00:00.000Z',
+    },
+    {
+      id: 'stamp-2',
+      title: '행동 2',
+      difficulty: '이어가기',
+      updatedAt: '2024-01-02T00:00:00.000Z',
+    },
+    {
+      id: 'stamp-3',
+      title: '행동 3',
+      difficulty: '마음열기',
+      updatedAt: '2024-01-03T00:00:00.000Z',
+    },
+    {
+      id: 'stamp-4',
+      title: '행동 4',
+      difficulty: '시작하기',
+      updatedAt: '2024-01-04T00:00:00.000Z',
+    },
   ];
 
   it('스탬프 개수만큼 버튼을 렌더링한다', () => {

--- a/apps/frontend/src/pages/GoalDetailPage.spec.tsx
+++ b/apps/frontend/src/pages/GoalDetailPage.spec.tsx
@@ -70,8 +70,8 @@ describe('GoalDetailPage', () => {
 
   it('가져온 스탬프 개수를 표시한다', async () => {
     (fetchGoalStamps as any).mockResolvedValueOnce([
-      { id: 's1', difficulty: '몰입하기' },
-      { id: 's2', difficulty: '시작하기' },
+      { id: 's1', title: '행동 1', difficulty: '몰입하기', source: 'today' },
+      { id: 's2', title: 'AI 행동', difficulty: 'AI', source: 'ai' },
     ]);
 
     renderPage();
@@ -85,9 +85,9 @@ describe('GoalDetailPage', () => {
 
   it('GoalStampBoard에 stamps를 전달한다', async () => {
     (fetchGoalStamps as any).mockResolvedValueOnce([
-      { id: 's1', difficulty: '시작하기' },
-      { id: 's2', difficulty: '몰입하기' },
-      { id: 's3', difficulty: '이어가기' },
+      { id: 's1', title: '행동 1', difficulty: '시작하기', source: 'today' },
+      { id: 's2', title: '행동 2', difficulty: '몰입하기', source: 'today' },
+      { id: 's3', title: '행동 3', difficulty: '이어가기', source: 'today' },
     ]);
 
     renderPage();

--- a/apps/frontend/src/pages/GoalDetailPage.spec.tsx
+++ b/apps/frontend/src/pages/GoalDetailPage.spec.tsx
@@ -70,8 +70,18 @@ describe('GoalDetailPage', () => {
 
   it('가져온 스탬프 개수를 표시한다', async () => {
     (fetchGoalStamps as any).mockResolvedValueOnce([
-      { id: 's1', title: '행동 1', difficulty: '몰입하기', source: 'today' },
-      { id: 's2', title: 'AI 행동', difficulty: 'AI', source: 'ai' },
+      {
+        id: 's1',
+        title: '행동 1',
+        difficulty: '몰입하기',
+        updatedAt: '2024-01-01T00:00:00.000Z',
+      },
+      {
+        id: 's2',
+        title: 'AI 행동',
+        difficulty: 'AI',
+        updatedAt: '2024-01-02T00:00:00.000Z',
+      },
     ]);
 
     renderPage();
@@ -85,9 +95,24 @@ describe('GoalDetailPage', () => {
 
   it('GoalStampBoard에 stamps를 전달한다', async () => {
     (fetchGoalStamps as any).mockResolvedValueOnce([
-      { id: 's1', title: '행동 1', difficulty: '시작하기', source: 'today' },
-      { id: 's2', title: '행동 2', difficulty: '몰입하기', source: 'today' },
-      { id: 's3', title: '행동 3', difficulty: '이어가기', source: 'today' },
+      {
+        id: 's1',
+        title: '행동 1',
+        difficulty: '시작하기',
+        updatedAt: '2024-01-01T00:00:00.000Z',
+      },
+      {
+        id: 's2',
+        title: '행동 2',
+        difficulty: '몰입하기',
+        updatedAt: '2024-01-02T00:00:00.000Z',
+      },
+      {
+        id: 's3',
+        title: '행동 3',
+        difficulty: '이어가기',
+        updatedAt: '2024-01-03T00:00:00.000Z',
+      },
     ]);
 
     renderPage();

--- a/apps/frontend/src/pages/IndexPage.tsx
+++ b/apps/frontend/src/pages/IndexPage.tsx
@@ -7,11 +7,19 @@ import { TodayBahaviorList } from '@/features/behavior/components/TodayBehaviorL
 import { fetchTodayBehaviors } from '@/features/behavior/apis/fetchBehaviors.api';
 import { fetchGoals } from '@/features/goal/apis/fetchGoals.api';
 import { updateTodayBehaviorStatus } from '@/features/behavior/apis/updateTodayBehaviorStatus.api';
+import { useAIBehaviors } from '@/features/behavior/hooks/useAIBehaviors';
+import { updateAIBehaviorStatus } from '@/features/behavior/apis/updateAIBehaviorStatus.api';
 
 export function IndexPage() {
   const [behaviors, setBehaviors] = useState<Behavior[]>([]);
   const [goalTitles, setGoalTitles] = useState<string[]>([]);
   const { quote, resetQuote } = useDodoChatStore();
+  const {
+    behaviors: aiBehaviors,
+    setBehaviors: setAIBehaviors,
+    isLoading,
+    isMaking,
+  } = useAIBehaviors();
 
   const toggleBehaviorIsChecked = (behaviorId: string) => {
     setBehaviors((bs) =>
@@ -19,7 +27,7 @@ export function IndexPage() {
     );
   };
 
-  const handleToggle = (id: string) => {
+  const handleBehaviorToggle = (id: string) => {
     const targetBehavior = behaviors.find((bs) => bs.id === id);
     if (!targetBehavior) return;
 
@@ -27,6 +35,22 @@ export function IndexPage() {
 
     const nextStatus = targetBehavior.isChecked ? 'pending' : 'completed';
     updateTodayBehaviorStatus(id, nextStatus).catch(() => toggleBehaviorIsChecked(id));
+  };
+
+  const handleAIBehaviorToggle = (id: string) => {
+    const targetBehavior = aiBehaviors.find((bs) => bs.id === id);
+    if (!targetBehavior) return;
+
+    const toggleAIBehaviorIsChecked = (behaviorId: string) => {
+      setAIBehaviors((bs) =>
+        bs.map((b) => (b.id === behaviorId ? { ...b, isChecked: !b.isChecked } : b)),
+      );
+    };
+
+    toggleAIBehaviorIsChecked(id);
+
+    const nextStatus = targetBehavior.isChecked ? 'pending' : 'completed';
+    updateAIBehaviorStatus(id, nextStatus).catch(() => toggleAIBehaviorIsChecked(id));
   };
 
   useEffect(() => {
@@ -43,27 +67,21 @@ export function IndexPage() {
     [resetQuote],
   );
 
-  const aiBehavior = behaviors[0];
-
   return (
     <div className="bg-bg-normal mx-auto flex max-w-5xl flex-col pt-2">
       {/* 두두의 말 */}
       <Hero quote={quote} />
 
       {/* AI 추천 행동 */}
-      {aiBehavior && (
-        <AIBehaviorContainer
-          behavior={behaviors[0]}
-          onToggle={() => handleToggle(behaviors[0].id)}
-        />
-      )}
+      <AIBehaviorContainer
+        behaviors={aiBehaviors}
+        isLoading={isLoading}
+        isMaking={isMaking}
+        onToggle={handleAIBehaviorToggle}
+      />
 
       {/* 오늘의 행동 */}
-      <TodayBahaviorList
-        goals={goalTitles}
-        behaviors={behaviors.slice(1)}
-        onToggle={handleToggle}
-      />
+      <TodayBahaviorList goals={goalTitles} behaviors={behaviors} onToggle={handleBehaviorToggle} />
     </div>
   );
 }

--- a/apps/frontend/src/pages/IndexPage.tsx
+++ b/apps/frontend/src/pages/IndexPage.tsx
@@ -27,6 +27,12 @@ export function IndexPage() {
     );
   };
 
+  const toggleAIBehaviorIsChecked = (behaviorId: string) => {
+    setAIBehaviors((bs) =>
+      bs.map((b) => (b.id === behaviorId ? { ...b, isChecked: !b.isChecked } : b)),
+    );
+  };
+
   const handleBehaviorToggle = (id: string) => {
     const targetBehavior = behaviors.find((bs) => bs.id === id);
     if (!targetBehavior) return;
@@ -40,12 +46,6 @@ export function IndexPage() {
   const handleAIBehaviorToggle = (id: string) => {
     const targetBehavior = aiBehaviors.find((bs) => bs.id === id);
     if (!targetBehavior) return;
-
-    const toggleAIBehaviorIsChecked = (behaviorId: string) => {
-      setAIBehaviors((bs) =>
-        bs.map((b) => (b.id === behaviorId ? { ...b, isChecked: !b.isChecked } : b)),
-      );
-    };
 
     toggleAIBehaviorIsChecked(id);
 

--- a/packages/shared/src/schemas/behavior.schemas.ts
+++ b/packages/shared/src/schemas/behavior.schemas.ts
@@ -1,4 +1,5 @@
 import {
+  AI_BEHAVIOR_STATUS,
   BEHAVIOR_DIFFICULTIES,
   TODAY_BEHAVIOR_STATUS,
   type Behavior,
@@ -54,3 +55,14 @@ export type GetAIBehaviorResponse = z.infer<typeof GetAIBehaviorResponseSchema>;
 
 export const PostAIBehaviorResponseSchema = z.array(AIBehaviorSchema);
 export type PostAIBehaviorResponse = z.infer<typeof PostAIBehaviorResponseSchema>;
+
+export const PatchAIBehaviorStatusRequestSchema = z.object({
+  status: z.enum(AI_BEHAVIOR_STATUS),
+});
+export type PatchAIBehaviorStatusRequest = z.infer<typeof PatchAIBehaviorStatusRequestSchema>;
+
+export const PatchAIBehaviorStatusResponseSchema = z.object({
+  id: z.uuid({ version: 'v7' }),
+  status: z.enum(AI_BEHAVIOR_STATUS),
+});
+export type PatchAIBehaviorStatusResponse = z.infer<typeof PatchAIBehaviorStatusResponseSchema>;

--- a/packages/shared/src/schemas/behavior.schemas.ts
+++ b/packages/shared/src/schemas/behavior.schemas.ts
@@ -51,3 +51,6 @@ export type PatchTodayBehaviorStatusResponse = z.infer<
 
 export const GetAIBehaviorResponseSchema = z.array(AIBehaviorSchema);
 export type GetAIBehaviorResponse = z.infer<typeof GetAIBehaviorResponseSchema>;
+
+export const PostAIBehaviorResponseSchema = z.array(AIBehaviorSchema);
+export type PostAIBehaviorResponse = z.infer<typeof PostAIBehaviorResponseSchema>;

--- a/packages/shared/src/schemas/behavior.schemas.ts
+++ b/packages/shared/src/schemas/behavior.schemas.ts
@@ -47,7 +47,7 @@ export const PatchTodayBehaviorStatusResponseSchema = z.object({
   status: z.enum(TODAY_BEHAVIOR_STATUS),
 });
 export type PatchTodayBehaviorStatusResponse = z.infer<
-  typeof PatchTodayBehaviorStatusRequestSchema
+  typeof PatchTodayBehaviorStatusResponseSchema
 >;
 
 export const GetAIBehaviorResponseSchema = z.array(AIBehaviorSchema);

--- a/packages/shared/src/schemas/behavior.schemas.ts
+++ b/packages/shared/src/schemas/behavior.schemas.ts
@@ -16,6 +16,8 @@ export const TodayBehaviorSchema = z.object({
   isRecommended: z.boolean(),
 });
 
+export const AIBehaviorSchema = TodayBehaviorSchema;
+
 export type TodayBehavior = z.infer<typeof TodayBehaviorSchema>;
 
 export const BehaviorSchema = z.object({
@@ -46,3 +48,6 @@ export const PatchTodayBehaviorStatusResponseSchema = z.object({
 export type PatchTodayBehaviorStatusResponse = z.infer<
   typeof PatchTodayBehaviorStatusRequestSchema
 >;
+
+export const GetAIBehaviorResponseSchema = z.array(AIBehaviorSchema);
+export type GetAIBehaviorResponse = z.infer<typeof GetAIBehaviorResponseSchema>;

--- a/packages/shared/src/schemas/goal.schemas.ts
+++ b/packages/shared/src/schemas/goal.schemas.ts
@@ -1,7 +1,7 @@
 import { BEHAVIOR_TITLE_MAX_LENGTH } from '../constants/behavior.constants';
 import { GOAL_TITLE_MAX_LENGTH } from '../constants/goal.constants';
 import { BEHAVIOR_DIFFICULTIES } from '../types/behavior.types';
-import { GOAL_COLORS, GOAL_STAMP_SOURCES } from '../types/goal.types';
+import { GOAL_COLORS } from '../types/goal.types';
 import { z } from '../zod';
 
 export const GoalTemplateLevelSchema = z.object({
@@ -75,7 +75,7 @@ export const GoalStampSchema = z.object({
   id: z.uuid({ version: 'v7' }),
   title: z.string().min(1),
   difficulty: z.enum(BEHAVIOR_DIFFICULTIES),
-  source: z.enum(GOAL_STAMP_SOURCES),
+  updatedAt: z.iso.datetime(),
 });
 
 export const GetGoalStampsResponseSchema = z.array(GoalStampSchema);

--- a/packages/shared/src/schemas/goal.schemas.ts
+++ b/packages/shared/src/schemas/goal.schemas.ts
@@ -1,7 +1,7 @@
 import { BEHAVIOR_TITLE_MAX_LENGTH } from '../constants/behavior.constants';
 import { GOAL_TITLE_MAX_LENGTH } from '../constants/goal.constants';
 import { BEHAVIOR_DIFFICULTIES } from '../types/behavior.types';
-import { GOAL_COLORS } from '../types/goal.types';
+import { GOAL_COLORS, GOAL_STAMP_SOURCES } from '../types/goal.types';
 import { z } from '../zod';
 
 export const GoalTemplateLevelSchema = z.object({
@@ -73,7 +73,9 @@ export type GetGoalResponse = z.infer<typeof GetGoalResponseSchema>;
 
 export const GoalStampSchema = z.object({
   id: z.uuid({ version: 'v7' }),
+  title: z.string().min(1),
   difficulty: z.enum(BEHAVIOR_DIFFICULTIES),
+  source: z.enum(GOAL_STAMP_SOURCES),
 });
 
 export const GetGoalStampsResponseSchema = z.array(GoalStampSchema);

--- a/packages/shared/src/types/behavior.types.ts
+++ b/packages/shared/src/types/behavior.types.ts
@@ -16,6 +16,10 @@ export const TODAY_BEHAVIOR_ORIGIN = ['user', 'system'] as const;
 
 export type TodayBehaviorOrigin = (typeof TODAY_BEHAVIOR_ORIGIN)[number];
 
+export const AI_BEHAVIOR_STATUS = ['pending', 'completed'] as const;
+
+export type AIBehaviorStatus = (typeof AI_BEHAVIOR_STATUS)[number];
+
 export interface Behavior {
   id: string;
   goalId?: string;

--- a/packages/shared/src/types/goal.types.ts
+++ b/packages/shared/src/types/goal.types.ts
@@ -15,10 +15,6 @@ export const GOAL_COLORS = [
 
 export type GoalColor = (typeof GOAL_COLORS)[number];
 
-export const GOAL_STAMP_SOURCES = ['today', 'ai'] as const;
-
-export type GoalStampSource = (typeof GOAL_STAMP_SOURCES)[number];
-
 export interface Goal {
   id: string;
   title: string;
@@ -33,5 +29,5 @@ export interface GoalStamp {
   id: string;
   title: string;
   difficulty: BehaviorDifficulty;
-  source: GoalStampSource;
+  updatedAt: string;
 }

--- a/packages/shared/src/types/goal.types.ts
+++ b/packages/shared/src/types/goal.types.ts
@@ -15,6 +15,10 @@ export const GOAL_COLORS = [
 
 export type GoalColor = (typeof GOAL_COLORS)[number];
 
+export const GOAL_STAMP_SOURCES = ['today', 'ai'] as const;
+
+export type GoalStampSource = (typeof GOAL_STAMP_SOURCES)[number];
+
 export interface Goal {
   id: string;
   title: string;
@@ -27,5 +31,7 @@ export interface GoalSummary extends Goal {
 
 export interface GoalStamp {
   id: string;
+  title: string;
   difficulty: BehaviorDifficulty;
+  source: GoalStampSource;
 }


### PR DESCRIPTION
## 🔗 관련 이슈

- close: #102

## ✅ 작업 내용

### Backend
- **AiBehavior 엔티티 및 테이블 생성**: AI 추천 행동 저장을 위한 엔티티 정의 및 마이그레이션 (`ai_behaviors` 테이블)
- **Clova AI 연동**: `AIService`를 구현하여 네이버 Clova Studio(HCX-005)와 연동, 사용자의 목표에 최적화된 행동을 AI가 추천하도록 구현
- **API 엔드포인트 추가**: `TodayBehaviorController`에 아래 엔드포인트 추가
    - `GET /today-behaviors/ai`: 오늘의 AI 추천 행동 목록 조회
    - `POST /today-behaviors/ai`: 신규 AI 추천 행동 생성
    - `PATCH /today-behaviors/ai/:id/status`: AI 추천 행동 상태(완료/취소) 업데이트
- **문서화**: `@web24/shared` 패키지와 연동하여 Swagger API 문서화 완료
- **테스트**: `AiBehavior` 엔티티, `AIService`, `TodayBehaviorController` 등에 대한 단위/통합 테스트 코드 작성

### Frontend
- **API 연동**: `@web24/shared` 타입을 활용한 AI 행동 관련 API 호출 로직 구현
- **Custom Hook**: `useAIBehaviors` 훅을 구현하여 AI 추천 행동의 조회, 생성, 상태 변경 로직을 캡슐화
- **UI 개발**:
    - `AIBehaviorContainer`: AI 추천 행동 섹션 구현, 생성 중(Loding, Making) 상태 대응 UI 추가
    - `TodayBehaviorList`: 기존 투두 리스트와 통합하여 AI 추천 행동을 표시하고 인터랙션 연동
    - `IndexPage`: 메인 페이지에 AI 추천 행동 기능 통합
- **테스트**: API 호출, 훅 로직, 컴포넌트 렌더링 테스트 완료

### 기타
- **환경 변수**: `.env.template`에 `CLOVA_API_KEY` 추가

## 📸 스크린샷 / 데모
새롭게 생성한 행동
<img width="700"  alt="image" src="https://github.com/user-attachments/assets/1a10a2f8-b0c5-4540-9472-503efac18f9e" />


## 💡 체크리스트

- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 테스트는 잘 통과했나요?
- [x] 빌드에 성공했나요?

## 💬 To Reviewers

- Clova AI의 응답 파싱 로직에서 JSON 형식을 강제하기 위한 프롬프트를 최적화했습니다.
- AI 추천 행동은 현재 '몰입하기' 단계의 행동을 위주로 추천하도록 설정되어 있습니다. 추후 확장이 용이하도록 구조를 잡았습니다.
