### PR TITLE
feat: 목표 편집 / 목표 요약 UI 구현

### DIFF
--- a/apps/backend/src/features/goal/goal.controller.ts
+++ b/apps/backend/src/features/goal/goal.controller.ts
@@ -111,8 +111,9 @@ export class GoalController {
   async updateGoal(
     @Param('id', new ParseUUIDPipe()) id: string,
     @Body(new ZodValidationPipe(UpdateGoalRequestSchema)) body: UpdateGoalRequest,
+    @UserId() userId: string,
   ): Promise<UpdateGoalResponse> {
-    return this.goalService.updateGoal(id, body);
+    return this.goalService.updateGoal(userId, id, body);
   }
 
   @Post(':goalId/behaviors')
@@ -120,8 +121,9 @@ export class GoalController {
     @Param('goalId', new ParseUUIDPipe()) goalId: string,
     @Body(new ZodValidationPipe(CreateGoalBehaviorsRequestSchema))
     body: CreateGoalBehaviorsRequest,
+    @UserId() userId: string,
   ): Promise<void> {
-    return this.goalService.createGoalBehaviors(goalId, body);
+    return this.goalService.createGoalBehaviors(userId, goalId, body);
   }
 
   @Patch(':goalId/behaviors')
@@ -129,15 +131,17 @@ export class GoalController {
     @Param('goalId', new ParseUUIDPipe()) goalId: string,
     @Body(new ZodValidationPipe(UpdateGoalBehaviorsRequestSchema))
     body: UpdateGoalBehaviorsRequest,
+    @UserId() userId: string,
   ): Promise<void> {
-    return this.goalService.updateGoalBehaviors(goalId, body);
+    return this.goalService.updateGoalBehaviors(userId, goalId, body);
   }
 
   @Delete(':goalId/behaviors')
   async deleteGoalBehaviors(
     @Param('goalId', new ParseUUIDPipe()) goalId: string,
     @Body(new ZodValidationPipe(DeleteGoalBehaviorsRequestSchema)) body: DeleteGoalBehaviorsRequest,
+    @UserId() userId: string,
   ): Promise<void> {
-    return this.goalService.deleteGoalBehaviors(goalId, body);
+    return this.goalService.deleteGoalBehaviors(userId, goalId, body);
   }
 }

--- a/apps/backend/src/features/goal/goal.controller.ts
+++ b/apps/backend/src/features/goal/goal.controller.ts
@@ -1,4 +1,15 @@
-import { Body, Controller, Get, Param, ParseUUIDPipe, Post, Put, UseGuards } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  ParseUUIDPipe,
+  Patch,
+  Post,
+  Put,
+  UseGuards,
+} from '@nestjs/common';
 import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 
@@ -14,8 +25,13 @@ import {
   GoalTemplateListResponse,
   type UpdateGoalRequest,
   type UpdateGoalResponse,
+  CreateGoalBehaviorsRequestSchema,
+  UpdateGoalBehaviorsRequestSchema,
+  DeleteGoalBehaviorsRequestSchema,
+  type DeleteGoalBehaviorsRequest,
+  type UpdateGoalBehaviorsRequest,
+  type CreateGoalBehaviorsRequest,
 } from '@web24/shared';
-import { ZodType } from 'zod';
 import { ZodValidationPipe } from '../../common/pipes/zod-validation.pipe';
 import { SessionAuthGuard } from '../../common/guards/session-auth.guard';
 import { UserId } from '../../common/decorators/user-id.decorator';
@@ -94,8 +110,34 @@ export class GoalController {
   @Put(':id')
   async updateGoal(
     @Param('id', new ParseUUIDPipe()) id: string,
-    @Body(new ZodValidationPipe(UpdateGoalRequestSchema as ZodType)) body: UpdateGoalRequest,
+    @Body(new ZodValidationPipe(UpdateGoalRequestSchema)) body: UpdateGoalRequest,
   ): Promise<UpdateGoalResponse> {
     return this.goalService.updateGoal(id, body);
+  }
+
+  @Post(':goalId/behaviors')
+  async createGoalBehaviors(
+    @Param('goalId', new ParseUUIDPipe()) goalId: string,
+    @Body(new ZodValidationPipe(CreateGoalBehaviorsRequestSchema))
+    body: CreateGoalBehaviorsRequest,
+  ): Promise<void> {
+    return this.goalService.createGoalBehaviors(goalId, body);
+  }
+
+  @Patch(':goalId/behaviors')
+  async updateGoalBehaviors(
+    @Param('goalId', new ParseUUIDPipe()) goalId: string,
+    @Body(new ZodValidationPipe(UpdateGoalBehaviorsRequestSchema))
+    body: UpdateGoalBehaviorsRequest,
+  ): Promise<void> {
+    return this.goalService.updateGoalBehaviors(goalId, body);
+  }
+
+  @Delete(':goalId/behaviors')
+  async deleteGoalBehaviors(
+    @Param('goalId', new ParseUUIDPipe()) goalId: string,
+    @Body(new ZodValidationPipe(DeleteGoalBehaviorsRequestSchema)) body: DeleteGoalBehaviorsRequest,
+  ): Promise<void> {
+    return this.goalService.deleteGoalBehaviors(goalId, body);
   }
 }

--- a/apps/backend/src/features/goal/goal.controller.ts
+++ b/apps/backend/src/features/goal/goal.controller.ts
@@ -1,17 +1,21 @@
-import { Body, Controller, Get, Param, ParseUUIDPipe, Post, UseGuards } from '@nestjs/common';
+import { Body, Controller, Get, Param, ParseUUIDPipe, Post, Put, UseGuards } from '@nestjs/common';
 import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 
 import {
   CreateGoalRequestSchema,
+  UpdateGoalRequestSchema,
   GetGoalsResponse,
   type GetGoalStampsResponse,
   type GetGoalResponse,
   GoalTemplateListResponseSchema,
   type CreateGoalRequest,
   type CreateGoalResponse,
-  type GoalTemplateListResponse,
+  GoalTemplateListResponse,
+  type UpdateGoalRequest,
+  type UpdateGoalResponse,
 } from '@web24/shared';
+import { ZodType } from 'zod';
 import { ZodValidationPipe } from '../../common/pipes/zod-validation.pipe';
 import { SessionAuthGuard } from '../../common/guards/session-auth.guard';
 import { UserId } from '../../common/decorators/user-id.decorator';
@@ -85,5 +89,13 @@ export class GoalController {
     @Body(new ZodValidationPipe(CreateGoalRequestSchema)) body: CreateGoalRequest,
   ): Promise<CreateGoalResponse> {
     return this.goalService.createGoal(userId, body);
+  }
+
+  @Put(':id')
+  async updateGoal(
+    @Param('id', new ParseUUIDPipe()) id: string,
+    @Body(new ZodValidationPipe(UpdateGoalRequestSchema as ZodType)) body: UpdateGoalRequest,
+  ): Promise<UpdateGoalResponse> {
+    return this.goalService.updateGoal(id, body);
   }
 }

--- a/apps/backend/src/features/goal/goal.docs.ts
+++ b/apps/backend/src/features/goal/goal.docs.ts
@@ -9,6 +9,9 @@ import {
   GetGoalStampsResponseSchema,
   UpdateGoalRequestSchema,
   UpdateGoalResponseSchema,
+  CreateGoalBehaviorsRequestSchema,
+  UpdateGoalBehaviorsRequestSchema,
+  DeleteGoalBehaviorsRequestSchema,
 } from '@web24/shared';
 
 export function registerGoalApi(registry: OpenAPIRegistry) {
@@ -29,6 +32,18 @@ export function registerGoalApi(registry: OpenAPIRegistry) {
   const getGoalStampsResponse = registry.register(
     'GetGoalStampsResponse',
     GetGoalStampsResponseSchema,
+  );
+  const createGoalBehaviorsRequest = registry.register(
+    'CreateGoalBehaviorsRequest',
+    CreateGoalBehaviorsRequestSchema,
+  );
+  const updateGoalBehaviorsRequest = registry.register(
+    'UpdateGoalBehaviorsRequest',
+    UpdateGoalBehaviorsRequestSchema,
+  );
+  const deleteGoalBehaviorsRequest = registry.register(
+    'DeleteGoalBehaviorsRequest',
+    DeleteGoalBehaviorsRequestSchema,
   );
 
   registry.registerPath({
@@ -162,6 +177,66 @@ export function registerGoalApi(registry: OpenAPIRegistry) {
             schema: getGoalStampsResponse,
           },
         },
+      },
+    },
+  });
+
+  registry.registerPath({
+    method: 'post',
+    path: '/goals/{goalId}/behaviors',
+    summary: '목표에 새로운 행동 추가',
+    request: {
+      body: {
+        content: {
+          'application/json': {
+            schema: createGoalBehaviorsRequest,
+          },
+        },
+      },
+    },
+    responses: {
+      201: {
+        description: '행동 생성 성공',
+      },
+    },
+  });
+
+  registry.registerPath({
+    method: 'patch',
+    path: '/goals/{goalId}/behaviors',
+    summary: '목표의 행동 목록 수정',
+    request: {
+      body: {
+        content: {
+          'application/json': {
+            schema: updateGoalBehaviorsRequest,
+          },
+        },
+      },
+    },
+    responses: {
+      200: {
+        description: '행동 수정 성공',
+      },
+    },
+  });
+
+  registry.registerPath({
+    method: 'delete',
+    path: '/goals/{goalId}/behaviors',
+    summary: '목표의 행동 목록 삭제',
+    request: {
+      body: {
+        content: {
+          'application/json': {
+            schema: deleteGoalBehaviorsRequest,
+          },
+        },
+      },
+    },
+    responses: {
+      200: {
+        description: '행동 삭제 성공',
       },
     },
   });

--- a/apps/backend/src/features/goal/goal.docs.ts
+++ b/apps/backend/src/features/goal/goal.docs.ts
@@ -7,12 +7,16 @@ import {
   GoalTemplateListResponseSchema,
   GetGoalBehaviorsResponseSchema,
   GetGoalStampsResponseSchema,
+  UpdateGoalRequestSchema,
+  UpdateGoalResponseSchema,
 } from '@web24/shared';
 
 export function registerGoalApi(registry: OpenAPIRegistry) {
   const getGoalsResponse = registry.register('GetGoalsResponse', GetGoalsResponseSchema);
   const createGoalRequest = registry.register('CreateGoalRequest', CreateGoalRequestSchema);
   const createGoalResponse = registry.register('CreateGoalResponse', CreateGoalResponseSchema);
+  const updateGoalRequest = registry.register('UpdateGoalRequest', UpdateGoalRequestSchema);
+  const updateGoalResponse = registry.register('UpdateGoalResponse', UpdateGoalResponseSchema);
   const getGoalResponse = registry.register('GetGoalResponse', GetGoalResponseSchema);
   const getGoalTemplatesResponse = registry.register(
     'GetGoalTemplatesResponse',
@@ -64,6 +68,36 @@ export function registerGoalApi(registry: OpenAPIRegistry) {
             schema: createGoalResponse,
           },
         },
+      },
+    },
+  });
+
+  registry.registerPath({
+    method: 'put',
+    path: '/goals/{id}',
+    request: {
+      body: {
+        content: {
+          'application/json': {
+            schema: updateGoalRequest,
+          },
+        },
+      },
+    },
+    responses: {
+      200: {
+        description: 'Goal updated',
+        content: {
+          'application/json': {
+            schema: updateGoalResponse,
+          },
+        },
+      },
+      400: {
+        description: 'Validation failed',
+      },
+      404: {
+        description: 'Goal not found',
       },
     },
   });

--- a/apps/backend/src/features/goal/goal.service.spec.ts
+++ b/apps/backend/src/features/goal/goal.service.spec.ts
@@ -385,7 +385,7 @@ describe('GoalService', () => {
         color: 'blue',
       };
 
-      const result = await service.updateGoal(goalId, request2);
+      const result = await service.updateGoal(user.id, goalId, request2);
 
       expect(result).toEqual({
         id: goalId,
@@ -436,7 +436,7 @@ describe('GoalService', () => {
         behaviors: [{ title: '물 1컵 마시기', difficulty: '마음열기' }],
       };
 
-      await service.createGoalBehaviors(goalId, request3);
+      await service.createGoalBehaviors(user.id, goalId, request3);
 
       expect(behaviorRepoMock.create).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -497,7 +497,7 @@ describe('GoalService', () => {
         behaviors: [{ id: 'b1', title: '수정된 행동', difficulty: '시작하기' }],
       };
 
-      await service.updateGoalBehaviors(goalId, request4);
+      await service.updateGoalBehaviors(user.id, goalId, request4);
 
       expect(behaviorRepoMock.find).toHaveBeenCalledWith({
         where: {
@@ -545,7 +545,7 @@ describe('GoalService', () => {
         behaviorIds: ['b1', 'b2'],
       };
 
-      await service.deleteGoalBehaviors(goalId, request5);
+      await service.deleteGoalBehaviors(user.id, goalId, request5);
 
       expect(behaviorRepoMock.softDelete).toHaveBeenCalledWith({
         id: expect.anything(),

--- a/apps/backend/src/features/goal/goal.service.spec.ts
+++ b/apps/backend/src/features/goal/goal.service.spec.ts
@@ -1,7 +1,13 @@
 import { NotFoundException } from '@nestjs/common';
 import { Test, type TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
-import type { CreateGoalRequest } from '@web24/shared';
+import type {
+  CreateGoalBehaviorsRequest,
+  CreateGoalRequest,
+  DeleteGoalBehaviorsRequest,
+  UpdateGoalBehaviorsRequest,
+  UpdateGoalRequest,
+} from '@web24/shared';
 import { GoalService } from './goal.service';
 import { TodayBehavior } from '../behavior/today-behavior.entity';
 import { Behavior } from '../behavior/behavior.entity';
@@ -354,6 +360,138 @@ describe('GoalService', () => {
       await expect(service.getGoalBehaviors(userId, goalId)).rejects.toBeInstanceOf(
         NotFoundException,
       );
+    });
+  });
+
+  describe('updateGoal & behaviors', () => {
+    it('updateGoal: 목표 업데이트 후 반환', async () => {
+      const goalId = '01890c6a-3f6b-7c9a-8e3a-9f3b1a2d4c55';
+      const user = { id: 'user-1', nickname: '테스트유저' };
+      const goal = { id: goalId, title: '기존 목표', color: 'red', user };
+
+      const userRepository = { findOne: jest.fn().mockResolvedValue(user) };
+      const goalRepository = {
+        findOne: jest.fn().mockResolvedValue(goal),
+        save: jest.fn().mockImplementation((g) => Promise.resolve(g)),
+      };
+
+      const { service } = await createService({ goalRepository, userRepository });
+
+      const request2: UpdateGoalRequest = { title: '업데이트된 목표', color: 'blue' };
+      const result = await service.updateGoal(goalId, request2);
+
+      expect(result).toEqual({ id: goalId, title: '업데이트된 목표', color: 'blue' });
+      expect(userRepository.findOne).toHaveBeenCalled();
+      expect(goalRepository.findOne).toHaveBeenCalledWith({
+        where: { id: goalId, user: { id: user.id } },
+        relations: ['user'],
+      });
+      expect(goalRepository.save).toHaveBeenCalledWith({
+        ...goal,
+        title: '업데이트된 목표',
+        color: 'blue',
+      });
+    });
+
+    it('createGoalBehaviors: 새로운 행동 생성', async () => {
+      const goalId = 'goal-1';
+      const user = { id: 'user-1', nickname: '테스트유저' };
+      const goal = { id: goalId, user };
+
+      const behaviorRepoMock = {
+        create: jest.fn((data) => data),
+        save: jest.fn(),
+      };
+      const managerMock = {
+        getRepository: jest.fn(() => behaviorRepoMock),
+      };
+      const goalRepository = {
+        findOne: jest.fn().mockImplementation(({ where }: any) => {
+          if (where.nickname) return Promise.resolve(user);
+          if (where.id) return Promise.resolve(goal);
+          return Promise.resolve(null);
+        }),
+        manager: { transaction: jest.fn((cb) => cb(managerMock)) },
+      };
+      const userRepository = { findOne: jest.fn().mockResolvedValue(user) };
+
+      const { service } = await createService({ goalRepository, userRepository });
+
+      const request3: CreateGoalBehaviorsRequest = {
+        behaviors: [{ title: '물 1컵 마시기', difficulty: '마음열기' }],
+      };
+      await service.createGoalBehaviors(goalId, request3);
+
+      expect(behaviorRepoMock.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: '물 1컵 마시기',
+          difficulty: '마음열기',
+          goal: expect.objectContaining({ id: 'goal-1' }), // 최소 필드만 체크
+        }),
+      );
+      expect(behaviorRepoMock.save).toHaveBeenCalledWith([
+        { title: '물 1컵 마시기', difficulty: '마음열기', goal },
+      ]);
+    });
+
+    it('updateGoalBehaviors: 행동 업데이트', async () => {
+      const goalId = 'goal-1';
+      const user = { id: 'user-1', nickname: '테스트유저' };
+      const goal = { id: goalId, user };
+
+      const behavior = { id: 'b1', title: '기존 행동', difficulty: '마음열기' };
+      const behaviorRepoMock = {
+        findOne: jest.fn().mockResolvedValue(behavior),
+        merge: jest.fn(),
+        save: jest.fn(),
+      };
+
+      const managerMock = { getRepository: jest.fn(() => behaviorRepoMock) };
+      const goalRepository = {
+        findOne: jest.fn().mockResolvedValueOnce(user).mockResolvedValueOnce(goal),
+        manager: { transaction: jest.fn((cb) => cb(managerMock)) },
+      };
+      const userRepository = { findOne: jest.fn().mockResolvedValue(user) };
+
+      const { service } = await createService({ goalRepository, userRepository });
+
+      const request4: UpdateGoalBehaviorsRequest = {
+        behaviors: [{ id: 'b1', title: '수정된 행동', difficulty: '시작하기' }],
+      };
+      await service.updateGoalBehaviors(goalId, request4);
+
+      expect(behaviorRepoMock.findOne).toHaveBeenCalledWith({
+        where: { id: 'b1', goal: { id: goalId } },
+      });
+      expect(behaviorRepoMock.merge).toHaveBeenCalledWith(behavior, {
+        title: '수정된 행동',
+        difficulty: '시작하기',
+      });
+      expect(behaviorRepoMock.save).toHaveBeenCalledWith(behavior);
+    });
+
+    it('deleteGoalBehaviors: 행동 삭제', async () => {
+      const goalId = 'goal-1';
+      const user = { id: 'user-1', nickname: '테스트유저' };
+      const goal = { id: goalId, user };
+
+      const behaviorRepoMock = { delete: jest.fn() };
+      const managerMock = { getRepository: jest.fn(() => behaviorRepoMock) };
+      const goalRepository = {
+        findOne: jest.fn().mockResolvedValueOnce(user).mockResolvedValueOnce(goal),
+        manager: { transaction: jest.fn((cb) => cb(managerMock)) },
+      };
+      const userRepository = { findOne: jest.fn().mockResolvedValue(user) };
+
+      const { service } = await createService({ goalRepository, userRepository });
+
+      const request5: DeleteGoalBehaviorsRequest = { behaviorIds: ['b1', 'b2'] };
+      await service.deleteGoalBehaviors(goalId, request5);
+
+      expect(behaviorRepoMock.delete).toHaveBeenCalledWith({
+        id: expect.anything(), // In() 내부 값은 라이브러리에서 처리
+        goal: { id: goalId },
+      });
     });
   });
 });

--- a/apps/backend/src/features/goal/goal.service.spec.ts
+++ b/apps/backend/src/features/goal/goal.service.spec.ts
@@ -369,7 +369,10 @@ describe('GoalService', () => {
       const user = { id: 'user-1', nickname: '테스트유저' };
       const goal = { id: goalId, title: '기존 목표', color: 'red', user };
 
-      const userRepository = { findOne: jest.fn().mockResolvedValue(user) };
+      const userRepository = {
+        findOne: jest.fn().mockResolvedValue(user),
+      };
+
       const goalRepository = {
         findOne: jest.fn().mockResolvedValue(goal),
         save: jest.fn().mockImplementation((g) => Promise.resolve(g)),
@@ -377,15 +380,24 @@ describe('GoalService', () => {
 
       const { service } = await createService({ goalRepository, userRepository });
 
-      const request2: UpdateGoalRequest = { title: '업데이트된 목표', color: 'blue' };
+      const request2: UpdateGoalRequest = {
+        title: '업데이트된 목표',
+        color: 'blue',
+      };
+
       const result = await service.updateGoal(goalId, request2);
 
-      expect(result).toEqual({ id: goalId, title: '업데이트된 목표', color: 'blue' });
-      expect(userRepository.findOne).toHaveBeenCalled();
+      expect(result).toEqual({
+        id: goalId,
+        title: '업데이트된 목표',
+        color: 'blue',
+      });
+
       expect(goalRepository.findOne).toHaveBeenCalledWith({
         where: { id: goalId, user: { id: user.id } },
         relations: ['user'],
       });
+
       expect(goalRepository.save).toHaveBeenCalledWith({
         ...goal,
         title: '업데이트된 목표',
@@ -402,35 +414,44 @@ describe('GoalService', () => {
         create: jest.fn((data) => data),
         save: jest.fn(),
       };
+
       const managerMock = {
         getRepository: jest.fn(() => behaviorRepoMock),
       };
-      const goalRepository = {
-        findOne: jest.fn().mockImplementation(({ where }: any) => {
-          if (where.nickname) return Promise.resolve(user);
-          if (where.id) return Promise.resolve(goal);
-          return Promise.resolve(null);
-        }),
-        manager: { transaction: jest.fn((cb) => cb(managerMock)) },
+
+      const userRepository = {
+        findOne: jest.fn().mockResolvedValue(user),
       };
-      const userRepository = { findOne: jest.fn().mockResolvedValue(user) };
+
+      const goalRepository = {
+        findOne: jest.fn().mockResolvedValue(goal),
+        manager: {
+          transaction: jest.fn((cb) => cb(managerMock)),
+        },
+      };
 
       const { service } = await createService({ goalRepository, userRepository });
 
       const request3: CreateGoalBehaviorsRequest = {
         behaviors: [{ title: '물 1컵 마시기', difficulty: '마음열기' }],
       };
+
       await service.createGoalBehaviors(goalId, request3);
 
       expect(behaviorRepoMock.create).toHaveBeenCalledWith(
         expect.objectContaining({
           title: '물 1컵 마시기',
           difficulty: '마음열기',
-          goal: expect.objectContaining({ id: 'goal-1' }), // 최소 필드만 체크
+          goal: expect.objectContaining({ id: goalId }),
         }),
       );
+
       expect(behaviorRepoMock.save).toHaveBeenCalledWith([
-        { title: '물 1컵 마시기', difficulty: '마음열기', goal },
+        {
+          title: '물 1컵 마시기',
+          difficulty: '마음열기',
+          goal,
+        },
       ]);
     });
 
@@ -439,57 +460,95 @@ describe('GoalService', () => {
       const user = { id: 'user-1', nickname: '테스트유저' };
       const goal = { id: goalId, user };
 
-      const behavior = { id: 'b1', title: '기존 행동', difficulty: '마음열기' };
+      const existingBehavior = {
+        id: 'b1',
+        title: '기존 행동',
+        difficulty: '마음열기',
+        goal,
+      };
+
       const behaviorRepoMock = {
-        findOne: jest.fn().mockResolvedValue(behavior),
-        merge: jest.fn(),
+        find: jest.fn().mockResolvedValue([existingBehavior]),
+        merge: jest.fn((entity, dto) => Object.assign(entity, dto)),
         save: jest.fn(),
       };
 
-      const managerMock = { getRepository: jest.fn(() => behaviorRepoMock) };
-      const goalRepository = {
-        findOne: jest.fn().mockResolvedValueOnce(user).mockResolvedValueOnce(goal),
-        manager: { transaction: jest.fn((cb) => cb(managerMock)) },
+      const managerMock = {
+        getRepository: jest.fn(() => behaviorRepoMock),
       };
-      const userRepository = { findOne: jest.fn().mockResolvedValue(user) };
+
+      const goalRepository = {
+        findOne: jest
+          .fn()
+          .mockResolvedValueOnce(user) // 사용자 조회
+          .mockResolvedValueOnce(goal), // 목표 조회
+        manager: {
+          transaction: jest.fn((cb) => cb(managerMock)),
+        },
+      };
+
+      const userRepository = {
+        findOne: jest.fn().mockResolvedValue(user),
+      };
 
       const { service } = await createService({ goalRepository, userRepository });
 
       const request4: UpdateGoalBehaviorsRequest = {
         behaviors: [{ id: 'b1', title: '수정된 행동', difficulty: '시작하기' }],
       };
+
       await service.updateGoalBehaviors(goalId, request4);
 
-      expect(behaviorRepoMock.findOne).toHaveBeenCalledWith({
-        where: { id: 'b1', goal: { id: goalId } },
+      expect(behaviorRepoMock.find).toHaveBeenCalledWith({
+        where: {
+          id: expect.anything(), // In(['b1'])
+          goal: { id: goalId },
+        },
       });
-      expect(behaviorRepoMock.merge).toHaveBeenCalledWith(behavior, {
-        title: '수정된 행동',
-        difficulty: '시작하기',
-      });
-      expect(behaviorRepoMock.save).toHaveBeenCalledWith(behavior);
+
+      expect(behaviorRepoMock.save).toHaveBeenCalledWith([
+        {
+          ...existingBehavior,
+          title: '수정된 행동',
+          difficulty: '시작하기',
+        },
+      ]);
     });
 
-    it('deleteGoalBehaviors: 행동 삭제', async () => {
+    it('deleteGoalBehaviors: 행동 soft delete', async () => {
       const goalId = 'goal-1';
       const user = { id: 'user-1', nickname: '테스트유저' };
       const goal = { id: goalId, user };
 
-      const behaviorRepoMock = { delete: jest.fn() };
-      const managerMock = { getRepository: jest.fn(() => behaviorRepoMock) };
+      const behaviorRepoMock = {
+        softDelete: jest.fn(),
+      };
+
+      const managerMock = {
+        getRepository: jest.fn(() => behaviorRepoMock),
+      };
+
       const goalRepository = {
         findOne: jest.fn().mockResolvedValueOnce(user).mockResolvedValueOnce(goal),
-        manager: { transaction: jest.fn((cb) => cb(managerMock)) },
+        manager: {
+          transaction: jest.fn((cb) => cb(managerMock)),
+        },
       };
-      const userRepository = { findOne: jest.fn().mockResolvedValue(user) };
+
+      const userRepository = {
+        findOne: jest.fn().mockResolvedValue(user),
+      };
 
       const { service } = await createService({ goalRepository, userRepository });
 
-      const request5: DeleteGoalBehaviorsRequest = { behaviorIds: ['b1', 'b2'] };
+      const request5: DeleteGoalBehaviorsRequest = {
+        behaviorIds: ['b1', 'b2'],
+      };
+
       await service.deleteGoalBehaviors(goalId, request5);
 
-      expect(behaviorRepoMock.delete).toHaveBeenCalledWith({
-        id: expect.anything(), // In() 내부 값은 라이브러리에서 처리
+      expect(behaviorRepoMock.softDelete).toHaveBeenCalledWith({
+        id: expect.anything(),
         goal: { id: goalId },
       });
     });

--- a/apps/backend/src/features/goal/goal.service.ts
+++ b/apps/backend/src/features/goal/goal.service.ts
@@ -233,23 +233,35 @@ export class GoalService {
         throw new NotFoundException('Goal not found');
       }
 
-      const updatePromises = request.behaviors.map(async (dto) => {
-        const behaviorRepo = manager.getRepository(Behavior);
-        const behavior = await behaviorRepo.findOne({
-          where: { id: dto.id, goal: { id: goalId } },
-        });
+      const behaviorIds = request.behaviors.map((b) => b.id);
 
-        if (!behavior) return;
+      if (behaviorIds.length === 0) {
+        throw new NotFoundException('No behaviors provided');
+      }
 
-        // 변경된 필드만 업데이트
-        behaviorRepo.merge(behavior, {
+      const behaviorRepo = manager.getRepository(Behavior);
+
+      const behaviors = await behaviorRepo.find({
+        where: {
+          id: In(behaviorIds),
+          goal: { id: goalId },
+        },
+      });
+
+      // id -> dto 매핑
+      const behaviorMap = new Map(request.behaviors.map((dto) => [dto.id, dto]));
+
+      const updatedBehaviors = behaviors.map((behavior) => {
+        const dto = behaviorMap.get(behavior.id);
+        if (!dto) return behavior;
+
+        return behaviorRepo.merge(behavior, {
           title: dto.title,
           difficulty: dto.difficulty,
         });
-        await behaviorRepo.save(behavior);
       });
 
-      await Promise.all(updatePromises);
+      await behaviorRepo.save(updatedBehaviors);
     });
   }
 
@@ -273,7 +285,7 @@ export class GoalService {
       }
 
       // goalId와 behaviorIds가 모두 일치하는 것만 삭제
-      await manager.getRepository(Behavior).delete({
+      await manager.getRepository(Behavior).softDelete({
         id: In(request.behaviorIds),
         goal: { id: goalId },
       });

--- a/apps/backend/src/features/goal/goal.service.ts
+++ b/apps/backend/src/features/goal/goal.service.ts
@@ -2,9 +2,12 @@ import { Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import {
   CreateGoalResponseSchema,
+  type UpdateGoalRequest,
   type CreateGoalRequest,
   type CreateGoalResponse,
   type GoalStamp,
+  type UpdateGoalResponse,
+  UpdateGoalResponseSchema,
 } from '@web24/shared';
 import { Repository } from 'typeorm';
 import { Behavior } from '../behavior/behavior.entity';
@@ -146,6 +149,34 @@ export class GoalService {
           title: behavior.title,
           difficulty: behavior.difficulty,
         })),
+      });
+    });
+  }
+
+  async updateGoal(goalId: string, request: UpdateGoalRequest): Promise<UpdateGoalResponse> {
+    return this.goalRepository.manager.transaction(async (manager) => {
+      const goalRepo = manager.getRepository(Goal);
+
+      // 목표 조회
+      const goal = await goalRepo.findOne({
+        where: { id: goalId },
+        relations: ['user'],
+      });
+
+      if (!goal) {
+        throw new NotFoundException('Goal not found');
+      }
+
+      goal.title = request.title;
+      goal.color = request.color;
+
+      const savedGoal = await goalRepo.save(goal);
+
+      // 응답
+      return UpdateGoalResponseSchema.parse({
+        id: savedGoal.id,
+        title: savedGoal.title,
+        color: savedGoal.color,
       });
     });
   }

--- a/apps/backend/src/features/goal/goal.service.ts
+++ b/apps/backend/src/features/goal/goal.service.ts
@@ -8,8 +8,11 @@ import {
   type GoalStamp,
   type UpdateGoalResponse,
   UpdateGoalResponseSchema,
+  type CreateGoalBehaviorsRequest,
+  type UpdateGoalBehaviorsRequest,
+  type DeleteGoalBehaviorsRequest,
 } from '@web24/shared';
-import { Repository } from 'typeorm';
+import { In, Repository } from 'typeorm';
 import { Behavior } from '../behavior/behavior.entity';
 import { User } from '../user/user.entity';
 import { Goal } from './goal.entity';
@@ -154,12 +157,45 @@ export class GoalService {
   }
 
   async updateGoal(goalId: string, request: UpdateGoalRequest): Promise<UpdateGoalResponse> {
-    return this.goalRepository.manager.transaction(async (manager) => {
-      const goalRepo = manager.getRepository(Goal);
+    // MEMO: 임시로 테스트 사용자를 바탕으로 조회
+    const user = await this.userRepository.findOne({ where: { nickname: '테스트유저' } });
 
-      // 목표 조회
-      const goal = await goalRepo.findOne({
-        where: { id: goalId },
+    if (!user) {
+      throw new NotFoundException('User not found');
+    }
+
+    const goal = await this.goalRepository.findOne({
+      where: { id: goalId, user: { id: user.id } },
+      relations: ['user'],
+    });
+
+    if (!goal) {
+      throw new NotFoundException('Goal not found');
+    }
+
+    goal.title = request.title;
+    goal.color = request.color;
+
+    const savedGoal = await this.goalRepository.save(goal);
+
+    // 응답
+    return UpdateGoalResponseSchema.parse({
+      id: savedGoal.id,
+      title: savedGoal.title,
+      color: savedGoal.color,
+    });
+  }
+
+  async createGoalBehaviors(goalId: string, request: CreateGoalBehaviorsRequest): Promise<void> {
+    await this.goalRepository.manager.transaction(async (manager) => {
+      // MEMO: 임시로 테스트 사용자를 바탕으로 조회
+      const user = await this.userRepository.findOne({ where: { nickname: '테스트유저' } });
+      if (!user) {
+        throw new NotFoundException('Test User not found');
+      }
+
+      const goal = await this.goalRepository.findOne({
+        where: { id: goalId, user: { id: user.id } },
         relations: ['user'],
       });
 
@@ -167,16 +203,79 @@ export class GoalService {
         throw new NotFoundException('Goal not found');
       }
 
-      goal.title = request.title;
-      goal.color = request.color;
+      const newBehaviors = request.behaviors.map((behavior) =>
+        manager.getRepository(Behavior).create({
+          title: behavior.title,
+          difficulty: behavior.difficulty,
+          goal,
+        }),
+      );
 
-      const savedGoal = await goalRepo.save(goal);
+      // 일괄 저장
+      await manager.getRepository(Behavior).save(newBehaviors);
+    });
+  }
 
-      // 응답
-      return UpdateGoalResponseSchema.parse({
-        id: savedGoal.id,
-        title: savedGoal.title,
-        color: savedGoal.color,
+  async updateGoalBehaviors(goalId: string, request: UpdateGoalBehaviorsRequest): Promise<void> {
+    await this.goalRepository.manager.transaction(async (manager) => {
+      // MEMO: 임시로 테스트 사용자를 바탕으로 조회
+      const user = await this.userRepository.findOne({ where: { nickname: '테스트유저' } });
+      if (!user) {
+        throw new NotFoundException('Test User not found');
+      }
+
+      const goal = await this.goalRepository.findOne({
+        where: { id: goalId, user: { id: user.id } },
+        relations: ['user'],
+      });
+
+      if (!goal) {
+        throw new NotFoundException('Goal not found');
+      }
+
+      const updatePromises = request.behaviors.map(async (dto) => {
+        const behaviorRepo = manager.getRepository(Behavior);
+        const behavior = await behaviorRepo.findOne({
+          where: { id: dto.id, goal: { id: goalId } },
+        });
+
+        if (!behavior) return;
+
+        // 변경된 필드만 업데이트
+        behaviorRepo.merge(behavior, {
+          title: dto.title,
+          difficulty: dto.difficulty,
+        });
+        await behaviorRepo.save(behavior);
+      });
+
+      await Promise.all(updatePromises);
+    });
+  }
+
+  async deleteGoalBehaviors(goalId: string, request: DeleteGoalBehaviorsRequest): Promise<void> {
+    if (request.behaviorIds.length === 0) return;
+
+    await this.goalRepository.manager.transaction(async (manager) => {
+      // MEMO: 임시로 테스트 사용자를 바탕으로 조회
+      const user = await this.userRepository.findOne({ where: { nickname: '테스트유저' } });
+      if (!user) {
+        throw new NotFoundException('Test User not found');
+      }
+
+      const goal = await this.goalRepository.findOne({
+        where: { id: goalId, user: { id: user.id } },
+        relations: ['user'],
+      });
+
+      if (!goal) {
+        throw new NotFoundException('Goal not found');
+      }
+
+      // goalId와 behaviorIds가 모두 일치하는 것만 삭제
+      await manager.getRepository(Behavior).delete({
+        id: In(request.behaviorIds),
+        goal: { id: goalId },
       });
     });
   }

--- a/apps/backend/src/features/goal/goal.service.ts
+++ b/apps/backend/src/features/goal/goal.service.ts
@@ -156,16 +156,13 @@ export class GoalService {
     });
   }
 
-  async updateGoal(goalId: string, request: UpdateGoalRequest): Promise<UpdateGoalResponse> {
-    // MEMO: 임시로 테스트 사용자를 바탕으로 조회
-    const user = await this.userRepository.findOne({ where: { nickname: '테스트유저' } });
-
-    if (!user) {
-      throw new NotFoundException('User not found');
-    }
-
+  async updateGoal(
+    userId: string,
+    goalId: string,
+    request: UpdateGoalRequest,
+  ): Promise<UpdateGoalResponse> {
     const goal = await this.goalRepository.findOne({
-      where: { id: goalId, user: { id: user.id } },
+      where: { id: goalId, user: { id: userId } },
       relations: ['user'],
     });
 
@@ -178,7 +175,6 @@ export class GoalService {
 
     const savedGoal = await this.goalRepository.save(goal);
 
-    // 응답
     return UpdateGoalResponseSchema.parse({
       id: savedGoal.id,
       title: savedGoal.title,
@@ -186,16 +182,14 @@ export class GoalService {
     });
   }
 
-  async createGoalBehaviors(goalId: string, request: CreateGoalBehaviorsRequest): Promise<void> {
+  async createGoalBehaviors(
+    userId: string,
+    goalId: string,
+    request: CreateGoalBehaviorsRequest,
+  ): Promise<void> {
     await this.goalRepository.manager.transaction(async (manager) => {
-      // MEMO: 임시로 테스트 사용자를 바탕으로 조회
-      const user = await this.userRepository.findOne({ where: { nickname: '테스트유저' } });
-      if (!user) {
-        throw new NotFoundException('Test User not found');
-      }
-
       const goal = await this.goalRepository.findOne({
-        where: { id: goalId, user: { id: user.id } },
+        where: { id: goalId, user: { id: userId } },
         relations: ['user'],
       });
 
@@ -216,16 +210,14 @@ export class GoalService {
     });
   }
 
-  async updateGoalBehaviors(goalId: string, request: UpdateGoalBehaviorsRequest): Promise<void> {
+  async updateGoalBehaviors(
+    userId: string,
+    goalId: string,
+    request: UpdateGoalBehaviorsRequest,
+  ): Promise<void> {
     await this.goalRepository.manager.transaction(async (manager) => {
-      // MEMO: 임시로 테스트 사용자를 바탕으로 조회
-      const user = await this.userRepository.findOne({ where: { nickname: '테스트유저' } });
-      if (!user) {
-        throw new NotFoundException('Test User not found');
-      }
-
       const goal = await this.goalRepository.findOne({
-        where: { id: goalId, user: { id: user.id } },
+        where: { id: goalId, user: { id: userId } },
         relations: ['user'],
       });
 
@@ -265,18 +257,16 @@ export class GoalService {
     });
   }
 
-  async deleteGoalBehaviors(goalId: string, request: DeleteGoalBehaviorsRequest): Promise<void> {
+  async deleteGoalBehaviors(
+    userId: string,
+    goalId: string,
+    request: DeleteGoalBehaviorsRequest,
+  ): Promise<void> {
     if (request.behaviorIds.length === 0) return;
 
     await this.goalRepository.manager.transaction(async (manager) => {
-      // MEMO: 임시로 테스트 사용자를 바탕으로 조회
-      const user = await this.userRepository.findOne({ where: { nickname: '테스트유저' } });
-      if (!user) {
-        throw new NotFoundException('Test User not found');
-      }
-
       const goal = await this.goalRepository.findOne({
-        where: { id: goalId, user: { id: user.id } },
+        where: { id: goalId, user: { id: userId } },
         relations: ['user'],
       });
 

--- a/apps/frontend/src/features/goal/apis/createGoalBehaviors.api.spec.ts
+++ b/apps/frontend/src/features/goal/apis/createGoalBehaviors.api.spec.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Behavior } from '@web24/shared';
+import { createGoalBehaviors } from './createGoalBehaviors.api';
+
+describe('createGoalBehaviors', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('POST 요청을 올바른 URL과 body로 보낸다', async () => {
+    const mockFetch = vi.fn(() => Promise.resolve({ ok: true } as Response));
+    globalThis.fetch = mockFetch as any;
+
+    const goalId = 'goal-1';
+    const behaviors: Omit<Behavior, 'id'>[] = [
+      { title: '물 1컵 마시기', difficulty: '마음열기' },
+      { title: '스트레칭 5분', difficulty: '시작하기' },
+    ];
+
+    await createGoalBehaviors(goalId, behaviors);
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(mockFetch).toHaveBeenCalledWith(`/api/goals/${goalId}/behaviors`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ behaviors }),
+    });
+  });
+
+  it('응답이 ok가 아니면 에러를 던진다', async () => {
+    globalThis.fetch = vi.fn(() => Promise.resolve({ ok: false, status: 500 } as Response)) as any;
+
+    const goalId = 'goal-1';
+    const behaviors: Omit<Behavior, 'id'>[] = [{ title: '물 1컵 마시기', difficulty: '마음열기' }];
+
+    await expect(createGoalBehaviors(goalId, behaviors)).rejects.toThrow('Create failed: 500');
+  });
+});

--- a/apps/frontend/src/features/goal/apis/createGoalBehaviors.api.ts
+++ b/apps/frontend/src/features/goal/apis/createGoalBehaviors.api.ts
@@ -1,0 +1,14 @@
+import type { Behavior } from '@web24/shared';
+
+export const createGoalBehaviors = async (
+  goalId: string,
+  behaviors: Omit<Behavior, 'id'>[],
+): Promise<void> => {
+  const response = await fetch(`/api/goals/${goalId}/behaviors`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ behaviors }),
+  });
+
+  if (!response.ok) throw new Error(`Create failed: ${response.status}`);
+};

--- a/apps/frontend/src/features/goal/apis/deleteGoalBehaviors.api.spec.ts
+++ b/apps/frontend/src/features/goal/apis/deleteGoalBehaviors.api.spec.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { deleteGoalBehaviors } from './deleteGoalBehaviors.api';
+
+describe('deleteGoalBehaviors', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('DELETE 요청을 올바른 URL과 body로 보낸다', async () => {
+    const mockFetch = vi.fn(() => Promise.resolve({ ok: true } as Response));
+    globalThis.fetch = mockFetch as any;
+
+    const goalId = 'goal-1';
+    const idsToDelete = ['b1', 'b2'];
+
+    await deleteGoalBehaviors(goalId, idsToDelete);
+
+    expect(mockFetch).toHaveBeenCalledWith(`/api/goals/${goalId}/behaviors`, {
+      method: 'DELETE',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ behaviorIds: idsToDelete }),
+    });
+  });
+
+  it('ok가 false면 에러 발생', async () => {
+    globalThis.fetch = vi.fn(() => Promise.resolve({ ok: false, status: 404 } as Response)) as any;
+
+    await expect(deleteGoalBehaviors('goal-1', [])).rejects.toThrow('Delete failed: 404');
+  });
+});

--- a/apps/frontend/src/features/goal/apis/deleteGoalBehaviors.api.ts
+++ b/apps/frontend/src/features/goal/apis/deleteGoalBehaviors.api.ts
@@ -1,0 +1,9 @@
+export const deleteGoalBehaviors = async (goalId: string, behaviorIds: string[]): Promise<void> => {
+  const response = await fetch(`/api/goals/${goalId}/behaviors`, {
+    method: 'DELETE',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ behaviorIds }),
+  });
+
+  if (!response.ok) throw new Error(`Delete failed: ${response.status}`);
+};

--- a/apps/frontend/src/features/goal/apis/fetchGoalStamps.api.spec.ts
+++ b/apps/frontend/src/features/goal/apis/fetchGoalStamps.api.spec.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
+import type { GetGoalStampsResponse } from '@web24/shared';
+import { fetchGoalStamps } from './fetchGoalStamps.api';
+
+describe('fetchGoalStamps', () => {
+  const mockFetch = vi.fn();
+
+  beforeEach(() => {
+    globalThis.fetch = mockFetch as any;
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('GET 요청 후 데이터를 최신순으로 정렬해서 반환한다', async () => {
+    const goalId = 'goal-1';
+    const apiResponse: GetGoalStampsResponse = [
+      {
+        id: '01890c6a-3f6b-7c9a-8e3a-9f3b1a2d4c55',
+        title: '행동 A',
+        difficulty: '몰입하기',
+        updatedAt: '2024-01-01T00:00:00.000Z',
+      },
+      {
+        id: '01890c6a-3f6b-7c9a-8e3a-9f3b1a2d4c56',
+        title: '행동 B',
+        difficulty: '시작하기',
+        updatedAt: '2024-01-03T00:00:00.000Z',
+      },
+      {
+        id: '01890c6a-3f6b-7c9a-8e3a-9f3b1a2d4c57',
+        title: '행동 C',
+        difficulty: '마음열기',
+        updatedAt: '2024-01-02T00:00:00.000Z',
+      },
+    ];
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => apiResponse,
+    } as Response);
+
+    const result = await fetchGoalStamps(goalId);
+
+    // fetch 호출 확인
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(mockFetch).toHaveBeenCalledWith(`/api/goals/${goalId}/stamps`, {
+      method: 'GET',
+      headers: { 'Content-Type': 'application/json' },
+    });
+
+    // 최신순 정렬 확인
+    expect(result.map((r) => r.id)).toEqual([
+      '01890c6a-3f6b-7c9a-8e3a-9f3b1a2d4c56',
+      '01890c6a-3f6b-7c9a-8e3a-9f3b1a2d4c57',
+      '01890c6a-3f6b-7c9a-8e3a-9f3b1a2d4c55',
+    ]);
+  });
+
+  it('fetch 실패 시 에러를 던진다', async () => {
+    const goalId = 'goal-1';
+    mockFetch.mockResolvedValueOnce({ ok: false } as Response);
+
+    await expect(fetchGoalStamps(goalId)).rejects.toThrow('Failed to fetch goal stamps');
+  });
+
+  it('잘못된 JSON이면 Zod 에러를 던진다', async () => {
+    const goalId = 'goal-1';
+    // Zod parse 실패용 잘못된 데이터
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ invalid: 'data' }),
+    } as Response);
+
+    await expect(fetchGoalStamps(goalId)).rejects.toThrow();
+  });
+});

--- a/apps/frontend/src/features/goal/apis/updateGoal.api.spec.ts
+++ b/apps/frontend/src/features/goal/apis/updateGoal.api.spec.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { UpdateGoalResponseSchema, type UpdateGoalRequest } from '@web24/shared';
+import { updateGoal } from './updateGoal.api';
+
+describe('updateGoal', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('PUT 요청을 올바른 URL과 body로 보낸다', async () => {
+    const mockResponse = {
+      id: '01890c6a-3f6b-7c9a-8e3a-9f3b1a2d4c55',
+      title: '업데이트된 목표',
+      color: 'beige',
+    };
+    const mockFetch = vi.fn(() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve(mockResponse),
+      } as Response),
+    );
+    globalThis.fetch = mockFetch as any;
+
+    const goalId = '01890c6a-3f6b-7c9a-8e3a-9f3b1a2d4c55';
+    const request: UpdateGoalRequest = { title: '업데이트된 목표', color: 'beige' };
+
+    const result = await updateGoal(goalId, request);
+
+    // fetch 호출 확인
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(mockFetch).toHaveBeenCalledWith(`/api/goals/${goalId}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(request),
+    });
+
+    // 반환값 zod 스키마 검증
+    expect(result).toEqual(UpdateGoalResponseSchema.parse(mockResponse));
+  });
+
+  it('ok가 false면 에러 발생', async () => {
+    globalThis.fetch = vi.fn(() => Promise.resolve({ ok: false, status: 500 } as Response)) as any;
+
+    await expect(updateGoal('goal-1', { title: '테스트', color: 'beige' })).rejects.toThrow(
+      'Request failed: 500',
+    );
+  });
+
+  it('응답이 스키마와 맞지 않으면 zod 에러 발생', async () => {
+    const invalidResponse = { wrong: 'field' };
+    globalThis.fetch = vi.fn(() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve(invalidResponse),
+      } as Response),
+    ) as any;
+
+    const goalId = 'goal-1';
+    const request: UpdateGoalRequest = { title: '테스트', color: 'beige' };
+
+    await expect(updateGoal(goalId, request)).rejects.toThrow();
+  });
+});

--- a/apps/frontend/src/features/goal/apis/updateGoal.api.ts
+++ b/apps/frontend/src/features/goal/apis/updateGoal.api.ts
@@ -1,0 +1,25 @@
+import {
+  UpdateGoalResponseSchema,
+  type UpdateGoalRequest,
+  type UpdateGoalResponse,
+} from '@web24/shared';
+
+export async function updateGoal(
+  id: string,
+  request: UpdateGoalRequest,
+): Promise<UpdateGoalResponse> {
+  const response = await fetch(`/api/goals/${id}`, {
+    method: 'PUT',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(request),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Request failed: ${response.status}`);
+  }
+
+  const json = await response.json();
+  return UpdateGoalResponseSchema.parse(json);
+}

--- a/apps/frontend/src/features/goal/apis/updateGoalBehaviors.api.spec.ts
+++ b/apps/frontend/src/features/goal/apis/updateGoalBehaviors.api.spec.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Behavior } from '@web24/shared';
+import { updateGoalBehaviors } from './updateGoalBehaviors.api';
+
+describe('updateGoalBehaviors', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('PATCH 요청을 올바른 URL과 body로 보낸다', async () => {
+    const mockFetch = vi.fn(() => Promise.resolve({ ok: true } as Response));
+    globalThis.fetch = mockFetch as any;
+
+    const goalId = '123e4567-e89b-12d3-a456-426614174000';
+    const behaviors: Behavior[] = [{ id: 'b1', title: '물 1컵 마시기', difficulty: '마음열기' }];
+
+    await updateGoalBehaviors(goalId, behaviors);
+
+    expect(mockFetch).toHaveBeenCalledWith(`/api/goals/${goalId}/behaviors`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ behaviors }),
+    });
+  });
+
+  it('ok가 false면 에러 발생', async () => {
+    globalThis.fetch = vi.fn(() => Promise.resolve({ ok: false, status: 500 } as Response)) as any;
+
+    await expect(updateGoalBehaviors('goal-1', [])).rejects.toThrow('Update failed: 500');
+  });
+});

--- a/apps/frontend/src/features/goal/apis/updateGoalBehaviors.api.ts
+++ b/apps/frontend/src/features/goal/apis/updateGoalBehaviors.api.ts
@@ -1,0 +1,11 @@
+import type { Behavior } from '@web24/shared';
+
+export const updateGoalBehaviors = async (goalId: string, behaviors: Behavior[]): Promise<void> => {
+  const response = await fetch(`/api/goals/${goalId}/behaviors`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ behaviors }),
+  });
+
+  if (!response.ok) throw new Error(`Update failed: ${response.status}`);
+};

--- a/apps/frontend/src/features/goal/components/GoalBehaviorList.spec.tsx
+++ b/apps/frontend/src/features/goal/components/GoalBehaviorList.spec.tsx
@@ -1,5 +1,6 @@
 import { render, screen, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Behavior } from '@web24/shared';
 import { useGoalBehaviors } from '../hooks/useGoalBehaviors';
 import { GoalBehaviorList } from './GoalBehaviorList';
 
@@ -13,17 +14,27 @@ describe('GoalBehaviorList', () => {
   });
 
   it('전체 필터에서 모든 행동과 건수를 표시한다', () => {
+    const mockBehaviors: Behavior[] = [
+      { id: 'b1', title: '물 1컵 마시기', difficulty: '마음열기' },
+      { id: 'b2', title: '스트레칭 5분', difficulty: '시작하기' },
+      { id: 'b3', title: 'AI 추천', difficulty: 'AI' },
+    ];
+
     vi.mocked(useGoalBehaviors).mockReturnValue({
-      behaviors: [
-        { id: 'b1', title: '물 1컵 마시기', difficulty: '마음열기' },
-        { id: 'b2', title: '스트레칭 5분', difficulty: '시작하기' },
-        { id: 'b3', title: 'AI 추천', difficulty: 'AI' },
-      ],
+      behaviors: mockBehaviors,
       isLoading: false,
       error: null,
+      refetch: async () => {},
     });
 
-    render(<GoalBehaviorList goalId="goal-1" />);
+    render(
+      <GoalBehaviorList
+        goalId="goal-1"
+        behaviors={mockBehaviors}
+        isLoading={false}
+        onRefetch={() => {}}
+      />,
+    );
 
     expect(screen.getByRole('button', { name: /전체 3/ })).toBeInTheDocument();
     expect(screen.getByText('물 1컵 마시기')).toBeInTheDocument();
@@ -32,16 +43,26 @@ describe('GoalBehaviorList', () => {
   });
 
   it('난이도 칩을 선택하면 해당 난이도만 보여준다', () => {
+    const mockBehaviors: Behavior[] = [
+      { id: 'b1', title: '물 1컵 마시기', difficulty: '마음열기' },
+      { id: 'b2', title: '스트레칭 5분', difficulty: '시작하기' },
+    ];
+
     vi.mocked(useGoalBehaviors).mockReturnValue({
-      behaviors: [
-        { id: 'b1', title: '물 1컵 마시기', difficulty: '마음열기' },
-        { id: 'b2', title: '스트레칭 5분', difficulty: '시작하기' },
-      ],
+      behaviors: mockBehaviors,
       isLoading: false,
       error: null,
+      refetch: async () => {},
     });
 
-    render(<GoalBehaviorList goalId="goal-1" />);
+    render(
+      <GoalBehaviorList
+        goalId="goal-1"
+        behaviors={mockBehaviors}
+        isLoading={false}
+        onRefetch={() => {}}
+      />,
+    );
 
     fireEvent.click(screen.getByRole('button', { name: /시작하기/ }));
 

--- a/apps/frontend/src/features/goal/components/GoalBehaviorList.tsx
+++ b/apps/frontend/src/features/goal/components/GoalBehaviorList.tsx
@@ -1,18 +1,124 @@
-import { useMemo, useState } from 'react';
-import { BEHAVIOR_DIFFICULTIES, type Behavior, type BehaviorDifficulty } from '@web24/shared';
+import { useEffect, useMemo, useState } from 'react';
+import {
+  BEHAVIOR_DIFFICULTIES,
+  BEHAVIOR_TITLE_MAX_LENGTH,
+  type Behavior,
+  type BehaviorDifficulty,
+} from '@web24/shared';
 import { DifficultyBadge } from '@/shared/components/behavior/DifficultyBadge';
-import { useGoalBehaviors } from '../hooks/useGoalBehaviors';
+import { Minus, Plus } from 'lucide-react';
+import { DIFFICULTY_COLOR_STYLES } from '@/shared/constants/difficultyColor';
+import { createGoalBehaviors } from '../apis/createGoalBehaviors.api';
+import { updateGoalBehaviors } from '../apis/updateGoalBehaviors.api';
+import { deleteGoalBehaviors } from '../apis/deleteGoalBehaviors.api';
 
 type DifficultyFilter = 'ALL' | BehaviorDifficulty;
 const VISIBLE_DIFFICULTIES = BEHAVIOR_DIFFICULTIES.filter((difficulty) => difficulty !== 'AI');
 
 interface GoalBehaviorListProps {
   goalId: string;
+  behaviors?: Behavior[];
+  isLoading: boolean;
+  onRefetch: () => void;
 }
 
-export function GoalBehaviorList({ goalId }: GoalBehaviorListProps) {
-  const { behaviors, isLoading, error } = useGoalBehaviors(goalId, Boolean(goalId));
+export function GoalBehaviorList({
+  goalId,
+  behaviors,
+  isLoading,
+  onRefetch,
+}: GoalBehaviorListProps) {
   const [activeFilter, setActiveFilter] = useState<DifficultyFilter>('ALL');
+  const [isEditing, setIsEditing] = useState(false);
+  const [localBehaviors, setLocalBehaviors] = useState<Behavior[]>([]);
+  const [openDropdownId, setOpenDropdownId] = useState<string | null>(null);
+
+  // 초기 데이터 로드 시 로컬 상태 동기화
+  useEffect(() => {
+    if (behaviors) {
+      setLocalBehaviors(behaviors);
+    }
+  }, [behaviors]);
+
+  // 편집 모드 토글
+  const toggleEditMode = () => {
+    if (isEditing) {
+      if (behaviors) setLocalBehaviors(behaviors);
+      setIsEditing(false);
+    } else {
+      setIsEditing(true);
+    }
+  };
+
+  // 행동 추가
+  const handleAddBehavior = () => {
+    const newBehavior: Behavior = {
+      id: `new-${Date.now()}`,
+      title: '',
+      difficulty: '마음열기',
+    };
+    setLocalBehaviors([...localBehaviors, newBehavior]);
+  };
+
+  // 행동 삭제
+  const handleDeleteBehavior = (id: string) => {
+    setLocalBehaviors(localBehaviors.filter((b) => b.id !== id));
+  };
+
+  // 행동 제목 수정
+  const handleChangeTitle = (id: string, newTitle: string) => {
+    setLocalBehaviors(localBehaviors.map((b) => (b.id === id ? { ...b, title: newTitle } : b)));
+  };
+
+  // 행동 난이도 수정
+  const handleChangeDifficulty = (id: string, newDifficulty: BehaviorDifficulty) => {
+    setLocalBehaviors(
+      localBehaviors.map((b) => (b.id === id ? { ...b, difficulty: newDifficulty } : b)),
+    );
+  };
+
+  // 행동 저장
+  const handleSave = async () => {
+    const validBehaviors = localBehaviors.filter((b) => b.title.trim() !== '');
+
+    // 새로운 행동
+    const toCreate = validBehaviors
+      .filter((b) => b.id.startsWith('new-'))
+      .map(({ id, ...rest }) => rest);
+
+    // 기존 행동
+    const toUpdate = validBehaviors.filter((b) => !b.id.startsWith('new-'));
+
+    // 삭제한 행동
+    const currentIds = new Set(validBehaviors.map((b) => b.id));
+    const toDeleteIds = (behaviors || []).filter((b) => !currentIds.has(b.id)).map((b) => b.id);
+
+    try {
+      const promises = [];
+
+      if (toCreate.length > 0) {
+        promises.push(createGoalBehaviors(goalId, toCreate));
+      }
+      if (toUpdate.length > 0) {
+        promises.push(updateGoalBehaviors(goalId, toUpdate));
+      }
+      if (toDeleteIds.length > 0) {
+        promises.push(deleteGoalBehaviors(goalId, toDeleteIds));
+      }
+
+      // 3. 병렬 처리
+      await Promise.all(promises);
+      onRefetch();
+      setIsEditing(false);
+    } catch (e) {
+      console.error(e);
+    }
+  };
+
+  // 렌더링용 데이터
+  const EMPTY_BEHAVIORS: Behavior[] = [];
+
+  const currentBehaviors = isEditing ? localBehaviors : (behaviors ?? EMPTY_BEHAVIORS);
 
   const difficultyCounts = useMemo(() => {
     const base = BEHAVIOR_DIFFICULTIES.reduce(
@@ -23,65 +129,166 @@ export function GoalBehaviorList({ goalId }: GoalBehaviorListProps) {
       {} as Record<BehaviorDifficulty, number>,
     );
 
-    (behaviors ?? []).forEach((behavior) => {
+    currentBehaviors.forEach((behavior) => {
       base[behavior.difficulty] += 1;
     });
 
     return base;
-  }, [behaviors]);
+  }, [currentBehaviors]);
 
   const filteredBehaviors = useMemo(() => {
-    if (!behaviors) return [];
-    if (activeFilter === 'ALL') return behaviors;
-    return behaviors.filter((behavior) => behavior.difficulty === activeFilter);
-  }, [behaviors, activeFilter]);
+    if (activeFilter === 'ALL') return currentBehaviors;
+    return currentBehaviors.filter((behavior) => behavior.difficulty === activeFilter);
+  }, [currentBehaviors, activeFilter]);
 
   return (
     <div className="flex flex-col gap-4">
-      <div className="flex flex-wrap items-center gap-2">
-        <button
-          type="button"
-          className={`bg-primary-strong text-bg-light rounded-full border px-3 py-1 text-[12px] font-bold transition ${
-            activeFilter === 'ALL'
-              ? 'border-primary-strong opacity-100'
-              : 'border-primary-weak opacity-60 hover:opacity-100'
-          }`}
-          onClick={() => setActiveFilter('ALL')}
-        >
-          전체 {behaviors?.length ?? 0}
-        </button>
-        {VISIBLE_DIFFICULTIES.map((difficulty) => (
-          <DifficultyBadge
-            key={difficulty}
-            level={difficulty}
-            count={difficultyCounts[difficulty]}
-            selected={activeFilter === difficulty}
-            onClick={() => setActiveFilter(difficulty)}
-            className="px-3 py-1 text-[12px]"
-          />
-        ))}
+      <div className="flex items-start gap-2">
+        {/* 왼쪽: 필터 칩들 */}
+        <div className="flex flex-1 flex-wrap items-center gap-2">
+          <button
+            type="button"
+            className={`bg-primary-strong text-bg-light rounded-full border px-3 py-1 text-[12px] font-bold transition ${
+              activeFilter === 'ALL'
+                ? 'border-primary-strong opacity-100'
+                : 'border-primary-weak opacity-60 hover:opacity-100'
+            }`}
+            onClick={() => setActiveFilter('ALL')}
+          >
+            전체 {currentBehaviors?.length ?? 0}
+          </button>
+
+          {VISIBLE_DIFFICULTIES.map((difficulty) => (
+            <DifficultyBadge
+              key={difficulty}
+              level={difficulty}
+              count={difficultyCounts[difficulty]}
+              selected={activeFilter === difficulty}
+              onClick={() => setActiveFilter(difficulty)}
+              className="px-3 py-1 text-[12px]"
+            />
+          ))}
+        </div>
+
+        {/* 오른쪽: 편집 버튼 */}
+        <div className="ml-auto shrink-0">
+          {isEditing ? (
+            <div className="flex gap-2">
+              <button
+                type="button"
+                onClick={toggleEditMode}
+                className="border-secondary-weak text-primary-strong cursor-pointer rounded-full border px-3 py-1 text-[12px] font-bold"
+              >
+                취소
+              </button>
+              <button
+                type="button"
+                onClick={handleSave}
+                className="bg-secondary-strong text-bg-light cursor-pointer rounded-full px-3 py-1 text-[12px] font-bold"
+              >
+                저장
+              </button>
+            </div>
+          ) : (
+            <button
+              type="button"
+              onClick={toggleEditMode}
+              className="bg-secondary-strong text-bg-light cursor-pointer rounded-full px-3 py-1 text-[12px] font-bold"
+            >
+              수정
+            </button>
+          )}
+        </div>
       </div>
 
       {isLoading && <p className="text-label-disable text-sm">행동을 불러오는 중...</p>}
-      {!isLoading && error && (
-        <p className="text-sm text-red-600">행동을 불러오는 데 실패했습니다.</p>
-      )}
 
-      <div className="bg-primary-weak/30 scrollbar-pretty max-h-[60vh] min-h-[45vh] flex-1 overflow-y-auto rounded-2xl p-6">
-        {!isLoading && !error && filteredBehaviors.length === 0 && (
-          <p className="text-label-disable text-sm">등록된 행동이 없습니다.</p>
-        )}
-        <div className="flex flex-col gap-3">
-          {filteredBehaviors.map((behavior: Behavior) => (
-            <div
-              key={behavior.id}
-              className="bg-bg-light flex items-center justify-between gap-3 rounded-2xl px-4 py-3 shadow-sm"
-            >
-              <p className="text-headline-2 font-semibold">{behavior.title}</p>
-              <DifficultyBadge level={behavior.difficulty} />
+      <div className="flex flex-col gap-3">
+        {filteredBehaviors.map((behavior: Behavior) => (
+          <div
+            key={behavior.id}
+            className="bg-bg-light flex items-center gap-3 rounded-2xl px-4 py-3 shadow-sm transition-all duration-200"
+          >
+            {/* 내용 수정 */}
+            <div className="min-w-0 flex-1">
+              {isEditing ? (
+                <input
+                  type="text"
+                  placeholder="행동을 입력해주세요"
+                  value={behavior.title}
+                  maxLength={BEHAVIOR_TITLE_MAX_LENGTH}
+                  onChange={(e) => handleChangeTitle(behavior.id, e.target.value)}
+                  className="text-label-normal w-full bg-transparent font-semibold focus:outline-none"
+                />
+              ) : (
+                <p className="text-label-alternative truncate font-semibold">{behavior.title}</p>
+              )}
             </div>
-          ))}
-        </div>
+
+            {/* 난이도 표시 */}
+            <div className="relative shrink-0">
+              {isEditing ? (
+                <>
+                  <DifficultyBadge
+                    level={behavior.difficulty}
+                    onClick={() =>
+                      setOpenDropdownId(openDropdownId === behavior.id ? null : behavior.id)
+                    }
+                    className="hover:ring-primary-strong/30 cursor-pointer hover:ring-2 hover:ring-offset-1"
+                  />
+
+                  {/* 난이도 선택 드롭다운 */}
+                  {openDropdownId === behavior.id && (
+                    <div className="animate-in fade-in zoom-in-95 border-bg-normal bg-bg-light absolute top-full -left-3 z-20 mt-2 flex w-max flex-col gap-1 rounded-xl border p-1.5 shadow-xl duration-100">
+                      {BEHAVIOR_DIFFICULTIES.map((diff) => (
+                        <button
+                          type="button"
+                          key={diff}
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            handleChangeDifficulty(behavior.id, diff);
+                            setOpenDropdownId(null);
+                          }}
+                          className={`rounded-lg px-3 py-2 text-left text-xs font-bold transition-colors ${
+                            behavior.difficulty === diff
+                              ? `${DIFFICULTY_COLOR_STYLES[behavior.difficulty].bg} ${DIFFICULTY_COLOR_STYLES[behavior.difficulty].txt}`
+                              : 'text-label-disable hover:bg-primary-strong/30'
+                          } `}
+                        >
+                          {diff}
+                        </button>
+                      ))}
+                    </div>
+                  )}
+                </>
+              ) : (
+                <DifficultyBadge level={behavior.difficulty} />
+              )}
+            </div>
+
+            {/* 삭제 버튼 */}
+            {isEditing && (
+              <button
+                type="button"
+                onClick={() => handleDeleteBehavior(behavior.id)}
+                className="text-primary-weak hover:text-label-disable transition-colors"
+                aria-label="지우기"
+              >
+                <Minus className="h-6 w-6 stroke-[3px]" />
+              </button>
+            )}
+          </div>
+        ))}
+        {/* 행동 추가 버튼 */}
+        {isEditing && (
+          <button
+            type="button"
+            onClick={handleAddBehavior}
+            className="border-primary-strong/40 text-label-alternative hover:bg-bg-light hover:border-primary-normal mt-2 flex w-full items-center justify-center gap-2 rounded-2xl border-2 border-dashed py-3 font-bold"
+          >
+            <Plus size={20} strokeWidth={2.5} /> 추가
+          </button>
+        )}
       </div>
     </div>
   );

--- a/apps/frontend/src/features/goal/components/GoalBehaviorList.tsx
+++ b/apps/frontend/src/features/goal/components/GoalBehaviorList.tsx
@@ -55,7 +55,7 @@ export function GoalBehaviorList({
     const newBehavior: Behavior = {
       id: `new-${Date.now()}`,
       title: '',
-      difficulty: '마음열기',
+      difficulty: activeFilter === 'ALL' ? '마음열기' : activeFilter,
     };
     setLocalBehaviors([...localBehaviors, newBehavior]);
   };
@@ -203,92 +203,98 @@ export function GoalBehaviorList({
 
       {isLoading && <p className="text-label-disable text-sm">행동을 불러오는 중...</p>}
 
-      <div className="flex flex-col gap-3">
-        {filteredBehaviors.map((behavior: Behavior) => (
-          <div
-            key={behavior.id}
-            className="bg-bg-light flex items-center gap-3 rounded-2xl px-4 py-3 shadow-sm transition-all duration-200"
-          >
-            {/* 내용 수정 */}
-            <div className="min-w-0 flex-1">
-              {isEditing ? (
-                <input
-                  type="text"
-                  placeholder="행동을 입력해주세요"
-                  value={behavior.title}
-                  maxLength={BEHAVIOR_TITLE_MAX_LENGTH}
-                  onChange={(e) => handleChangeTitle(behavior.id, e.target.value)}
-                  className="text-label-normal w-full bg-transparent font-semibold focus:outline-none"
-                />
-              ) : (
-                <p className="text-label-alternative truncate font-semibold">{behavior.title}</p>
-              )}
-            </div>
-
-            {/* 난이도 표시 */}
-            <div className="relative shrink-0">
-              {isEditing ? (
-                <>
-                  <DifficultyBadge
-                    level={behavior.difficulty}
-                    onClick={() =>
-                      setOpenDropdownId(openDropdownId === behavior.id ? null : behavior.id)
-                    }
-                    className="hover:ring-primary-strong/30 cursor-pointer hover:ring-2 hover:ring-offset-1"
-                  />
-
-                  {/* 난이도 선택 드롭다운 */}
-                  {openDropdownId === behavior.id && (
-                    <div className="animate-in fade-in zoom-in-95 border-bg-normal bg-bg-light absolute top-full -left-3 z-20 mt-2 flex w-max flex-col gap-1 rounded-xl border p-1.5 shadow-xl duration-100">
-                      {BEHAVIOR_DIFFICULTIES.map((diff) => (
-                        <button
-                          type="button"
-                          key={diff}
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            handleChangeDifficulty(behavior.id, diff);
-                            setOpenDropdownId(null);
-                          }}
-                          className={`rounded-lg px-3 py-2 text-left text-xs font-bold transition-colors ${
-                            behavior.difficulty === diff
-                              ? `${DIFFICULTY_COLOR_STYLES[behavior.difficulty].bg} ${DIFFICULTY_COLOR_STYLES[behavior.difficulty].txt}`
-                              : 'text-label-disable hover:bg-primary-strong/30'
-                          } `}
-                        >
-                          {diff}
-                        </button>
-                      ))}
-                    </div>
-                  )}
-                </>
-              ) : (
-                <DifficultyBadge level={behavior.difficulty} />
-              )}
-            </div>
-
-            {/* 삭제 버튼 */}
-            {isEditing && (
-              <button
-                type="button"
-                onClick={() => handleDeleteBehavior(behavior.id)}
-                className="text-primary-weak hover:text-label-disable transition-colors"
-                aria-label="지우기"
-              >
-                <Minus className="h-6 w-6 stroke-[3px]" />
-              </button>
-            )}
-          </div>
-        ))}
-        {/* 행동 추가 버튼 */}
-        {isEditing && (
-          <button
-            type="button"
-            onClick={handleAddBehavior}
-            className="border-primary-strong/40 text-label-alternative hover:bg-bg-light hover:border-primary-normal mt-2 flex w-full items-center justify-center gap-2 rounded-2xl border-2 border-dashed py-3 font-bold"
-          >
-            <Plus size={20} strokeWidth={2.5} /> 추가
-          </button>
+      <div className="bg-primary-weak/30 scrollbar-pretty max-h-[60vh] min-h-[45vh] flex-1 overflow-y-auto rounded-2xl p-6">
+        {!isLoading && filteredBehaviors.length === 0 && (
+          <p className="text-label-disable text-sm">등록된 행동이 없습니다.</p>
         )}
+
+        <div className="flex flex-col gap-3">
+          {filteredBehaviors.map((behavior: Behavior) => (
+            <div
+              key={behavior.id}
+              className="bg-bg-light flex items-center gap-3 rounded-2xl px-4 py-3 shadow-sm transition-all duration-200"
+            >
+              {/* 내용 수정 */}
+              <div className="min-w-0 flex-1">
+                {isEditing ? (
+                  <input
+                    type="text"
+                    placeholder="행동을 입력해주세요"
+                    value={behavior.title}
+                    maxLength={BEHAVIOR_TITLE_MAX_LENGTH}
+                    onChange={(e) => handleChangeTitle(behavior.id, e.target.value)}
+                    className="text-label-normal w-full bg-transparent font-semibold focus:outline-none"
+                  />
+                ) : (
+                  <p className="text-label-alternative truncate font-semibold">{behavior.title}</p>
+                )}
+              </div>
+
+              {/* 난이도 표시 */}
+              <div className="relative shrink-0">
+                {isEditing ? (
+                  <>
+                    <DifficultyBadge
+                      level={behavior.difficulty}
+                      onClick={() =>
+                        setOpenDropdownId(openDropdownId === behavior.id ? null : behavior.id)
+                      }
+                      className="hover:ring-primary-strong/30 cursor-pointer hover:ring-2 hover:ring-offset-1"
+                    />
+
+                    {/* 난이도 선택 드롭다운 */}
+                    {openDropdownId === behavior.id && (
+                      <div className="animate-in fade-in zoom-in-95 border-bg-normal bg-bg-light absolute top-full -left-3 z-20 mt-2 flex w-max flex-col gap-1 rounded-xl border p-1.5 shadow-xl duration-100">
+                        {BEHAVIOR_DIFFICULTIES.map((diff) => (
+                          <button
+                            type="button"
+                            key={diff}
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              handleChangeDifficulty(behavior.id, diff);
+                              setOpenDropdownId(null);
+                            }}
+                            className={`rounded-lg px-3 py-2 text-left text-xs font-bold transition-colors ${
+                              behavior.difficulty === diff
+                                ? `${DIFFICULTY_COLOR_STYLES[behavior.difficulty].bg} ${DIFFICULTY_COLOR_STYLES[behavior.difficulty].txt}`
+                                : 'text-label-disable hover:bg-primary-strong/30'
+                            } `}
+                          >
+                            {diff}
+                          </button>
+                        ))}
+                      </div>
+                    )}
+                  </>
+                ) : (
+                  <DifficultyBadge level={behavior.difficulty} />
+                )}
+              </div>
+
+              {/* 삭제 버튼 */}
+              {isEditing && (
+                <button
+                  type="button"
+                  onClick={() => handleDeleteBehavior(behavior.id)}
+                  className="text-primary-weak hover:text-label-disable transition-colors"
+                  aria-label="지우기"
+                >
+                  <Minus className="h-6 w-6 stroke-[3px]" />
+                </button>
+              )}
+            </div>
+          ))}
+          {/* 행동 추가 버튼 */}
+          {isEditing && (
+            <button
+              type="button"
+              onClick={handleAddBehavior}
+              className="border-primary-strong/40 text-label-alternative hover:bg-bg-light hover:border-primary-normal mt-2 flex w-full items-center justify-center gap-2 rounded-2xl border-2 border-dashed py-3 font-bold"
+            >
+              <Plus size={20} strokeWidth={2.5} /> 추가
+            </button>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/apps/frontend/src/features/goal/components/GoalBehaviorList.tsx
+++ b/apps/frontend/src/features/goal/components/GoalBehaviorList.tsx
@@ -8,6 +8,7 @@ import {
 import { DifficultyBadge } from '@/shared/components/behavior/DifficultyBadge';
 import { Minus, Plus } from 'lucide-react';
 import { DIFFICULTY_COLOR_STYLES } from '@/shared/constants/difficultyColor';
+import { toast } from 'react-toastify';
 import { createGoalBehaviors } from '../apis/createGoalBehaviors.api';
 import { updateGoalBehaviors } from '../apis/updateGoalBehaviors.api';
 import { deleteGoalBehaviors } from '../apis/deleteGoalBehaviors.api';
@@ -111,7 +112,7 @@ export function GoalBehaviorList({
       onRefetch();
       setIsEditing(false);
     } catch (e) {
-      console.error(e);
+      toast.error(`저장에 실패했습니다. 다시 시도해주세요: ${e}`);
     }
   };
 
@@ -195,7 +196,7 @@ export function GoalBehaviorList({
               onClick={toggleEditMode}
               className="bg-secondary-strong text-bg-light cursor-pointer rounded-full px-3 py-1 text-[12px] font-bold"
             >
-              수정
+              행동 수정
             </button>
           )}
         </div>

--- a/apps/frontend/src/features/goal/components/GoalColorPicker.tsx
+++ b/apps/frontend/src/features/goal/components/GoalColorPicker.tsx
@@ -1,6 +1,7 @@
 import { GOAL_COLOR_STYLES } from '@/shared/constants/goalColor';
 import { GOAL_COLORS, type GoalColor } from '@web24/shared';
 import { Check } from 'lucide-react';
+import { useState } from 'react';
 
 interface GoalColorPickerProps {
   selectedColor: GoalColor;
@@ -9,7 +10,7 @@ interface GoalColorPickerProps {
 
 export function GoalColorPicker({ selectedColor, onSelect }: GoalColorPickerProps) {
   return (
-    <div className="grid grid-cols-5 gap-4 p-4">
+    <div className="grid grid-cols-3 gap-4 p-4 md:grid-cols-5">
       {GOAL_COLORS.map((color) => {
         const isSelected = selectedColor === color;
         return (
@@ -29,6 +30,35 @@ export function GoalColorPicker({ selectedColor, onSelect }: GoalColorPickerProp
           </button>
         );
       })}
+    </div>
+  );
+}
+
+export function GoalColorPickerPopover({ selectedColor, onSelect }: GoalColorPickerProps) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <div className="relative">
+      {/* 현재 색상 원 */}
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className={`border-primary-strong h-6 w-6 cursor-pointer rounded-full border-2 ${GOAL_COLOR_STYLES[selectedColor].bg}`}
+        aria-label="목표 색상 변경"
+      />
+
+      {/* 팝업 */}
+      {open && (
+        <div className="bg-bg-light absolute top-12 right-0 z-30 w-56 rounded-xl border shadow-xl md:w-90">
+          <GoalColorPicker
+            selectedColor={selectedColor}
+            onSelect={(color) => {
+              onSelect(color);
+              setOpen(false);
+            }}
+          />
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/frontend/src/features/goal/components/GoalDetailPageHeader.tsx
+++ b/apps/frontend/src/features/goal/components/GoalDetailPageHeader.tsx
@@ -55,8 +55,9 @@ function ViewHeader({ goal, onStartEdit }: ViewHeaderProps) {
         </button>
 
         <button
+          disabled
           type="button"
-          className="cursor-pointer rounded-lg bg-[#c94949] px-4 py-1 font-medium text-white hover:bg-[#c77777]"
+          className="cursor-not-allowed rounded-lg bg-[#c94949] px-4 py-1 font-medium text-white"
         >
           삭제
         </button>

--- a/apps/frontend/src/features/goal/components/GoalDetailPageHeader.tsx
+++ b/apps/frontend/src/features/goal/components/GoalDetailPageHeader.tsx
@@ -1,0 +1,163 @@
+import { GOAL_TITLE_MAX_LENGTH, type Goal, type GoalColor } from '@web24/shared';
+import { GOAL_COLOR_STYLES } from '@/shared/constants/goalColor';
+import { GoalColorPickerPopover } from './GoalColorPicker';
+
+interface ViewHeaderProps {
+  goal?: Goal;
+  onStartEdit: () => void;
+}
+
+interface EditHeaderProps {
+  title: string;
+  color: GoalColor;
+  onChangeTitle: (v: string) => void;
+  onChangeColor: (c: GoalColor) => void;
+  onCancel: () => void;
+  onSave: () => void;
+}
+
+interface GoalDetailPageHeaderProps {
+  goal?: Goal;
+  isLoading: boolean;
+
+  isEditing: boolean;
+  editTitle: string;
+  editColor: GoalColor;
+
+  onChangeTitle: (v: string) => void;
+  onChangeColor: (c: GoalColor) => void;
+
+  onStartEdit: () => void;
+  onCancel: () => void;
+  onSave: () => void;
+}
+
+// 보기모드 헤더
+function ViewHeader({ goal, onStartEdit }: ViewHeaderProps) {
+  return (
+    <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+      {/* 왼쪽 */}
+      <div className="flex items-center gap-3">
+        <h1 className="flex items-center gap-2 text-2xl font-bold text-gray-800">
+          {goal?.title ?? '목표'}
+          {goal && <span className={`h-5 w-5 rounded-full ${GOAL_COLOR_STYLES[goal.color].bg}`} />}
+        </h1>
+      </div>
+
+      {/* 오른쪽 버튼 */}
+      <div className="flex gap-2">
+        <button
+          type="button"
+          onClick={onStartEdit}
+          className="border-label-alternative text-label-normal cursor-pointer rounded-lg border px-4 py-1 hover:bg-gray-100"
+        >
+          편집
+        </button>
+
+        <button
+          type="button"
+          className="cursor-pointer rounded-lg bg-[#c94949] px-4 py-1 font-medium text-white hover:bg-[#c77777]"
+        >
+          삭제
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// 수정 모드 헤더
+function EditHeader({
+  title,
+  color,
+  onChangeTitle,
+  onChangeColor,
+  onCancel,
+  onSave,
+}: EditHeaderProps) {
+  const titleLength = title.length;
+
+  return (
+    <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+      {/* 왼쪽 */}
+      <div className="flex flex-1 items-center gap-3">
+        {/* 제목 input wrapper */}
+        <div className="relative max-w-100 flex-1">
+          <input
+            value={title}
+            onChange={(e) => onChangeTitle(e.target.value)}
+            maxLength={GOAL_TITLE_MAX_LENGTH}
+            // eslint-disable-next-line jsx-a11y/no-autofocus
+            autoFocus
+            className="focus:ring-primary-strong border-primary-normal w-full rounded-lg border px-3 py-2 pr-10 text-2xl font-bold focus:ring-2 focus:outline-none"
+            placeholder="목표 제목"
+          />
+
+          {/* 글자 수 */}
+          <span className="text-label-disable pointer-events-none absolute top-1/2 right-2 text-xs">
+            {titleLength}/{GOAL_TITLE_MAX_LENGTH}
+          </span>
+        </div>
+
+        {/* 색상 원 + 팝오버 */}
+        <GoalColorPickerPopover selectedColor={color} onSelect={onChangeColor} />
+      </div>
+
+      {/* 오른쪽 버튼 */}
+      <div className="flex gap-2 sm:shrink-0">
+        <button
+          type="button"
+          onClick={onCancel}
+          className="border-label-normal text-label-normal hover:bg-bg-alternative cursor-pointer rounded-lg border px-4 py-1"
+        >
+          취소
+        </button>
+
+        <button
+          type="button"
+          onClick={onSave}
+          className="bg-primary-strong hover:bg-primary-normal cursor-pointer rounded-lg px-4 py-1 font-medium text-white"
+        >
+          저장
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export default function GoalDetailPageHeader({
+  goal,
+  isLoading,
+  isEditing,
+  editTitle,
+  editColor,
+  onChangeTitle,
+  onChangeColor,
+  onStartEdit,
+  onCancel,
+  onSave,
+}: GoalDetailPageHeaderProps) {
+  if (isLoading) {
+    return (
+      <header className="mb-6">
+        <div className="h-10 w-1/3 animate-pulse rounded bg-gray-200" />
+      </header>
+    );
+  }
+
+  return (
+    <header className="mb-6">
+      {isEditing ? (
+        <EditHeader
+          title={editTitle}
+          color={editColor}
+          onChangeTitle={onChangeTitle}
+          onChangeColor={onChangeColor}
+          onCancel={onCancel}
+          onSave={onSave}
+        />
+      ) : (
+        <ViewHeader goal={goal} onStartEdit={onStartEdit} />
+      )}
+    </header>
+  );
+}

--- a/apps/frontend/src/features/goal/components/SummaryView.tsx
+++ b/apps/frontend/src/features/goal/components/SummaryView.tsx
@@ -1,0 +1,80 @@
+import { BEHAVIOR_DIFFICULTIES, type BehaviorDifficulty, type GoalColor } from '@web24/shared';
+import { ChevronRight } from 'lucide-react';
+import { GOAL_COLOR_STYLES } from '@/shared/constants/goalColor';
+import { DifficultyBadge } from '@/shared/components/behavior/DifficultyBadge';
+import type { BehaviorItem } from './BehaviorSelection';
+
+interface SummaryViewProps {
+  goalTitle: string;
+  goalColor: GoalColor;
+  behaviorsMap: Record<Exclude<BehaviorDifficulty, 'AI'>, BehaviorItem[]>;
+  onEditStep: (stepIndex: number) => void;
+}
+
+export function SummaryView({ goalTitle, goalColor, behaviorsMap, onEditStep }: SummaryViewProps) {
+  return (
+    <div className="flex h-full w-full flex-col gap-4">
+      <div className="custom-scrollbar flex flex-1 flex-col gap-5 overflow-y-auto pr-2 pb-4">
+        {/* 목표 헤더 */}
+        <button
+          type="button"
+          onClick={() => onEditStep(1)}
+          className={`group relative cursor-pointer overflow-hidden rounded-3xl p-6 shadow-lg transition-all hover:scale-[0.98] ${GOAL_COLOR_STYLES[goalColor].bg}`}
+        >
+          <div className="absolute top-0 right-0 p-4 opacity-0 transition-opacity group-hover:opacity-100">
+            <span className="bg-bg-light/20 text-bg-light rounded-full px-2 py-1 text-[10px] font-bold backdrop-blur-sm">
+              수정
+            </span>
+          </div>
+          <span className="text-bg-light/60 mb-1 block text-[10px] font-bold tracking-widest">
+            MY GOAL
+          </span>
+          <h3 className="text-bg-light text-2xl leading-tight font-bold">
+            {goalTitle || '제목 없음'}
+          </h3>
+        </button>
+
+        {/* 난이도 별 행동 리스트 */}
+        {BEHAVIOR_DIFFICULTIES.filter((difficulty) => difficulty !== 'AI').map(
+          (difficulty, idx) => {
+            const items = behaviorsMap[difficulty];
+            const stepIndex = idx + 2;
+
+            return (
+              <button
+                type="button"
+                key={difficulty}
+                onClick={() => onEditStep(stepIndex)}
+                className="group border-primary-weak bg-bg-light hover:border-primary-strong cursor-pointer rounded-2xl border p-5 shadow-sm transition-all hover:shadow-md"
+              >
+                <div className="mb-3 flex items-center justify-between">
+                  <DifficultyBadge
+                    level={difficulty}
+                    className="px-3 py-1 text-[14px]"
+                    count={items.length}
+                  />
+                  <span className="text-label-disable/70 group-hover:text-label-disable flex items-center gap-1 text-[12px] font-bold transition-colors">
+                    수정 <ChevronRight size={12} />
+                  </span>
+                </div>
+
+                <div className="flex flex-col gap-3">
+                  {items.map((item) => (
+                    <div
+                      key={item.id}
+                      className="bg-bg-alternative/50 border-primary-strong flex items-center gap-2 rounded-xl border p-3"
+                    >
+                      <span className="text-label-alternative text-sm leading-snug font-medium">
+                        {item.title}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              </button>
+            );
+          },
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/features/goal/hooks/useAllBehaviors.spec.ts
+++ b/apps/frontend/src/features/goal/hooks/useAllBehaviors.spec.ts
@@ -1,0 +1,70 @@
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { useAllBehaviors } from './useAllBehaviors';
+import { fetchAllBehaviors } from '../apis/fetchAllBehaviors.api';
+
+vi.mock('../apis/fetchAllBehaviors.api', () => ({
+  fetchAllBehaviors: vi.fn(),
+}));
+
+describe('useAllBehaviors Hook', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('enabled가 false(기본값)일 때는 데이터를 자동으로 불러오지 않아야 한다', () => {
+    const { result } = renderHook(() => useAllBehaviors());
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.allBehaviors).toBeUndefined();
+    expect(fetchAllBehaviors).not.toHaveBeenCalled();
+  });
+
+  it('enabled가 true일 때는 자동으로 데이터를 불러와야 한다', async () => {
+    const mockData = [
+      { id: '1', title: '행동 1', difficulty: '마음열기', isCompleted: false },
+      { id: '2', title: '행동 2', difficulty: '몰입하기', isCompleted: true },
+    ];
+    (fetchAllBehaviors as any).mockResolvedValue(mockData);
+
+    const { result } = renderHook(() => useAllBehaviors(true));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.allBehaviors).toEqual(mockData);
+    expect(result.current.error).toBeNull();
+    expect(fetchAllBehaviors).toHaveBeenCalledTimes(1);
+  });
+
+  it('refetch 함수를 호출하면 데이터를 다시 불러와야 한다', async () => {
+    const mockData = [{ id: '1', title: '새로운 행동' }];
+    (fetchAllBehaviors as any).mockResolvedValue(mockData);
+
+    const { result } = renderHook(() => useAllBehaviors(false));
+
+    expect(fetchAllBehaviors).not.toHaveBeenCalled();
+
+    await act(async () => {
+      await result.current.refetch();
+    });
+
+    expect(result.current.allBehaviors).toEqual(mockData);
+    expect(fetchAllBehaviors).toHaveBeenCalledTimes(1);
+  });
+
+  it('API 호출 실패 시 에러 상태가 설정되어야 한다', async () => {
+    const mockError = new Error('Failed to fetch all behaviors');
+    (fetchAllBehaviors as any).mockRejectedValue(mockError);
+
+    const { result } = renderHook(() => useAllBehaviors(true));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.allBehaviors).toBeUndefined();
+    expect(result.current.error).toEqual(mockError);
+  });
+});

--- a/apps/frontend/src/features/goal/hooks/useGoalBehaviors.spec.ts
+++ b/apps/frontend/src/features/goal/hooks/useGoalBehaviors.spec.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import type { Behavior } from '@web24/shared';
+import { useGoalBehaviors } from './useGoalBehaviors';
+import { fetchGoalBehaviors } from '../apis/fetchGoalBehaviors.api';
+
+vi.mock('../apis/fetchGoalBehaviors.api');
+
+describe('useGoalBehaviors', () => {
+  const mockedFetch = vi.mocked(fetchGoalBehaviors);
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('초기 로딩 후 behaviors를 정상적으로 가져온다', async () => {
+    const goalId = 'goal-1';
+    const mockData: Behavior[] = [
+      { id: 'b1', title: '물 1컵 마시기', difficulty: '마음열기' },
+      { id: 'b2', title: '스트레칭 5분', difficulty: '시작하기' },
+    ];
+
+    mockedFetch.mockResolvedValueOnce(mockData);
+
+    const { result } = renderHook(() => useGoalBehaviors(goalId));
+
+    // isLoading 초기 상태 확인
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.behaviors).toBeUndefined();
+    expect(result.current.error).toBeNull();
+
+    // behaviors 값이 변경될 때까지 기다리기
+    await waitFor(() => expect(result.current.behaviors).toEqual(mockData));
+
+    // 데이터 확인
+    expect(result.current.behaviors).toEqual(mockData);
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('fetch 실패 시 error를 설정한다', async () => {
+    const goalId = 'goal-1';
+    mockedFetch.mockRejectedValueOnce(new Error('Network Error'));
+
+    const { result } = renderHook(() => useGoalBehaviors(goalId));
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.behaviors).toBeUndefined();
+    expect(result.current.error).toEqual(new Error('Network Error'));
+  });
+
+  it('enabled가 false면 자동 호출하지 않는다', () => {
+    const goalId = 'goal-1';
+    renderHook(() => useGoalBehaviors(goalId, false));
+
+    expect(mockedFetch).not.toHaveBeenCalled();
+  });
+
+  it('refetch 호출 시 다시 데이터를 가져온다', async () => {
+    const goalId = 'goal-1';
+    const initialData: Behavior[] = [{ id: 'b1', title: '물 1컵 마시기', difficulty: '마음열기' }];
+
+    mockedFetch.mockResolvedValueOnce(initialData);
+
+    const { result } = renderHook(() => useGoalBehaviors(goalId));
+
+    await waitFor(() => expect(result.current.behaviors).toEqual(initialData));
+
+    // refetch용 새로운 데이터
+    const newData: Behavior[] = [{ id: 'b2', title: '스트레칭 5분', difficulty: '시작하기' }];
+    mockedFetch.mockResolvedValueOnce(newData);
+
+    await act(async () => {
+      await result.current.refetch();
+    });
+
+    expect(result.current.behaviors).toEqual(newData);
+  });
+});

--- a/apps/frontend/src/features/goal/hooks/useGoalBehaviors.ts
+++ b/apps/frontend/src/features/goal/hooks/useGoalBehaviors.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import type { Behavior } from '@web24/shared';
 import { fetchGoalBehaviors } from '../apis/fetchGoalBehaviors.api';
 
@@ -7,37 +7,23 @@ export function useGoalBehaviors(goalId: string, enabled: boolean = true) {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<Error | null>(null);
 
-  useEffect(() => {
-    let cancelled = false;
-
-    if (enabled && goalId) {
-      setIsLoading(true);
-
-      const loadBehaviors = async () => {
-        try {
-          const data = await fetchGoalBehaviors(goalId);
-          if (!cancelled) {
-            setBehaviors(data);
-            setError(null);
-          }
-        } catch (err) {
-          if (!cancelled) {
-            setError(err instanceof Error ? err : new Error('Failed to fetch behaviors'));
-          }
-        } finally {
-          if (!cancelled) {
-            setIsLoading(false);
-          }
-        }
-      };
-
-      loadBehaviors();
+  const loadBehaviors = useCallback(async () => {
+    if (!goalId) return;
+    setIsLoading(true);
+    try {
+      const data = await fetchGoalBehaviors(goalId);
+      setBehaviors(data);
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err : new Error('Failed to fetch'));
+    } finally {
+      setIsLoading(false);
     }
+  }, [goalId]);
 
-    return () => {
-      cancelled = true;
-    };
-  }, [goalId, enabled]);
+  useEffect(() => {
+    if (enabled) loadBehaviors();
+  }, [enabled, loadBehaviors]);
 
-  return { behaviors, isLoading, error };
+  return { behaviors, isLoading, error, refetch: loadBehaviors };
 }

--- a/apps/frontend/src/features/goal/hooks/useGoals.spec.ts
+++ b/apps/frontend/src/features/goal/hooks/useGoals.spec.ts
@@ -1,0 +1,58 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { useGoals } from './useGoals';
+import { fetchGoals } from '../apis/fetchGoals.api';
+
+vi.mock('../apis/fetchGoals.api', () => ({
+  fetchGoals: vi.fn(),
+}));
+
+describe('useGoals Hook', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('초기 렌더링 시 로딩 상태여야 한다', async () => {
+    (fetchGoals as any).mockReturnValue(new Promise(() => {}));
+
+    const { result } = renderHook(() => useGoals());
+
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.goals).toBeUndefined();
+    expect(result.current.error).toBeNull();
+  });
+
+  it('데이터를 성공적으로 불러오면 goals에 데이터가 담기고 로딩이 끝나야 한다', async () => {
+    const mockData = {
+      goals: [
+        { id: '1', title: 'Goal 1', color: 'green' },
+        { id: '2', title: 'Goal 2', color: 'blue' },
+      ],
+    };
+
+    (fetchGoals as any).mockResolvedValue(mockData);
+
+    const { result } = renderHook(() => useGoals());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.goals).toEqual(mockData);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('API 호출 실패 시 에러 상태가 설정되어야 한다', async () => {
+    const mockError = new Error('Network Error');
+    (fetchGoals as any).mockRejectedValue(mockError);
+
+    const { result } = renderHook(() => useGoals());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.goals).toBeUndefined();
+    expect(result.current.error).toEqual(mockError);
+  });
+});

--- a/apps/frontend/src/pages/GoalDetailPage.tsx
+++ b/apps/frontend/src/pages/GoalDetailPage.tsx
@@ -9,10 +9,18 @@ import { Swiper, SwiperSlide } from 'swiper/react';
 import 'swiper/css';
 import GoalDetailPageHeader from '@/features/goal/components/GoalDetailPageHeader';
 import { updateGoal } from '@/features/goal/apis/updateGoal.api';
+import { useGoalBehaviors } from '@/features/goal/hooks/useGoalBehaviors';
 
 export function GoalDetailPage() {
-  const [goal, setGoal] = useState<Goal | undefined>();
   const { goalId } = useParams<{ goalId: string }>();
+
+  const {
+    behaviors,
+    isLoading: isBehaviorsLoading,
+    refetch: refetchBehaviors,
+  } = useGoalBehaviors(goalId!, Boolean(goalId));
+
+  const [goal, setGoal] = useState<Goal | undefined>();
   const [stamps, setStamps] = useState<GoalStamp[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<Error | null>(null);
@@ -105,7 +113,16 @@ export function GoalDetailPage() {
           </p>
           <GoalStampBoard stamps={stamps} />
         </div>
-        <div className="w-1/2">{goalId && <GoalBehaviorList goalId={goalId} />}</div>
+        <div className="w-1/2">
+          {goalId && (
+            <GoalBehaviorList
+              goalId={goalId}
+              behaviors={behaviors}
+              isLoading={isBehaviorsLoading}
+              onRefetch={refetchBehaviors}
+            />
+          )}
+        </div>
       </div>
 
       {/* 목표 본문 (<TABLET) */}
@@ -143,7 +160,14 @@ export function GoalDetailPage() {
             </SwiperSlide>
 
             <SwiperSlide className="box-border p-2">
-              {goalId && <GoalBehaviorList goalId={goalId} />}
+              {goalId && (
+                <GoalBehaviorList
+                  goalId={goalId}
+                  behaviors={behaviors}
+                  isLoading={isBehaviorsLoading}
+                  onRefetch={refetchBehaviors}
+                />
+              )}
             </SwiperSlide>
           </Swiper>
         </div>

--- a/apps/frontend/src/pages/GoalDetailPage.tsx
+++ b/apps/frontend/src/pages/GoalDetailPage.tsx
@@ -2,20 +2,26 @@ import { fetchGoalStamps } from '@/features/goal/apis/fetchGoalStamps.api';
 import { fetchGoal } from '@/features/goal/apis/fetchGoal.api';
 import { GoalBehaviorList } from '@/features/goal/components/GoalBehaviorList';
 import { GoalStampBoard } from '@/features/goal/components/GoalStampBoard';
-import { type Goal, type GoalStamp } from '@web24/shared';
+import { type Goal, type GoalColor, type GoalStamp } from '@web24/shared';
 import { useEffect, useState, useRef } from 'react';
 import { useParams } from 'react-router-dom';
 import { Swiper, SwiperSlide } from 'swiper/react';
 import 'swiper/css';
+import GoalDetailPageHeader from '@/features/goal/components/GoalDetailPageHeader';
+import { updateGoal } from '@/features/goal/apis/updateGoal.api';
 
 export function GoalDetailPage() {
-  const [goal, setGoal] = useState<Goal | null>(null);
+  const [goal, setGoal] = useState<Goal | undefined>();
   const { goalId } = useParams<{ goalId: string }>();
   const [stamps, setStamps] = useState<GoalStamp[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<Error | null>(null);
   const [activeIndex, setActiveIndex] = useState(0);
   const swiperRef = useRef<any>(null);
+
+  const [isEditing, setIsEditing] = useState(false);
+  const [editTitle, setEditTitle] = useState('');
+  const [editColor, setEditColor] = useState<GoalColor>('beige');
 
   useEffect(() => {
     let cancelled = false;
@@ -30,6 +36,8 @@ export function GoalDetailPage() {
         if (cancelled) return;
         setGoal(goalData);
         setStamps(stampsData);
+        setEditTitle(goalData.title);
+        setEditColor(goalData.color);
         setError(null);
       })
       .catch((err) => {
@@ -46,14 +54,47 @@ export function GoalDetailPage() {
     };
   }, [goalId]);
 
+  // 수정 핸들러
+  const handleUpdate = async () => {
+    if (!goalId || !goal) return;
+
+    try {
+      const updated = await updateGoal(goalId, {
+        title: editTitle,
+        color: editColor,
+      });
+
+      setGoal(updated);
+      setIsEditing(false);
+    } catch (e) {
+      setError(e instanceof Error ? e : new Error('Failed to update goal'));
+    }
+  };
+
+  // 수정 취소 핸들러
+  const handleCancel = () => {
+    if (goal) {
+      setEditTitle(goal.title);
+      setEditColor(goal.color);
+    }
+    setIsEditing(false);
+  };
+
   return (
     <div className="mx-auto max-w-7xl p-4 sm:px-6 lg:px-8">
       {/* 목표 헤더 */}
-      <header className="mb-4 flex flex-col items-start justify-between gap-4 sm:flex-row sm:items-center">
-        <h1 className="text-label-normal text-title-1 font-bold">
-          {isLoading ? '불러오는 중...' : (goal?.title ?? '목표')}
-        </h1>
-      </header>
+      <GoalDetailPageHeader
+        goal={goal}
+        isLoading={isLoading}
+        isEditing={isEditing}
+        editColor={editColor}
+        editTitle={editTitle}
+        onChangeTitle={setEditTitle}
+        onChangeColor={setEditColor}
+        onStartEdit={() => setIsEditing(true)}
+        onCancel={handleCancel}
+        onSave={handleUpdate}
+      />
       {error && <p>데이터를 불러오는 데 실패했습니다.</p>}
 
       {/* 목표 본문(>=TABLET) */}

--- a/apps/frontend/src/pages/NewGoalPage.spec.tsx
+++ b/apps/frontend/src/pages/NewGoalPage.spec.tsx
@@ -191,6 +191,7 @@ describe('NewGoalPage', () => {
     fireEvent.click(screen.getByRole('button', { name: '다음' }));
     fireEvent.click(screen.getByRole('button', { name: '다음' }));
     fireEvent.click(screen.getByRole('button', { name: '다음' }));
+    fireEvent.click(screen.getByRole('button', { name: '다음' }));
 
     await fireEvent.click(screen.getByRole('button', { name: '완료' }));
 

--- a/apps/frontend/src/pages/NewGoalPage.tsx
+++ b/apps/frontend/src/pages/NewGoalPage.tsx
@@ -10,6 +10,7 @@ import { NewGoal } from '@/features/goal/components/NewGoal';
 import { createGoal } from '@/features/goal/apis/createGoal.api';
 import { v7 } from 'uuid';
 import { toast } from 'react-toastify';
+import { SummaryView } from '@/features/goal/components/SummaryView';
 
 export function NewGoalPage() {
   const navigate = useNavigate();
@@ -25,6 +26,13 @@ export function NewGoalPage() {
   const [startBehaviors, setStartBehaviors] = useState<BehaviorItem[]>([]);
   const [continueBehaviors, setContinueBehaviors] = useState<BehaviorItem[]>([]);
   const [deepBehaviors, setDeepBehaviors] = useState<BehaviorItem[]>([]);
+
+  const behaviorsMap = {
+    [BEHAVIOR_DIFFICULTIES[0]]: openBehaviors,
+    [BEHAVIOR_DIFFICULTIES[1]]: startBehaviors,
+    [BEHAVIOR_DIFFICULTIES[2]]: continueBehaviors,
+    [BEHAVIOR_DIFFICULTIES[3]]: deepBehaviors,
+  };
 
   const newGoalFrameSteps: NewGoalFrameStep[] = [
     {
@@ -179,6 +187,20 @@ export function NewGoalPage() {
         />
       ),
     },
+    {
+      step: 7,
+      headerText: '최종 확인',
+      unskippable: true,
+      dialogue: DODO_LINES.summary,
+      content: (
+        <SummaryView
+          goalTitle={newGoalTitle}
+          goalColor={newGoalColor}
+          behaviorsMap={behaviorsMap}
+          onEditStep={(stepIdx) => setCurrentStepIndex(stepIdx)}
+        />
+      ),
+    },
   ];
 
   const handleSkip = () => {};
@@ -222,10 +244,13 @@ export function NewGoalPage() {
     <NewGoalFrame
       currStepIdx={currentStepIndex}
       steps={newGoalFrameSteps}
-      progressSteps={[2, 3, 4, 5, 6]}
+      progressSteps={[2, 3, 4, 5, 6, 7]}
       onMove={(targetIdx) => setCurrentStepIndex(targetIdx)}
       onSkip={handleSkip}
-      onComplete={handleComplete}
+      onComplete={() => {
+        if (currentStepIndex === newGoalFrameSteps.length - 1) handleComplete();
+        else setCurrentStepIndex((prev) => prev + 1);
+      }}
     />
   );
 }

--- a/apps/frontend/src/pages/NewGoalPage.tsx
+++ b/apps/frontend/src/pages/NewGoalPage.tsx
@@ -203,7 +203,9 @@ export function NewGoalPage() {
     },
   ];
 
-  const handleSkip = () => {};
+  const handleSkip = () => {
+    setCurrentStepIndex(newGoalFrameSteps.length - 1);
+  };
 
   const handleComplete = async () => {
     const isDemoBlocked = import.meta.env.VITE_DEMO_LOCK_CREATE_GOAL === 'true';

--- a/apps/frontend/src/shared/hooks/useScroll.spec.ts
+++ b/apps/frontend/src/shared/hooks/useScroll.spec.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useScroll } from './useScroll';
+
+describe('useScroll', () => {
+  afterEach(() => {
+    // scrollY 초기화
+    window.scrollY = 0;
+    vi.restoreAllMocks();
+  });
+
+  it('초기 scrollY가 threshold보다 작으면 false 반환', () => {
+    window.scrollY = 5;
+    const { result } = renderHook(() => useScroll(10));
+    expect(result.current).toBe(false);
+  });
+
+  it('scrollY가 threshold보다 크면 true 반환', () => {
+    window.scrollY = 20;
+    const { result } = renderHook(() => useScroll(10));
+    expect(result.current).toBe(true);
+  });
+
+  it('스크롤 이벤트 발생 시 isScrolled 상태가 변경된다', () => {
+    const { result } = renderHook(() => useScroll(10));
+
+    // 초기값
+    expect(result.current).toBe(false);
+
+    act(() => {
+      window.scrollY = 15;
+      globalThis.dispatchEvent(new Event('scroll'));
+    });
+
+    expect(result.current).toBe(true);
+
+    act(() => {
+      window.scrollY = 5;
+      globalThis.dispatchEvent(new Event('scroll'));
+    });
+
+    expect(result.current).toBe(false);
+  });
+
+  it('threshold를 커스텀으로 지정할 수 있다', () => {
+    window.scrollY = 50;
+    const { result } = renderHook(() => useScroll(40));
+    expect(result.current).toBe(true);
+
+    const { result: result2 } = renderHook(() => useScroll(60));
+    expect(result2.current).toBe(false);
+  });
+});

--- a/packages/shared/src/schemas/goal.schemas.ts
+++ b/packages/shared/src/schemas/goal.schemas.ts
@@ -95,3 +95,18 @@ export const GoalStampSchema = z.object({
 
 export const GetGoalStampsResponseSchema = z.array(GoalStampSchema);
 export type GetGoalStampsResponse = z.infer<typeof GetGoalStampsResponseSchema>;
+
+export const CreateGoalBehaviorsRequestSchema = z.object({
+  behaviors: z.array(CreateGoalBehaviorSchema).min(1),
+});
+export type CreateGoalBehaviorsRequest = z.infer<typeof CreateGoalBehaviorsRequestSchema>;
+
+export const UpdateGoalBehaviorsRequestSchema = z.object({
+  behaviors: z.array(CreateGoalBehaviorResponseSchema),
+});
+export type UpdateGoalBehaviorsRequest = z.infer<typeof UpdateGoalBehaviorsRequestSchema>;
+
+export const DeleteGoalBehaviorsRequestSchema = z.object({
+  behaviorIds: z.array(z.uuid({ version: 'v7' })).min(1),
+});
+export type DeleteGoalBehaviorsRequest = z.infer<typeof DeleteGoalBehaviorsRequestSchema>;

--- a/packages/shared/src/schemas/goal.schemas.ts
+++ b/packages/shared/src/schemas/goal.schemas.ts
@@ -48,6 +48,21 @@ export const CreateGoalResponseSchema = z.object({
 
 export type CreateGoalResponse = z.infer<typeof CreateGoalResponseSchema>;
 
+export const UpdateGoalRequestSchema = z.object({
+  title: z.string().min(1).max(GOAL_TITLE_MAX_LENGTH),
+  color: z.enum(GOAL_COLORS),
+});
+
+export type UpdateGoalRequest = z.infer<typeof UpdateGoalRequestSchema>;
+
+export const UpdateGoalResponseSchema = z.object({
+  id: z.uuid({ version: 'v7' }),
+  title: z.string().min(1).max(GOAL_TITLE_MAX_LENGTH),
+  color: z.enum(GOAL_COLORS),
+});
+
+export type UpdateGoalResponse = z.infer<typeof UpdateGoalResponseSchema>;
+
 export const GetGoalSummarySchema = z.object({
   id: z.uuid(),
   createdAt: z.iso.datetime(),


### PR DESCRIPTION
## 🔗 관련 이슈

- close: #111, #21

## ✅ 작업 내용
- 목표 상세 페이지:
   - 목표 제목, 목표 색상 수정 기능 구현 (`PUT /api/goals/:id`)
   - 목표 행동 리스트:
      - 행동 내용, 난이도 수정 기능 구현 (`PATCH /api/goals/:goalId/behaviors`)
      - 행동 추가 (`POST /api/goals/:goalId/behaviors`), 삭제 기능 구현 (`DELETE /api/goals/:goalId/behaviors`)
- 목표 추가 페이지
   - 목표 요약 UI 구현

## 📸 스크린샷 / 데모 (옵션)

- 목표 상세 페이지 - 기본
<img width="600" alt="detail-1" src="https://github.com/user-attachments/assets/ffcf7e6c-ca5e-4cde-a7cd-5775684d6fea" />

- 목표 상세 페이지 - 목표 수정
<img width="600" alt="detail-2" src="https://github.com/user-attachments/assets/15d5b724-1fd3-4b7a-8a1c-2d75f26310b9" />

- 목표 상세 페이지 - 행동 수정
<img width="600" alt="detail-2" src="https://github.com/user-attachments/assets/571d74d8-722e-4975-b46f-7c500345265a" />

- 목표 요약 UI
<img width="600" alt="summary" src="https://github.com/user-attachments/assets/b356bf07-8f38-4a67-8abf-8b3ea083fe2f" />

> 난이도 컨테이너 클릭 시, 해당 step으로 이동하도록 구현했습니다.

## 💡 체크리스트

- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (예: `feature/login` -> `develop`)
- [x] 테스트는 잘 통과했나요?
- [x] 빌드에 성공했나요?

## 💬 To Reviewers

