### PR TITLE
hotfix: API 엔드포인트 메서드 순서 변경

### DIFF
--- a/apps/backend/src/features/goal/goal.controller.spec.ts
+++ b/apps/backend/src/features/goal/goal.controller.spec.ts
@@ -152,15 +152,11 @@ describe('GoalController', () => {
   it('목표의 행동 목록을 반환한다', async () => {
     const goalId = '01890fba-7e6a-7b6b-9e5d-0f3c9b8b4c6d';
     const behaviorId = '01890fba-7e6a-7b6c-9e5d-0f3c9b8b4c6e';
-    const behaviors = [
-      { id: behaviorId, title: 'b1', difficulty: '몰입하기', extra: 'ignored' },
-      { id: 'ai-1', title: 'ai 1', difficulty: 'AI' },
-    ];
+    const behaviors = [{ id: behaviorId, title: 'b1', difficulty: 'easy', extra: 'ignored' }];
     goalService.getGoalBehaviors.mockResolvedValue(behaviors);
 
     await expect(controller.getGoalBehaviors(goalId)).resolves.toEqual([
-      { id: behaviorId, title: 'b1', difficulty: '몰입하기' },
-      { id: 'ai-1', title: 'ai 1', difficulty: 'AI' },
+      { id: behaviorId, title: 'b1', difficulty: 'easy' },
     ]);
     expect(goalService.getGoalBehaviors).toHaveBeenCalledWith(goalId);
   });

--- a/apps/backend/src/features/goal/goal.controller.ts
+++ b/apps/backend/src/features/goal/goal.controller.ts
@@ -32,6 +32,19 @@ export class GoalController {
     }));
   }
 
+  @Get('templates')
+  async getTemplates(): Promise<GoalTemplateListResponse> {
+    const filePath = join(process.cwd(), 'src/features/goal/goal-templates.ndjson');
+    const raw = await readFile(filePath, 'utf-8');
+    const templates = raw
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .map((line) => JSON.parse(line));
+
+    return GoalTemplateListResponseSchema.parse(templates);
+  }
+
   @Get(':id')
   async getGoal(@Param('id', ParseUUIDPipe) id: string): Promise<GetGoalResponse> {
     const goal = await this.goalService.getGoal(id);
@@ -55,19 +68,6 @@ export class GoalController {
   @Get(':id/stamps')
   async getGoalStamps(@Param('id', ParseUUIDPipe) id: string): Promise<GetGoalStampsResponse> {
     return this.goalService.getGoalStamps(id);
-  }
-
-  @Get('templates')
-  async getTemplates(): Promise<GoalTemplateListResponse> {
-    const filePath = join(process.cwd(), 'src/features/goal/goal-templates.ndjson');
-    const raw = await readFile(filePath, 'utf-8');
-    const templates = raw
-      .split(/\r?\n/)
-      .map((line) => line.trim())
-      .filter(Boolean)
-      .map((line) => JSON.parse(line));
-
-    return GoalTemplateListResponseSchema.parse(templates);
   }
 
   @Post()

--- a/apps/backend/src/features/goal/goal.service.spec.ts
+++ b/apps/backend/src/features/goal/goal.service.spec.ts
@@ -306,39 +306,24 @@ describe('GoalService', () => {
   });
 
   describe('getGoalBehaviors', () => {
-    it('목표의 행동과 AI 행동 목록을 반환한다', async () => {
+    it('목표의 행동 목록을 반환한다', async () => {
       const goalId = 'goal-1';
       const behaviors = [
-        { id: 'b1', title: 'b1', difficulty: '몰입하기' },
-        { id: 'b2', title: 'b2', difficulty: '시작하기' },
+        { id: 'b1', title: 'b1', difficulty: 'easy' },
+        { id: 'b2', title: 'b2', difficulty: 'hard' },
       ];
       const goal = { id: goalId, behaviors };
-      const aiBehaviors = [
-        { id: 'ai-1', title: 'ai 1' },
-        { id: 'ai-2', title: 'ai 2' },
-      ];
 
       const goalRepository = {
         findOne: jest.fn().mockResolvedValue(goal),
       };
-      const aiBehaviorRepository = {
-        find: jest.fn().mockResolvedValue(aiBehaviors),
-      };
 
-      const { service } = await createService({ goalRepository, aiBehaviorRepository });
+      const { service } = await createService({ goalRepository });
 
-      await expect(service.getGoalBehaviors(goalId)).resolves.toEqual([
-        { id: 'b1', goalId, title: 'b1', difficulty: '몰입하기' },
-        { id: 'b2', goalId, title: 'b2', difficulty: '시작하기' },
-        { id: 'ai-1', goalId, title: 'ai 1', difficulty: 'AI' },
-        { id: 'ai-2', goalId, title: 'ai 2', difficulty: 'AI' },
-      ]);
+      await expect(service.getGoalBehaviors(goalId)).resolves.toEqual(behaviors);
       expect(goalRepository.findOne).toHaveBeenCalledWith({
         where: { id: goalId },
         relations: ['behaviors'],
-      });
-      expect(aiBehaviorRepository.find).toHaveBeenCalledWith({
-        where: { goal: { id: goalId } },
       });
     });
 

--- a/apps/backend/src/features/goal/goal.service.ts
+++ b/apps/backend/src/features/goal/goal.service.ts
@@ -4,11 +4,10 @@ import {
   CreateGoalResponseSchema,
   type CreateGoalRequest,
   type CreateGoalResponse,
-  type Behavior as BehaviorResponse,
   type GoalStamp,
 } from '@web24/shared';
 import { Repository } from 'typeorm';
-import { Behavior as BehaviorEntity } from '../behavior/behavior.entity';
+import { Behavior } from '../behavior/behavior.entity';
 import { User } from '../user/user.entity';
 import { Goal } from './goal.entity';
 import { TodayBehavior } from '../behavior/today-behavior.entity';
@@ -58,7 +57,7 @@ export class GoalService {
     return goal;
   }
 
-  async getGoalBehaviors(goalId: string): Promise<BehaviorResponse[]> {
+  async getGoalBehaviors(goalId: string): Promise<Behavior[]> {
     const goal = await this.goalRepository.findOne({
       where: { id: goalId },
       relations: ['behaviors'],
@@ -68,25 +67,7 @@ export class GoalService {
       throw new NotFoundException('Goal not found');
     }
 
-    const behaviors: BehaviorResponse[] = (goal.behaviors || []).map((behavior) => ({
-      id: behavior.id,
-      goalId,
-      title: behavior.title,
-      difficulty: behavior.difficulty,
-    }));
-
-    const aiBehaviors = await this.aiBehaviorRepository.find({
-      where: { goal: { id: goalId } },
-    });
-
-    const aiMapped: BehaviorResponse[] = aiBehaviors.map((behavior) => ({
-      id: behavior.id,
-      goalId,
-      title: behavior.title,
-      difficulty: 'AI',
-    }));
-
-    return [...behaviors, ...aiMapped];
+    return goal.behaviors || [];
   }
 
   async getGoalStamps(goalId: string): Promise<GoalStamp[]> {
@@ -142,13 +123,13 @@ export class GoalService {
       const savedGoal = await manager.getRepository(Goal).save(goal);
 
       const behaviors = request.behaviors.map((behavior) =>
-        manager.getRepository(BehaviorEntity).create({
+        manager.getRepository(Behavior).create({
           title: behavior.title,
           difficulty: behavior.difficulty,
           goal: savedGoal,
         }),
       );
-      const savedBehaviors = await manager.getRepository(BehaviorEntity).save(behaviors);
+      const savedBehaviors = await manager.getRepository(Behavior).save(behaviors);
 
       return CreateGoalResponseSchema.parse({
         id: savedGoal.id,

--- a/apps/frontend/src/features/goal/components/GoalBehaviorList.tsx
+++ b/apps/frontend/src/features/goal/components/GoalBehaviorList.tsx
@@ -4,6 +4,7 @@ import { DifficultyBadge } from '@/shared/components/behavior/DifficultyBadge';
 import { useGoalBehaviors } from '../hooks/useGoalBehaviors';
 
 type DifficultyFilter = 'ALL' | BehaviorDifficulty;
+const VISIBLE_DIFFICULTIES = BEHAVIOR_DIFFICULTIES.filter((difficulty) => difficulty !== 'AI');
 
 interface GoalBehaviorListProps {
   goalId: string;
@@ -49,7 +50,7 @@ export function GoalBehaviorList({ goalId }: GoalBehaviorListProps) {
         >
           전체 {behaviors?.length ?? 0}
         </button>
-        {BEHAVIOR_DIFFICULTIES.map((difficulty) => (
+        {VISIBLE_DIFFICULTIES.map((difficulty) => (
           <DifficultyBadge
             key={difficulty}
             level={difficulty}


### PR DESCRIPTION
## ✅ 작업 내용

- GET 템플릿이 안 나오는 버그 수정
- getGoalBehaviors에서 사용자가 만든 행동만 나오도록 변경, AI는 제외

## 💡 체크리스트

- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (예: `feature/login` -> `develop`)
- [x] 테스트는 잘 통과했나요?
- [x] 빌드에 성공했나요?

