### PR TITLE
feat: 오늘 행동 새로고침

### DIFF
--- a/apps/backend/src/common/database/migrations/1768877793736-auto.ts
+++ b/apps/backend/src/common/database/migrations/1768877793736-auto.ts
@@ -1,0 +1,31 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class Auto1768877793736 implements MigrationInterface {
+  name = 'Auto1768877793736';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TYPE "public"."today_behaviors_status_enum" RENAME TO "today_behaviors_status_enum_old"`,
+    );
+    await queryRunner.query(
+      `CREATE TYPE "public"."today_behaviors_status_enum" AS ENUM('pending', 'completed', 'skipped', 'ignored', 'deleted')`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "today_behaviors" ALTER COLUMN "status" TYPE "public"."today_behaviors_status_enum" USING "status"::"text"::"public"."today_behaviors_status_enum"`,
+    );
+    await queryRunner.query(`DROP TYPE "public"."today_behaviors_status_enum_old"`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TYPE "public"."today_behaviors_status_enum_old" AS ENUM('pending', 'completed', 'skipped', 'ignored')`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "today_behaviors" ALTER COLUMN "status" TYPE "public"."today_behaviors_status_enum_old" USING "status"::"text"::"public"."today_behaviors_status_enum_old"`,
+    );
+    await queryRunner.query(`DROP TYPE "public"."today_behaviors_status_enum"`);
+    await queryRunner.query(
+      `ALTER TYPE "public"."today_behaviors_status_enum_old" RENAME TO "today_behaviors_status_enum"`,
+    );
+  }
+}

--- a/apps/backend/src/features/behavior/behavior.docs.ts
+++ b/apps/backend/src/features/behavior/behavior.docs.ts
@@ -67,6 +67,22 @@ export function registerBehaviorApi(registry: OpenAPIRegistry, common: CommonSch
   });
 
   registry.registerPath({
+    method: 'post',
+    path: '/today-behaviors/refresh',
+    responses: {
+      200: {
+        description:
+          '오늘 행동을 새로 추출해 반환한다. 기존 pending은 skipped 처리하고, completed는 유지한다.',
+        content: {
+          'application/json': {
+            schema: getTodayBehaviorsResponse,
+          },
+        },
+      },
+    },
+  });
+
+  registry.registerPath({
     method: 'get',
     path: '/today-behaviors/ai',
     security: [{ sessionAuth: [] }],

--- a/apps/backend/src/features/behavior/behavior.service.spec.ts
+++ b/apps/backend/src/features/behavior/behavior.service.spec.ts
@@ -9,6 +9,7 @@ import { TodayBehavior } from './today-behavior.entity';
 import { AIBehavior } from './ai-behavior.entity';
 import { AIService } from '../ai/ai.service';
 import { Goal } from '../goal/goal.entity';
+import { User } from '../user/user.entity';
 
 jest.mock('crypto', () => ({ randomInt: jest.fn() }));
 
@@ -344,6 +345,212 @@ describe('BehaviorService', () => {
 
       expect(result.some((b) => b.difficulty === 'AI')).toBe(false);
       expect(totalScore).toBeLessThanOrEqual(totalTodayBehaviorScore);
+    });
+  });
+
+  describe('refreshTodayBehaviors', () => {
+    it('기존 행동을 재사용하고 skipped를 pending으로 되돌린다', async () => {
+      const user = { id: 'user-1', nickname: '테스트유저' };
+      const goal = { title: '건강한 생활', color: 'mint' };
+      const behavior1 = {
+        id: 'b-1',
+        title: '물 1컵 마시기',
+        difficulty: '마음열기',
+        goal,
+      } as Behavior;
+      const behavior2 = {
+        id: 'b-2',
+        title: '스트레칭',
+        difficulty: '시작하기',
+        goal,
+      } as Behavior;
+      const behavior3 = {
+        id: 'b-3',
+        title: '걷기',
+        difficulty: '이어가기',
+        goal,
+      } as Behavior;
+      const existing = [
+        { id: 'tb-1', status: 'completed', behavior: behavior1 },
+        { id: 'tb-2', status: 'skipped', behavior: behavior2 },
+        { id: 'tb-3', status: 'pending', behavior: behavior3 },
+      ] as TodayBehavior[];
+
+      const userQueryBuilder = {
+        setLock: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        getOne: jest.fn().mockResolvedValue(user),
+      };
+      const userRepository = {
+        createQueryBuilder: jest.fn().mockReturnValue(userQueryBuilder),
+      };
+      const todayRepository = {
+        find: jest.fn().mockResolvedValue(existing),
+        update: jest.fn().mockResolvedValue({ affected: 1 }),
+        create: jest.fn((value) => value),
+        save: jest.fn(),
+      };
+      const behaviorRepository = {
+        find: jest.fn().mockResolvedValue([behavior1, behavior2, behavior3]),
+      };
+      const manager = {
+        getRepository: (entity: unknown) => {
+          if (entity === (User as unknown)) return userRepository;
+          if (entity === (TodayBehavior as unknown)) return todayRepository;
+          if (entity === (Behavior as unknown)) return behaviorRepository;
+          return null;
+        },
+      };
+
+      dataSource.transaction.mockImplementation(async (work: (m: typeof manager) => unknown) =>
+        work(manager),
+      );
+      const extractSpy = jest
+        .spyOn(service, 'extractTodayBehaviors')
+        .mockReturnValue([behavior1, behavior2]);
+
+      const result = await service.refreshTodayBehaviors();
+
+      expect(userRepository.createQueryBuilder).toHaveBeenCalledWith('user');
+      expect(userQueryBuilder.setLock).toHaveBeenCalledWith('pessimistic_write');
+      expect(todayRepository.update).toHaveBeenNthCalledWith(
+        1,
+        { date: expect.any(String), user: { id: user.id }, status: 'pending' },
+        { status: 'skipped' },
+      );
+      expect(todayRepository.update).toHaveBeenNthCalledWith(
+        2,
+        { id: In(['tb-2']) },
+        { status: 'pending' },
+      );
+      expect(todayRepository.save).not.toHaveBeenCalled();
+      expect(result).toEqual([
+        {
+          id: 'tb-1',
+          title: '물 1컵 마시기',
+          goalTitle: '건강한 생활',
+          goalColor: 'mint',
+          difficulty: '마음열기',
+          isChecked: true,
+          isRecommended: false,
+        },
+        {
+          id: 'tb-2',
+          title: '스트레칭',
+          goalTitle: '건강한 생활',
+          goalColor: 'mint',
+          difficulty: '시작하기',
+          isChecked: false,
+          isRecommended: false,
+        },
+      ]);
+      extractSpy.mockRestore();
+    });
+
+    it('추출 결과가 없으면 빈 배열을 반환한다', async () => {
+      const user = { id: 'user-1', nickname: '테스트유저' };
+
+      const userQueryBuilder = {
+        setLock: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        getOne: jest.fn().mockResolvedValue(user),
+      };
+      const userRepository = {
+        createQueryBuilder: jest.fn().mockReturnValue(userQueryBuilder),
+      };
+      const todayRepository = {
+        find: jest.fn().mockResolvedValue([]),
+        update: jest.fn().mockResolvedValue({ affected: 0 }),
+        create: jest.fn((value) => value),
+        save: jest.fn(),
+      };
+      const behaviorRepository = {
+        find: jest.fn().mockResolvedValue([]),
+      };
+      const manager = {
+        getRepository: (entity: unknown) => {
+          if (entity === (User as unknown)) return userRepository;
+          if (entity === (TodayBehavior as unknown)) return todayRepository;
+          if (entity === (Behavior as unknown)) return behaviorRepository;
+          return null;
+        },
+      };
+
+      dataSource.transaction.mockImplementation(async (work: (m: typeof manager) => unknown) =>
+        work(manager),
+      );
+      const extractSpy = jest.spyOn(service, 'extractTodayBehaviors').mockReturnValue([]);
+
+      const result = await service.refreshTodayBehaviors();
+
+      expect(todayRepository.update).toHaveBeenCalledWith(
+        { date: expect.any(String), user: { id: user.id }, status: 'pending' },
+        { status: 'skipped' },
+      );
+      expect(todayRepository.save).not.toHaveBeenCalled();
+      expect(result).toEqual([]);
+      extractSpy.mockRestore();
+    });
+
+    it('기존 행동이 없으면 새로 저장하고 반환한다', async () => {
+      const user = { id: 'user-1', nickname: '테스트유저' };
+      const behavior = {
+        id: 'b-1',
+        title: '물 1컵 마시기',
+        difficulty: '마음열기',
+        goal: { title: '건강한 생활', color: 'mint' },
+      } as Behavior;
+
+      const userQueryBuilder = {
+        setLock: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        getOne: jest.fn().mockResolvedValue(user),
+      };
+      const userRepository = {
+        createQueryBuilder: jest.fn().mockReturnValue(userQueryBuilder),
+      };
+      const todayRepository = {
+        find: jest.fn().mockResolvedValue([]),
+        update: jest.fn().mockResolvedValue({ affected: 1 }),
+        create: jest.fn((value) => value),
+        save: jest.fn().mockResolvedValue([{ id: 'tb-new', status: 'pending' }]),
+      };
+      const behaviorRepository = {
+        find: jest.fn().mockResolvedValue([behavior]),
+      };
+      const manager = {
+        getRepository: (entity: unknown) => {
+          if (entity === (User as unknown)) return userRepository;
+          if (entity === (TodayBehavior as unknown)) return todayRepository;
+          if (entity === (Behavior as unknown)) return behaviorRepository;
+          return null;
+        },
+      };
+
+      dataSource.transaction.mockImplementation(async (work: (m: typeof manager) => unknown) =>
+        work(manager),
+      );
+      const extractSpy = jest.spyOn(service, 'extractTodayBehaviors').mockReturnValue([behavior]);
+
+      const result = await service.refreshTodayBehaviors();
+
+      expect(todayRepository.update).toHaveBeenCalledWith(
+        { date: expect.any(String), user: { id: user.id }, status: 'pending' },
+        { status: 'skipped' },
+      );
+      expect(todayRepository.save).toHaveBeenCalledTimes(1);
+      expect(result).toEqual([
+        {
+          id: 'tb-new',
+          title: '물 1컵 마시기',
+          goalTitle: '건강한 생활',
+          goalColor: 'mint',
+          difficulty: '마음열기',
+          isChecked: false,
+          isRecommended: false,
+        },
+      ]);
+      extractSpy.mockRestore();
     });
   });
 

--- a/apps/backend/src/features/behavior/behavior.service.spec.ts
+++ b/apps/backend/src/features/behavior/behavior.service.spec.ts
@@ -385,7 +385,7 @@ describe('BehaviorService', () => {
         createQueryBuilder: jest.fn().mockReturnValue(userQueryBuilder),
       };
       const todayRepository = {
-        find: jest.fn().mockResolvedValue(existing),
+        find: jest.fn().mockResolvedValueOnce(existing).mockResolvedValueOnce([]),
         update: jest.fn().mockResolvedValue({ affected: 1 }),
         create: jest.fn((value) => value),
         save: jest.fn(),
@@ -409,10 +409,19 @@ describe('BehaviorService', () => {
         .spyOn(service, 'extractTodayBehaviors')
         .mockReturnValue([behavior1, behavior2]);
 
-      const result = await service.refreshTodayBehaviors();
+      const result = await service.refreshTodayBehaviors(user.id);
 
       expect(userRepository.createQueryBuilder).toHaveBeenCalledWith('user');
       expect(userQueryBuilder.setLock).toHaveBeenCalledWith('pessimistic_write');
+      expect(userQueryBuilder.where).toHaveBeenCalledWith('user.id = :id', { id: user.id });
+      expect(todayRepository.find).toHaveBeenNthCalledWith(1, {
+        where: {
+          date: expect.any(String),
+          user: { id: user.id },
+          status: Not(In(['deleted'])),
+        },
+        relations: { behavior: { goal: true }, user: true },
+      });
       expect(todayRepository.update).toHaveBeenNthCalledWith(
         1,
         { date: expect.any(String), user: { id: user.id }, status: 'pending' },
@@ -481,8 +490,9 @@ describe('BehaviorService', () => {
       );
       const extractSpy = jest.spyOn(service, 'extractTodayBehaviors').mockReturnValue([]);
 
-      const result = await service.refreshTodayBehaviors();
+      const result = await service.refreshTodayBehaviors(user.id);
 
+      expect(userQueryBuilder.where).toHaveBeenCalledWith('user.id = :id', { id: user.id });
       expect(todayRepository.update).toHaveBeenCalledWith(
         { date: expect.any(String), user: { id: user.id }, status: 'pending' },
         { status: 'skipped' },
@@ -532,8 +542,9 @@ describe('BehaviorService', () => {
       );
       const extractSpy = jest.spyOn(service, 'extractTodayBehaviors').mockReturnValue([behavior]);
 
-      const result = await service.refreshTodayBehaviors();
+      const result = await service.refreshTodayBehaviors(user.id);
 
+      expect(userQueryBuilder.where).toHaveBeenCalledWith('user.id = :id', { id: user.id });
       expect(todayRepository.update).toHaveBeenCalledWith(
         { date: expect.any(String), user: { id: user.id }, status: 'pending' },
         { status: 'skipped' },

--- a/apps/backend/src/features/behavior/behavior.service.ts
+++ b/apps/backend/src/features/behavior/behavior.service.ts
@@ -92,7 +92,7 @@ export class BehaviorService {
     return { id, status };
   }
 
-  async refreshTodayBehaviors() {
+  async refreshTodayBehaviors(userId: string) {
     return this.dataSource.transaction(async (manager) => {
       const todayDate = getKstDayKey();
 
@@ -101,7 +101,7 @@ export class BehaviorService {
         .getRepository(User)
         .createQueryBuilder('user')
         .setLock('pessimistic_write')
-        .where('user.nickname = :nickname', { nickname: '테스트유저' })
+        .where('user.id = :id', { id: userId })
         .getOne();
       if (!user) {
         throw new NotFoundException('User not found');

--- a/apps/backend/src/features/behavior/behavior.service.ts
+++ b/apps/backend/src/features/behavior/behavior.service.ts
@@ -111,7 +111,11 @@ export class BehaviorService {
       const behaviorRepository = manager.getRepository(Behavior);
 
       const existingTodayBehaviors = await todayBehaviorRepository.find({
-        where: { date: todayDate, user: { id: user.id } },
+        where: {
+          date: todayDate,
+          user: { id: user.id },
+          status: Not(In(['deleted'])),
+        },
         relations: { behavior: { goal: true }, user: true },
       });
 
@@ -125,7 +129,20 @@ export class BehaviorService {
         relations: { goal: true },
       });
 
-      const extractedTodayBehavior = this.extractTodayBehaviors(behaviors);
+      const deletedTodayBehaviors = await todayBehaviorRepository.find({
+        where: { date: todayDate, user: { id: user.id }, status: 'deleted' },
+        relations: { behavior: true },
+      });
+
+      const deletedBehaviorIds = new Set(
+        deletedTodayBehaviors.map((todayBehavior) => todayBehavior.behavior.id),
+      );
+
+      const candidateBehaviors = behaviors.filter(
+        (behavior) => !deletedBehaviorIds.has(behavior.id),
+      );
+
+      const extractedTodayBehavior = this.extractTodayBehaviors(candidateBehaviors);
       if (extractedTodayBehavior.length === 0) {
         return [];
       }

--- a/apps/backend/src/features/behavior/behavior.service.ts
+++ b/apps/backend/src/features/behavior/behavior.service.ts
@@ -92,6 +92,114 @@ export class BehaviorService {
     return { id, status };
   }
 
+  async refreshTodayBehaviors() {
+    return this.dataSource.transaction(async (manager) => {
+      const todayDate = getKstDayKey();
+
+      // 같은 사용자에 대한 새로고침을 직렬화해 중복 생성을 방지한다.
+      const user = await manager
+        .getRepository(User)
+        .createQueryBuilder('user')
+        .setLock('pessimistic_write')
+        .where('user.nickname = :nickname', { nickname: '테스트유저' })
+        .getOne();
+      if (!user) {
+        throw new NotFoundException('User not found');
+      }
+
+      const todayBehaviorRepository = manager.getRepository(TodayBehavior);
+      const behaviorRepository = manager.getRepository(Behavior);
+
+      const existingTodayBehaviors = await todayBehaviorRepository.find({
+        where: { date: todayDate, user: { id: user.id } },
+        relations: { behavior: { goal: true }, user: true },
+      });
+
+      // 새로고침 전에 기존 pending을 skipped로 변경한다.
+      await todayBehaviorRepository.update(
+        { date: todayDate, user: { id: user.id }, status: 'pending' },
+        { status: 'skipped' },
+      );
+
+      const behaviors = await behaviorRepository.find({
+        relations: { goal: true },
+      });
+
+      const extractedTodayBehavior = this.extractTodayBehaviors(behaviors);
+      if (extractedTodayBehavior.length === 0) {
+        return [];
+      }
+
+      // behaviorId 기준으로 중복을 제거하고, 기존 row를 재사용한다.
+      const existingByBehaviorId = new Map(
+        existingTodayBehaviors.map((todayBehavior) => [todayBehavior.behavior.id, todayBehavior]),
+      );
+
+      // 새로 삽입할 today-behaviors row
+      const toInsert: TodayBehavior[] = [];
+      // pending으로 되돌릴 기존 today-behaviors id 목록
+      const toRestoreIds: string[] = [];
+      // 이번 새로고침에 포함된 기존 today-behaviors
+      const selectedExisting: TodayBehavior[] = [];
+
+      extractedTodayBehavior.forEach((behavior) => {
+        const existing = existingByBehaviorId.get(behavior.id);
+        if (existing) {
+          // completed는 유지하고, 나머지는 pending으로 복구한다.
+          if (existing.status !== 'completed') {
+            toRestoreIds.push(existing.id);
+            existing.status = 'pending';
+          }
+          selectedExisting.push(existing);
+          return;
+        }
+
+        // 새로 선택된 행동은 today-behaviors row를 생성한다.
+        toInsert.push(
+          todayBehaviorRepository.create({
+            date: todayDate,
+            status: 'pending',
+            origin: 'system',
+            user,
+            behavior,
+          }),
+        );
+      });
+
+      if (toRestoreIds.length > 0) {
+        await todayBehaviorRepository.update({ id: In(toRestoreIds) }, { status: 'pending' });
+      }
+
+      const newTodayBehaviors =
+        toInsert.length > 0 ? await todayBehaviorRepository.save(toInsert) : [];
+
+      // TodayBehavior를 응답 형태로 매핑한다(관계 누락 시 fallback 사용).
+      const mapToResponse = (todayBehavior: TodayBehavior, fallbackBehavior?: Behavior) => {
+        const behavior = todayBehavior.behavior ?? fallbackBehavior;
+        if (!behavior) {
+          throw new NotFoundException('Behavior not found');
+        }
+
+        return {
+          id: todayBehavior.id,
+          title: behavior.title,
+          goalTitle: behavior.goal.title,
+          goalColor: behavior.goal.color,
+          difficulty: behavior.difficulty,
+          isChecked: todayBehavior.status === 'completed',
+          isRecommended: false,
+        };
+      };
+
+      return [
+        ...selectedExisting.map((behavior) => mapToResponse(behavior)),
+        ...newTodayBehaviors.map((behavior, index) =>
+          mapToResponse(behavior, toInsert[index]?.behavior),
+        ),
+      ];
+    });
+  }
+
   extractTodayBehaviors(behaviors: Behavior[]): Behavior[] {
     const LEVEL_SCORE = {
       마음열기: 1,

--- a/apps/backend/src/features/behavior/today-behavior.controller.spec.ts
+++ b/apps/backend/src/features/behavior/today-behavior.controller.spec.ts
@@ -7,6 +7,7 @@ describe('TodayBehaviorController', () => {
   let service: {
     updateTodayBehaviorStatus: jest.Mock;
     getTodayBehaviors: jest.Mock;
+    refreshTodayBehaviors: jest.Mock;
     getAIBehaviors: jest.Mock;
     createAIBehaviors: jest.Mock;
     updateAIBehaviorStatus: jest.Mock;
@@ -16,6 +17,7 @@ describe('TodayBehaviorController', () => {
     service = {
       updateTodayBehaviorStatus: jest.fn(),
       getTodayBehaviors: jest.fn(),
+      refreshTodayBehaviors: jest.fn(),
       getAIBehaviors: jest.fn(),
       createAIBehaviors: jest.fn(),
       updateAIBehaviorStatus: jest.fn(),
@@ -45,6 +47,27 @@ describe('TodayBehaviorController', () => {
 
       expect(service.getTodayBehaviors).toHaveBeenCalledWith(userId);
       expect(result).toBe(mock);
+    });
+  });
+
+  describe('refreshTodayBehaviors', () => {
+    it('서비스 결과를 반환한다', async () => {
+      const mock = [{ id: 'refreshed-1' }];
+      service.refreshTodayBehaviors.mockResolvedValue(mock);
+
+      const result = await controller.refreshTodayBehaviors();
+
+      expect(service.refreshTodayBehaviors).toHaveBeenCalledTimes(1);
+      expect(result).toBe(mock);
+    });
+
+    it('행동이 없으면 빈 배열을 반환한다', async () => {
+      service.refreshTodayBehaviors.mockResolvedValue([]);
+
+      const result = await controller.refreshTodayBehaviors();
+
+      expect(service.refreshTodayBehaviors).toHaveBeenCalledTimes(1);
+      expect(result).toEqual([]);
     });
   });
 

--- a/apps/backend/src/features/behavior/today-behavior.controller.spec.ts
+++ b/apps/backend/src/features/behavior/today-behavior.controller.spec.ts
@@ -55,18 +55,18 @@ describe('TodayBehaviorController', () => {
       const mock = [{ id: 'refreshed-1' }];
       service.refreshTodayBehaviors.mockResolvedValue(mock);
 
-      const result = await controller.refreshTodayBehaviors();
+      const result = await controller.refreshTodayBehaviors('user-1');
 
-      expect(service.refreshTodayBehaviors).toHaveBeenCalledTimes(1);
+      expect(service.refreshTodayBehaviors).toHaveBeenCalledWith('user-1');
       expect(result).toBe(mock);
     });
 
     it('행동이 없으면 빈 배열을 반환한다', async () => {
       service.refreshTodayBehaviors.mockResolvedValue([]);
 
-      const result = await controller.refreshTodayBehaviors();
+      const result = await controller.refreshTodayBehaviors('user-1');
 
-      expect(service.refreshTodayBehaviors).toHaveBeenCalledTimes(1);
+      expect(service.refreshTodayBehaviors).toHaveBeenCalledWith('user-1');
       expect(result).toEqual([]);
     });
   });

--- a/apps/backend/src/features/behavior/today-behavior.controller.ts
+++ b/apps/backend/src/features/behavior/today-behavior.controller.ts
@@ -10,6 +10,7 @@ import {
 } from '@nestjs/common';
 import {
   type GetAIBehaviorResponse,
+  type GetTodayBehaviorsResponse,
   type PatchAIBehaviorStatusRequest,
   PatchAIBehaviorStatusRequestSchema,
   PatchAIBehaviorStatusResponse,
@@ -31,6 +32,11 @@ export class TodayBehaviorController {
   @Get()
   async getTodayBehaviors(@UserId() userId: string) {
     return this.behaviorService.getTodayBehaviors(userId);
+  }
+
+  @Post('/refresh')
+  async refreshTodayBehaviors(): Promise<GetTodayBehaviorsResponse> {
+    return this.behaviorService.refreshTodayBehaviors();
   }
 
   @Get('/ai')

--- a/apps/backend/src/features/behavior/today-behavior.controller.ts
+++ b/apps/backend/src/features/behavior/today-behavior.controller.ts
@@ -35,8 +35,8 @@ export class TodayBehaviorController {
   }
 
   @Post('/refresh')
-  async refreshTodayBehaviors(): Promise<GetTodayBehaviorsResponse> {
-    return this.behaviorService.refreshTodayBehaviors();
+  async refreshTodayBehaviors(@UserId() userId: string): Promise<GetTodayBehaviorsResponse> {
+    return this.behaviorService.refreshTodayBehaviors(userId);
   }
 
   @Get('/ai')

--- a/apps/frontend/src/features/behavior/apis/refreshTodayBehaviors.api.spec.ts
+++ b/apps/frontend/src/features/behavior/apis/refreshTodayBehaviors.api.spec.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import type { Behavior } from '@/shared/components/behavior/BehaviorCard.types';
+import { refreshTodayBehaviors } from './refreshTodayBehaviors.api';
+
+describe('refreshTodayBehaviors', () => {
+  const mockBehaviors: Behavior[] = [
+    {
+      id: '1',
+      title: '행동 1',
+      goalTitle: '목표 A',
+      goalColor: 'beige',
+      isChecked: false,
+      difficulty: '시작하기',
+      isRecommended: true,
+    },
+  ];
+
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns behaviors on success', async () => {
+    (fetch as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockBehaviors,
+    });
+
+    const result = await refreshTodayBehaviors();
+
+    expect(result).toEqual(mockBehaviors);
+    expect(fetch).toHaveBeenCalledWith('/api/today-behaviors/refresh', expect.any(Object));
+  });
+
+  it('throws error on fetch failure', async () => {
+    (fetch as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: false,
+    });
+
+    await expect(refreshTodayBehaviors()).rejects.toThrow('Failed to fetch');
+  });
+});

--- a/apps/frontend/src/features/behavior/apis/refreshTodayBehaviors.api.ts
+++ b/apps/frontend/src/features/behavior/apis/refreshTodayBehaviors.api.ts
@@ -1,0 +1,16 @@
+import type { Behavior } from '@/shared/components/behavior/BehaviorCard.types';
+
+export async function refreshTodayBehaviors(): Promise<Behavior[]> {
+  const res = await fetch('/api/today-behaviors/refresh', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  });
+
+  if (!res.ok) {
+    throw new Error('Failed to fetch');
+  }
+
+  return res.json();
+}

--- a/apps/frontend/src/features/behavior/components/TodayBehaviorList.tsx
+++ b/apps/frontend/src/features/behavior/components/TodayBehaviorList.tsx
@@ -1,7 +1,7 @@
 import { useState, useMemo } from 'react';
 import { BehaviorCard } from '@/shared/components/behavior/BehaviorCard';
 import type { Behavior } from '@/shared/components/behavior/BehaviorCard.types';
-import { Plus, Info } from 'lucide-react';
+import { Plus, Info, RefreshCw } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import { toast } from 'react-toastify';
 import { ICON_SIZE } from '@/shared/constants/icon';
@@ -11,9 +11,10 @@ interface BehaviorListProps {
   goals: string[];
   behaviors: Behavior[];
   onToggle: (id: string) => void;
+  onRefresh?: () => void;
 }
 
-export function TodayBahaviorList({ goals, behaviors, onToggle }: BehaviorListProps) {
+export function TodayBahaviorList({ goals, behaviors, onToggle, onRefresh }: BehaviorListProps) {
   const [activeGoal, setActiveGoal] = useState<string>('ALL');
   const navigate = useNavigate();
 
@@ -45,6 +46,16 @@ export function TodayBahaviorList({ goals, behaviors, onToggle }: BehaviorListPr
             </span>
           </span>
         </h3>
+        {onRefresh && (
+          <button
+            type="button"
+            onClick={onRefresh}
+            className="text-label-disable hover:text-label-normal inline-flex items-center gap-1 text-sm font-semibold transition"
+          >
+            <RefreshCw size={16} />
+            새로고침
+          </button>
+        )}
       </div>
 
       {/* 목표 필터 탭 스와이퍼 */}

--- a/apps/frontend/src/pages/IndexPage.tsx
+++ b/apps/frontend/src/pages/IndexPage.tsx
@@ -9,6 +9,8 @@ import { fetchGoals } from '@/features/goal/apis/fetchGoals.api';
 import { updateTodayBehaviorStatus } from '@/features/behavior/apis/updateTodayBehaviorStatus.api';
 import { useAIBehaviors } from '@/features/behavior/hooks/useAIBehaviors';
 import { updateAIBehaviorStatus } from '@/features/behavior/apis/updateAIBehaviorStatus.api';
+import { refreshTodayBehaviors } from '@/features/behavior/apis/refreshTodayBehaviors.api';
+import { toast } from 'react-toastify';
 
 export function IndexPage() {
   const [behaviors, setBehaviors] = useState<Behavior[]>([]);
@@ -53,6 +55,14 @@ export function IndexPage() {
     updateAIBehaviorStatus(id, nextStatus).catch(() => toggleAIBehaviorIsChecked(id));
   };
 
+  const handleRefreshTodayBehaviors = () => {
+    refreshTodayBehaviors()
+      .then((refreshedBehaviors) => setBehaviors(refreshedBehaviors))
+      .catch(() => {
+        toast('새로고침에 실패했습니다.');
+      });
+  };
+
   useEffect(() => {
     Promise.all([fetchTodayBehaviors(), fetchGoals()]).then(([behaviorsData, goalsData]) => {
       setBehaviors(behaviorsData);
@@ -81,7 +91,12 @@ export function IndexPage() {
       />
 
       {/* 오늘의 행동 */}
-      <TodayBahaviorList goals={goalTitles} behaviors={behaviors} onToggle={handleBehaviorToggle} />
+      <TodayBahaviorList
+        goals={goalTitles}
+        behaviors={behaviors}
+        onToggle={handleBehaviorToggle}
+        onRefresh={handleRefreshTodayBehaviors}
+      />
     </div>
   );
 }

--- a/packages/shared/src/types/behavior.types.ts
+++ b/packages/shared/src/types/behavior.types.ts
@@ -8,7 +8,13 @@ export const BEHAVIOR_DIFFICULTIES = [
 
 export type BehaviorDifficulty = (typeof BEHAVIOR_DIFFICULTIES)[number];
 
-export const TODAY_BEHAVIOR_STATUS = ['pending', 'completed', 'skipped', 'ignored'] as const;
+export const TODAY_BEHAVIOR_STATUS = [
+  'pending',
+  'completed',
+  'skipped',
+  'ignored',
+  'deleted',
+] as const;
 
 export type TodayBehaviorStatus = (typeof TODAY_BEHAVIOR_STATUS)[number];
 


### PR DESCRIPTION
<!-- PR 제목 예시 : feat: 로그인 기능 구현 -->
<!-- PR 제목은 위 형식을 참고하여 작성해주세요. -->
<!-- 필요 없는 내용은 지우고 작성해주세요 -->

## 🔗 관련 이슈

- close: #157 

## ✅ 작업 내용

<!-- 구현한 기능이나 수정한 내용을 상세히 기술해주세요. -->

- 오늘 행동 새로고침 버튼 추가
- POST /api/today-behaviors/refresh 추가
  - 완료된 행동도 새로고침 이후의 오늘 행동에 포함 가능
  - 새로고침으로 오늘행동에 포함되지 않은 기존 오늘행동은 skipped로 status 변경

## 📸 스크린샷 / 데모 (옵션)

<!-- UI 변경사항이나 새로운 기능의 동작을 시각적으로 보여주세요. -->
<img width="1041" height="240" alt="image" src="https://github.com/user-attachments/assets/04ccaeff-5c62-48c8-8a14-459f84f6bbaa" />


## 🧪 테스트 방법 (옵션)

<!-- 리뷰어가 기능을 테스트할 수 있도록 구체적인 테스트 방법을 설명해주세요. -->

1. 메인페이지 새로고침 버튼을 클릭한다
2. 새로운 오늘 행동 목록이 조회되는지 확인한다

## 💡 체크리스트

<!-- PR을 제출하기 전에 아래 항목들을 확인해주세요. -->

- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (예: `feature/login` -> `develop`)
- [x] 테스트는 잘 통과했나요?
- [x] 빌드에 성공했나요?

## 💬 To Reviewers

<!-- 리뷰어에게 전달하고 싶은 내용이나 특별히 확인이 필요한 부분을 작성해주세요. -->
오늘 행동 새로고침을 기존 추출 알고리즘을 간단하게 재사용하는 방향으로 구현했습니다. 완료된 오늘 행동은 새로고침 이후의 오늘 행동에서 제외시킬까 고려해보았지만 완료 표시한 행동이 사라지는게 문제가 될 수 있다고 생각해 포함시켰습니다.