### PR TITLE
feat: 통계 페이지 레이아웃 추가 및 라우터 연결

### DIFF
--- a/apps/backend/src/features/stat/stat.controller.spec.ts
+++ b/apps/backend/src/features/stat/stat.controller.spec.ts
@@ -4,11 +4,15 @@ import { StatService } from './stat.service';
 
 describe('StatController', () => {
   let controller: StatController;
-  let service: { getDifficultyStats: jest.Mock };
+  let service: {
+    getDifficultyStats: jest.Mock;
+    getTopBehaviors: jest.Mock;
+  };
 
   beforeEach(async () => {
     service = {
       getDifficultyStats: jest.fn(),
+      getTopBehaviors: jest.fn(),
     };
 
     const module: TestingModule = await Test.createTestingModule({
@@ -32,5 +36,72 @@ describe('StatController', () => {
 
     expect(service.getDifficultyStats).toHaveBeenCalledWith(userId);
     expect(result).toBe(mock);
+  });
+
+  describe('getTopBehaviors', () => {
+    it('userId를 전달해 StatService.getTopBehaviors를 호출하고 결과를 그대로 반환한다', async () => {
+      const userId = 'user-1';
+      const mockResponse = {
+        all: {
+          totalCount: 5,
+          items: [
+            {
+              id: 'b1',
+              behaviorTitle: '행동1',
+              behaviorDifficulty: '몰입하기',
+              goalTitle: '목표1',
+              goalColor: '#111111',
+              count: 3,
+            },
+            {
+              id: 'b2',
+              behaviorTitle: '행동2',
+              behaviorDifficulty: '마음열기',
+              goalTitle: '목표2',
+              goalColor: '#222222',
+              count: 2,
+            },
+          ],
+        },
+        goals: [
+          {
+            id: 'g1',
+            goalTitle: '목표1',
+            goalColor: '#111111',
+            totalCount: 3,
+            items: [
+              {
+                id: 'b1',
+                behaviorTitle: '행동1(스냅샷)',
+                behaviorDifficulty: '몰입하기',
+                count: 2,
+              },
+              {
+                id: 'b3',
+                behaviorTitle: '행동3(스냅샷)',
+                behaviorDifficulty: '마음열기',
+                count: 1,
+              },
+            ],
+          },
+        ],
+      };
+
+      service.getTopBehaviors.mockResolvedValue(mockResponse);
+
+      const result = await controller.getTopBehaviors(userId);
+
+      expect(service.getTopBehaviors).toHaveBeenCalledTimes(1);
+      expect(service.getTopBehaviors).toHaveBeenCalledWith(userId);
+      expect(result).toBe(mockResponse);
+    });
+
+    it('StatService.getTopBehaviors가 에러를 던지면 그대로 전파한다', async () => {
+      const userId = 'user-1';
+      service.getTopBehaviors.mockRejectedValue(new Error('boom'));
+
+      await expect(controller.getTopBehaviors(userId)).rejects.toThrow('boom');
+      expect(service.getTopBehaviors).toHaveBeenCalledWith(userId);
+    });
   });
 });

--- a/apps/backend/src/features/stat/stat.controller.ts
+++ b/apps/backend/src/features/stat/stat.controller.ts
@@ -1,6 +1,6 @@
 import { Controller, Get, UseGuards } from '@nestjs/common';
 import * as Shared from '@web24/shared';
-import { type GetTopBehaviorsStatResponse } from '@web24/shared';
+import { GetTotalCompletedCountResponse, type GetTopBehaviorsStatResponse } from '@web24/shared';
 import { SessionAuthGuard } from '../../common/guards/session-auth.guard';
 import { UserId } from '../../common/decorators/user-id.decorator';
 import { StatService } from './stat.service';
@@ -13,6 +13,12 @@ export class StatController {
   @Get('difficulty')
   getDifficultyStats(@UserId() userId: string): Promise<Shared.GetDifficultyStatsResponse> {
     return this.statService.getDifficultyStats(userId);
+  }
+
+  @Get('total-completed-count')
+  async getTotalCompletedCounts(@UserId() userId: string): Promise<GetTotalCompletedCountResponse> {
+    const count = await this.statService.getTotalCompletedCounts(userId);
+    return { count: Number(count) };
   }
 
   @Get('top-behaviors')

--- a/apps/backend/src/features/stat/stat.controller.ts
+++ b/apps/backend/src/features/stat/stat.controller.ts
@@ -1,5 +1,6 @@
 import { Controller, Get, UseGuards } from '@nestjs/common';
 import * as Shared from '@web24/shared';
+import { type GetTopBehaviorsStatResponse } from '@web24/shared';
 import { SessionAuthGuard } from '../../common/guards/session-auth.guard';
 import { UserId } from '../../common/decorators/user-id.decorator';
 import { StatService } from './stat.service';
@@ -12,5 +13,10 @@ export class StatController {
   @Get('difficulty')
   getDifficultyStats(@UserId() userId: string): Promise<Shared.GetDifficultyStatsResponse> {
     return this.statService.getDifficultyStats(userId);
+  }
+
+  @Get('top-behaviors')
+  async getTopBehaviors(@UserId() userId: string): Promise<GetTopBehaviorsStatResponse> {
+    return this.statService.getTopBehaviors(userId);
   }
 }

--- a/apps/backend/src/features/stat/stat.docs.ts
+++ b/apps/backend/src/features/stat/stat.docs.ts
@@ -1,5 +1,9 @@
 import { OpenAPIRegistry } from '@asteasolutions/zod-to-openapi';
-import { GetDifficultyStatsResponseSchema } from '@web24/shared';
+import {
+  GetDifficultyStatsResponseSchema
+  GetTopBehaviorsStatResponseSchema,
+  GetTotalCompletedCountResponseSchema,
+} from '@web24/shared';
 
 type CommonSchemas = {
   errorResponse: ReturnType<OpenAPIRegistry['register']>;
@@ -9,6 +13,16 @@ export function registerStatApi(registry: OpenAPIRegistry, common: CommonSchemas
   const getDifficultyStatsResponse = registry.register(
     'GetDifficultyStatsResponse',
     GetDifficultyStatsResponseSchema,
+  );
+  
+  const getTopBehaviorsStatResponse = registry.register(
+    'GetTopBehaviorsStatResponse',
+    GetTopBehaviorsStatResponseSchema,
+  );
+
+  const getTotalCompletedCountResponse = registry.register(
+    'GetTotalCompletedCountResponse',
+    GetTotalCompletedCountResponseSchema,
   );
 
   const { errorResponse } = common;
@@ -23,6 +37,54 @@ export function registerStatApi(registry: OpenAPIRegistry, common: CommonSchemas
         content: {
           'application/json': {
             schema: getDifficultyStatsResponse,
+            },
+        },
+      },
+      401: {
+        description: 'Unauthorized',
+        content: {
+          'application/json': {
+            schema: errorResponse,
+          },
+        },
+      },
+    },
+  });
+
+  registry.registerPath({
+    method: 'get',
+    path: '/stats/top-behaviors',
+    security: [{ sessionAuth: [] }],
+    responses: {
+      200: {
+        description: '오늘 기준 Top behaviors 통계를 반환 (전체 + 목표별)',
+        content: {
+          'application/json': {
+            schema: getTopBehaviorsStatResponse,
+          },
+        },
+      },
+      401: {
+        description: 'Unauthorized',
+        content: {
+          'application/json': {
+            schema: errorResponse,
+          },
+        },
+      },
+    },
+  });
+
+  registry.registerPath({
+    method: 'get',
+    path: '/stats/total-completed-count',
+    security: [{ sessionAuth: [] }],
+    responses: {
+      200: {
+        description: '지금까지 완료한 전체 행동 횟수를 반환',
+        content: {
+          'application/json': {
+            schema: getTotalCompletedCountResponse,
           },
         },
       },

--- a/apps/backend/src/features/stat/stat.docs.ts
+++ b/apps/backend/src/features/stat/stat.docs.ts
@@ -1,6 +1,6 @@
 import { OpenAPIRegistry } from '@asteasolutions/zod-to-openapi';
 import {
-  GetDifficultyStatsResponseSchema
+  GetDifficultyStatsResponseSchema,
   GetTopBehaviorsStatResponseSchema,
   GetTotalCompletedCountResponseSchema,
 } from '@web24/shared';
@@ -14,7 +14,7 @@ export function registerStatApi(registry: OpenAPIRegistry, common: CommonSchemas
     'GetDifficultyStatsResponse',
     GetDifficultyStatsResponseSchema,
   );
-  
+
   const getTopBehaviorsStatResponse = registry.register(
     'GetTopBehaviorsStatResponse',
     GetTopBehaviorsStatResponseSchema,
@@ -37,7 +37,7 @@ export function registerStatApi(registry: OpenAPIRegistry, common: CommonSchemas
         content: {
           'application/json': {
             schema: getDifficultyStatsResponse,
-            },
+          },
         },
       },
       401: {

--- a/apps/backend/src/features/stat/stat.service.spec.ts
+++ b/apps/backend/src/features/stat/stat.service.spec.ts
@@ -482,4 +482,229 @@ describe('StatService', () => {
       expect((service as any).calcBehaviorDegree(80)).toBe('MORE');
     });
   });
+
+  describe('getTopBehaviors', () => {
+    afterEach(() => {
+      jest.useRealTimers();
+      jest.restoreAllMocks();
+    });
+
+    it('오늘 stat이 없으면 빈 응답을 반환한다', async () => {
+      jest.useFakeTimers().setSystemTime(new Date('2026-01-21T03:00:00.000Z'));
+      const todayKey = getKstDayKey(new Date());
+
+      const dailyUserStatRepository = {
+        findOne: jest.fn().mockResolvedValue(null),
+      };
+
+      const { service } = await createService({ dailyUserStatRepository });
+
+      const result = await service.getTopBehaviors('user-1');
+
+      expect(dailyUserStatRepository.findOne).toHaveBeenCalledWith({
+        where: { user: { id: 'user-1' }, statDate: todayKey },
+      });
+
+      expect(result).toEqual({
+        all: { totalCount: 0, items: [] },
+        goals: [],
+      });
+    });
+
+    it('오늘 stat이 있으면 all/goals를 매핑해서 반환한다 (goal 없는 behavior는 제외)', async () => {
+      jest.useFakeTimers().setSystemTime(new Date('2026-01-21T03:00:00.000Z'));
+      const todayKey = getKstDayKey(new Date());
+
+      const dailyUserStat = {
+        behaviorCompletedTopNCounts: [
+          { behaviorId: 'b1', count: 3 },
+          { behaviorId: 'b2', count: 2 },
+          { behaviorId: 'b-no-goal', count: 1 }, // goal 없어서 필터링 대상
+        ],
+        goalCompletedTopNCounts: [
+          {
+            goalId: 'g1',
+            behaviors: [
+              { behaviorId: 'b1', behaviorTitle: '행동1(스냅샷)', count: 2 },
+              { behaviorId: 'b3', behaviorTitle: '행동3(스냅샷)', count: 1 },
+            ],
+          },
+        ],
+      } as any;
+
+      const dailyUserStatRepository = {
+        findOne: jest.fn().mockResolvedValue(dailyUserStat),
+      };
+
+      const behaviorRepository = {
+        findOne: jest.fn().mockImplementation(async ({ where, relations }: any) => {
+          expect(relations).toEqual({ goal: true });
+
+          if (where.id === 'b1') {
+            return {
+              id: 'b1',
+              title: '행동1',
+              difficulty: '몰입하기',
+              goal: { id: 'g1', title: '목표1', color: '#111111' },
+            } as any;
+          }
+          if (where.id === 'b2') {
+            return {
+              id: 'b2',
+              title: '행동2',
+              difficulty: '마음열기',
+              goal: { id: 'g2', title: '목표2', color: '#222222' },
+            } as any;
+          }
+          if (where.id === 'b-no-goal') {
+            return {
+              id: 'b-no-goal',
+              title: 'goal없는행동',
+              difficulty: '몰입하기',
+              goal: null,
+            } as any;
+          }
+          return null;
+        }),
+      };
+
+      const goalRepository = {
+        findOne: jest.fn().mockImplementation(async ({ where, relations }: any) => {
+          expect(relations).toEqual({ behaviors: true });
+
+          if (where.id === 'g1') {
+            return {
+              id: 'g1',
+              title: '목표1',
+              color: '#111111',
+              behaviors: [
+                { id: 'b1', difficulty: '몰입하기' },
+                { id: 'b3', difficulty: '마음열기' },
+              ],
+            } as any;
+          }
+          return null;
+        }),
+      };
+
+      const { service } = await createService({
+        dailyUserStatRepository,
+        behaviorRepository,
+        goalRepository,
+      });
+
+      const result = await service.getTopBehaviors('user-1');
+
+      // stat 조회
+      expect(dailyUserStatRepository.findOne).toHaveBeenCalledWith({
+        where: { user: { id: 'user-1' }, statDate: todayKey },
+      });
+
+      // behavior 조회: 3개 시도 (b-no-goal은 결과에서 제외되지만 조회는 함)
+      expect(behaviorRepository.findOne).toHaveBeenCalledTimes(3);
+      expect(behaviorRepository.findOne).toHaveBeenNthCalledWith(1, {
+        where: { id: 'b1' },
+        relations: { goal: true },
+      });
+      expect(behaviorRepository.findOne).toHaveBeenNthCalledWith(2, {
+        where: { id: 'b2' },
+        relations: { goal: true },
+      });
+      expect(behaviorRepository.findOne).toHaveBeenNthCalledWith(3, {
+        where: { id: 'b-no-goal' },
+        relations: { goal: true },
+      });
+
+      // goal 조회
+      expect(goalRepository.findOne).toHaveBeenCalledTimes(1);
+      expect(goalRepository.findOne).toHaveBeenCalledWith({
+        where: { id: 'g1' },
+        relations: { behaviors: true },
+      });
+
+      // 결과 검증
+      expect(result).toEqual({
+        all: {
+          totalCount: 5, // b1(3) + b2(2) ; b-no-goal은 제외
+          items: [
+            {
+              id: 'b1',
+              behaviorTitle: '행동1',
+              behaviorDifficulty: '몰입하기',
+              goalTitle: '목표1',
+              goalColor: '#111111',
+              count: 3,
+            },
+            {
+              id: 'b2',
+              behaviorTitle: '행동2',
+              behaviorDifficulty: '마음열기',
+              goalTitle: '목표2',
+              goalColor: '#222222',
+              count: 2,
+            },
+          ],
+        },
+        goals: [
+          {
+            id: 'g1',
+            goalTitle: '목표1',
+            goalColor: '#111111',
+            totalCount: 3, // b1(2) + b3(1)
+            items: [
+              {
+                id: 'b1',
+                behaviorTitle: '행동1(스냅샷)',
+                behaviorDifficulty: '몰입하기', // goal.behaviors에서 difficulty를 가져옴
+                count: 2,
+              },
+              {
+                id: 'b3',
+                behaviorTitle: '행동3(스냅샷)',
+                behaviorDifficulty: '마음열기',
+                count: 1,
+              },
+            ],
+          },
+        ],
+      });
+    });
+
+    it('goalCompletedTopNCounts에 있는 behaviorId가 goal.behaviors에 없으면 에러를 던진다', async () => {
+      jest.useFakeTimers().setSystemTime(new Date('2026-01-21T03:00:00.000Z'));
+
+      const dailyUserStat = {
+        behaviorCompletedTopNCounts: [],
+        goalCompletedTopNCounts: [
+          {
+            goalId: 'g1',
+            behaviors: [{ behaviorId: 'b-not-in-goal', behaviorTitle: '없는행동', count: 1 }],
+          },
+        ],
+      } as any;
+
+      const dailyUserStatRepository = {
+        findOne: jest.fn().mockResolvedValue(dailyUserStat),
+      };
+
+      const goalRepository = {
+        findOne: jest.fn().mockResolvedValue({
+          id: 'g1',
+          title: '목표1',
+          color: '#111111',
+          behaviors: [
+            // b-not-in-goal 없음!
+            { id: 'b1', difficulty: '몰입하기' },
+          ],
+        } as any),
+      };
+
+      const { service } = await createService({
+        dailyUserStatRepository,
+        goalRepository,
+      });
+
+      await expect(service.getTopBehaviors('user-1')).rejects.toThrow('Behavior Not found');
+    });
+  });
 });

--- a/apps/backend/src/features/stat/stat.service.ts
+++ b/apps/backend/src/features/stat/stat.service.ts
@@ -1,7 +1,12 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Between, FindOptionsWhere, LessThanOrEqual, Repository } from 'typeorm';
-import { BEHAVIOR_DIFFICULTIES, BehaviorDifficulty, TodayBehaviorOrigin } from '@web24/shared';
+import {
+  BEHAVIOR_DIFFICULTIES,
+  BehaviorDifficulty,
+  TodayBehaviorOrigin,
+  type GetTopBehaviorsStatResponse,
+} from '@web24/shared';
 import { Cron } from '@nestjs/schedule';
 import pLimit from 'p-limit';
 import { addDays, getKstDayKey, toKstBoundary } from '../../common/utils/time.utils';
@@ -454,5 +459,88 @@ export class StatService {
     if (count <= BEHAVIOR_COUNT_THRESHOLD.MORE_BASELINE) return COUNT_DEGREE.NEUTRAL;
     if (count <= BEHAVIOR_COUNT_THRESHOLD.MUCH_MORE_BASELINE) return COUNT_DEGREE.MORE;
     return COUNT_DEGREE.MUCH_MORE;
+  }
+
+  async getTopBehaviors(userId: string): Promise<GetTopBehaviorsStatResponse> {
+    const todayKey = getKstDayKey(new Date());
+    const dailyUserStat = await this.dailyUserStatRepository.findOne({
+      where: { user: { id: userId }, statDate: todayKey },
+    });
+
+    if (!dailyUserStat) {
+      return {
+        all: {
+          totalCount: 0,
+          items: [],
+        },
+        goals: [],
+      };
+    }
+
+    const behaviorCompletedTopN = dailyUserStat.behaviorCompletedTopNCounts;
+    const allItems = (
+      await Promise.all(
+        behaviorCompletedTopN.map(async (bc) => {
+          const behavior = await this.behaviorRepository.findOne({
+            where: { id: bc.behaviorId },
+            relations: { goal: true },
+          });
+
+          if (!behavior?.goal) return [];
+
+          return {
+            id: behavior.id,
+            behaviorTitle: behavior.title,
+            behaviorDifficulty: behavior.difficulty,
+            goalTitle: behavior.goal.title,
+            goalColor: behavior.goal.color,
+            count: bc.count,
+          };
+        }),
+      )
+    ).flat();
+    const totalCount = allItems.reduce((acc, item) => acc + item.count, 0);
+
+    const goalCompletedTopN = dailyUserStat.goalCompletedTopNCounts;
+    const goals = (
+      await Promise.all(
+        goalCompletedTopN.map(async (gc) => {
+          const goal = await this.goalRepository.findOne({
+            where: { id: gc.goalId },
+            relations: { behaviors: true },
+          });
+
+          if (!goal) return [];
+
+          const items = gc.behaviors.map((b) => {
+            const behavior = goal.behaviors.find((gb) => gb.id === b.behaviorId);
+            if (!behavior) throw new Error('Behavior Not found');
+
+            return {
+              id: b.behaviorId,
+              behaviorTitle: b.behaviorTitle,
+              behaviorDifficulty: behavior.difficulty,
+              count: b.count,
+            };
+          });
+
+          return {
+            id: goal.id,
+            goalTitle: goal.title,
+            goalColor: goal.color,
+            totalCount: items.reduce((sum, item) => sum + item.count, 0),
+            items,
+          };
+        }),
+      )
+    ).flat();
+
+    return {
+      all: {
+        totalCount,
+        items: allItems,
+      },
+      goals,
+    };
   }
 }

--- a/apps/backend/src/features/stat/stat.service.ts
+++ b/apps/backend/src/features/stat/stat.service.ts
@@ -543,4 +543,12 @@ export class StatService {
       goals,
     };
   }
+
+  async getTotalCompletedCounts(userId: string): Promise<number> {
+    const todayKey = getKstDayKey(new Date());
+    const dailyUserStat = await this.dailyUserStatRepository.findOne({
+      where: { user: { id: userId }, statDate: todayKey },
+    });
+    return dailyUserStat?.totalCompletedCounts ?? 0;
+  }
 }

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -18,6 +18,8 @@
     "format:check": "pnpm exec prettier --check ."
   },
   "dependencies": {
+    "@nivo/core": "^0.99.0",
+    "@nivo/pie": "^0.99.0",
     "@web24/shared": "workspace:*",
     "framer-motion": "^12.27.1",
     "lucide-react": "^0.562.0",

--- a/apps/frontend/src/features/behavior/components/SwiperTabs.tsx
+++ b/apps/frontend/src/features/behavior/components/SwiperTabs.tsx
@@ -3,8 +3,15 @@ import { Swiper, SwiperSlide } from 'swiper/react';
 import 'swiper/css';
 import 'swiper/css/free-mode';
 
+type TabItem =
+  | string
+  | {
+      label: string;
+      value: string;
+    };
+
 interface SwiperTabsProps {
-  tabs: string[];
+  tabs: TabItem[];
   onChange: (id: string) => void;
   slideOffsetAfter?: number;
 }
@@ -19,27 +26,32 @@ export function SwiperTabs({ tabs, onChange, slideOffsetAfter }: SwiperTabsProps
       className="relative pb-2"
       slidesOffsetAfter={slideOffsetAfter}
     >
-      {tabs.map((label, idx) => (
-        <SwiperSlide key={label} className="w-auto!">
-          <button
-            type="button"
-            onClick={() => {
-              setActive(idx);
-              onChange(label);
-            }}
-            className={`relative pb-2 text-sm font-semibold ${
-              active === idx ? 'text-label-normal' : 'text-label-disable'
-            }`}
-          >
-            {label}
+      {tabs.map((tab, idx) => {
+        const label = typeof tab === 'string' ? tab : tab.label;
+        const value = typeof tab === 'string' ? tab : tab.value;
 
-            <span
-              className={`bg-primary-strong absolute bottom-0 left-0 h-0.5 w-full transition-transform duration-300 ${active === idx ? 'scale-x-100' : 'scale-x-0'} `}
-              style={{ transformOrigin: 'center' }}
-            />
-          </button>
-        </SwiperSlide>
-      ))}
+        return (
+          <SwiperSlide key={label} className="w-auto!">
+            <button
+              type="button"
+              onClick={() => {
+                setActive(idx);
+                onChange(value);
+              }}
+              className={`relative pb-2 text-sm font-semibold ${
+                active === idx ? 'text-label-normal' : 'text-label-disable'
+              }`}
+            >
+              {label}
+
+              <span
+                className={`bg-primary-strong absolute bottom-0 left-0 h-0.5 w-full transition-transform duration-300 ${active === idx ? 'scale-x-100' : 'scale-x-0'} `}
+                style={{ transformOrigin: 'center' }}
+              />
+            </button>
+          </SwiperSlide>
+        );
+      })}
     </Swiper>
   );
 }

--- a/apps/frontend/src/features/stat/apis/fetchTopBehaviors.api.spec.ts
+++ b/apps/frontend/src/features/stat/apis/fetchTopBehaviors.api.spec.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { fetchTopBehaviors } from './fetchTopBehaviors.api';
+
+describe('fetchTopBehaviors', () => {
+  const mockResponse = {
+    all: {
+      totalCount: 10,
+      items: [
+        {
+          id: '01890fba-7e6a-7b6b-9e5d-0f3c9b8b4c6c',
+          behaviorTitle: '운동',
+          behaviorDifficulty: '몰입하기',
+          goalTitle: '건강',
+          goalColor: 'mint',
+          count: 6,
+        },
+      ],
+    },
+    goals: [
+      {
+        id: '01890fba-7e6a-7b6b-9e5d-0f3c9b8b4c6d',
+        goalTitle: '건강',
+        goalColor: 'mint',
+        totalCount: 6,
+        items: [
+          {
+            id: '01890fba-7e6a-7b6b-9e5d-0f3c9b8b4c6e',
+            behaviorTitle: '운동',
+            behaviorDifficulty: '몰입하기',
+            count: 6,
+          },
+        ],
+      },
+    ],
+  };
+
+  beforeEach(() => {
+    // global.fetch mock
+    globalThis.fetch = vi.fn();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('성공적으로 데이터를 fetch하고 schema parse 결과를 반환한다', async () => {
+    (globalThis.fetch as any).mockResolvedValue({
+      ok: true,
+      json: async () => mockResponse,
+    });
+
+    const result = await fetchTopBehaviors();
+
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      '/api/stats/top-behaviors',
+      expect.objectContaining({
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      }),
+    );
+
+    expect(result.all.totalCount).toBe(10);
+    expect(result.goals[0].goalTitle).toBe('건강');
+  });
+
+  it('응답이 ok가 아니면 에러를 throw한다', async () => {
+    (globalThis.fetch as any).mockResolvedValue({
+      ok: false,
+    });
+
+    await expect(fetchTopBehaviors()).rejects.toThrow('Failed to fetch');
+  });
+
+  it('응답이 schema와 맞지 않으면 Zod 에러를 throw한다', async () => {
+    (globalThis.fetch as any).mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        invalid: 'data',
+      }),
+    });
+
+    await expect(fetchTopBehaviors()).rejects.toThrow();
+  });
+});

--- a/apps/frontend/src/features/stat/apis/fetchTopBehaviors.api.ts
+++ b/apps/frontend/src/features/stat/apis/fetchTopBehaviors.api.ts
@@ -1,0 +1,17 @@
+import { GetTopBehaviorsStatResponseSchema, type GetTopBehaviorsStatResponse } from '@web24/shared';
+
+export async function fetchTopBehaviors(): Promise<GetTopBehaviorsStatResponse> {
+  const res = await fetch('/api/stats/top-behaviors', {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  });
+
+  if (!res.ok) {
+    throw new Error('Failed to fetch');
+  }
+
+  const json = await res.json();
+  return GetTopBehaviorsStatResponseSchema.parse(json);
+}

--- a/apps/frontend/src/features/stat/apis/fetchTotalCompletedCount.api.spec.ts
+++ b/apps/frontend/src/features/stat/apis/fetchTotalCompletedCount.api.spec.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { fetchTotalCompletedCount } from './fetchTotalCompletedCount.api';
+
+describe('fetchTotalCompletedCount', () => {
+  const mockResponse = {
+    count: 184,
+  };
+
+  beforeEach(() => {
+    globalThis.fetch = vi.fn();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('성공적으로 총 완료 횟수를 fetch하고 schema parse 결과를 반환한다', async () => {
+    (globalThis.fetch as any).mockResolvedValue({
+      ok: true,
+      json: async () => mockResponse,
+    });
+
+    const result = await fetchTotalCompletedCount();
+
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      '/api/stats/total-completed-count',
+      expect.objectContaining({
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      }),
+    );
+
+    expect(result.count).toBe(184);
+  });
+
+  it('응답이 ok가 아니면 에러를 throw한다', async () => {
+    (globalThis.fetch as any).mockResolvedValue({
+      ok: false,
+    });
+
+    await expect(fetchTotalCompletedCount()).rejects.toThrow('Failed to fetch');
+  });
+
+  it('응답이 schema와 맞지 않으면 Zod 에러를 throw한다', async () => {
+    (globalThis.fetch as any).mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        wrong: 'data',
+      }),
+    });
+
+    await expect(fetchTotalCompletedCount()).rejects.toThrow();
+  });
+});

--- a/apps/frontend/src/features/stat/apis/fetchTotalCompletedCount.api.ts
+++ b/apps/frontend/src/features/stat/apis/fetchTotalCompletedCount.api.ts
@@ -1,0 +1,20 @@
+import {
+  GetTotalCompletedCountResponseSchema,
+  type GetTotalCompletedCountResponse,
+} from '@web24/shared';
+
+export async function fetchTotalCompletedCount(): Promise<GetTotalCompletedCountResponse> {
+  const res = await fetch('/api/stats/total-compledted-count', {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  });
+
+  if (!res.ok) {
+    throw new Error('Failed to fetch');
+  }
+
+  const json = await res.json();
+  return GetTotalCompletedCountResponseSchema.parse(json);
+}

--- a/apps/frontend/src/features/stat/apis/fetchTotalCompletedCount.api.ts
+++ b/apps/frontend/src/features/stat/apis/fetchTotalCompletedCount.api.ts
@@ -4,7 +4,7 @@ import {
 } from '@web24/shared';
 
 export async function fetchTotalCompletedCount(): Promise<GetTotalCompletedCountResponse> {
-  const res = await fetch('/api/stats/total-compledted-count', {
+  const res = await fetch('/api/stats/total-completed-count', {
     method: 'GET',
     headers: {
       'Content-Type': 'application/json',

--- a/apps/frontend/src/features/stat/components/AccumulatedBehaviorStats.spec.tsx
+++ b/apps/frontend/src/features/stat/components/AccumulatedBehaviorStats.spec.tsx
@@ -1,0 +1,123 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import type { AllBehaviorStatItem, GoalBehaviorStat } from '@web24/shared';
+import { AccumulatedBehaviorStats } from './AccumulatedBehaviorStats';
+
+vi.mock('@nivo/pie', () => ({
+  ResponsivePie: () => <div data-testid="pie-chart" />,
+}));
+
+vi.mock('@/features/behavior/components/SwiperTabs', () => ({
+  SwiperTabs: ({ tabs, onChange }: any) => (
+    <div>
+      {tabs.map((tab: any) => (
+        <button type="button" key={tab.value} onClick={() => onChange(tab.value)}>
+          {tab.label}
+        </button>
+      ))}
+    </div>
+  ),
+}));
+
+vi.mock('@/shared/components/behavior/DifficultyBadge', () => ({
+  DifficultyBadge: ({ level }: any) => <span>{level}</span>,
+}));
+
+describe('AccumulatedBehaviorStats', () => {
+  const allTopBehaviors: AllBehaviorStatItem = {
+    totalCount: 10,
+    items: [
+      {
+        id: 'b1',
+        behaviorTitle: '행동 A',
+        behaviorDifficulty: '시작하기',
+        count: 6,
+        goalTitle: '목표 1',
+        goalColor: 'pink',
+      },
+      {
+        id: 'b2',
+        behaviorTitle: '행동 B',
+        behaviorDifficulty: '이어가기',
+        count: 4,
+        goalTitle: '목표 2',
+        goalColor: 'blue',
+      },
+    ],
+  };
+
+  const goalTopBehaviors: GoalBehaviorStat[] = [
+    {
+      id: 'g1',
+      goalTitle: '목표 1',
+      goalColor: 'pink',
+      totalCount: 6,
+      items: [
+        {
+          id: 'b1',
+          behaviorTitle: '행동 A',
+          behaviorDifficulty: '시작하기',
+          count: 6,
+        },
+      ],
+    },
+    {
+      id: 'g2',
+      goalTitle: '목표 2',
+      goalColor: 'blue',
+      totalCount: 4,
+      items: [
+        {
+          id: 'b2',
+          behaviorTitle: '행동 B',
+          behaviorDifficulty: '이어가기',
+          count: 4,
+        },
+      ],
+    },
+  ];
+
+  it('기본으로 ALL 데이터가 렌더링된다', () => {
+    render(
+      <AccumulatedBehaviorStats
+        allTopBehaviors={allTopBehaviors}
+        goalTopBehaviors={goalTopBehaviors}
+      />,
+    );
+
+    expect(screen.getByText('행동 A')).toBeInTheDocument();
+    expect(screen.getByText('행동 B')).toBeInTheDocument();
+    expect(screen.getByText('6회')).toBeInTheDocument();
+    expect(screen.getByText('4회')).toBeInTheDocument();
+    expect(screen.getByTestId('pie-chart')).toBeInTheDocument();
+  });
+
+  it('goal 탭 클릭 시 해당 goal 데이터만 표시된다', () => {
+    render(
+      <AccumulatedBehaviorStats
+        allTopBehaviors={allTopBehaviors}
+        goalTopBehaviors={goalTopBehaviors}
+      />,
+    );
+
+    fireEvent.click(screen.getAllByText('목표 1')[0]);
+
+    expect(screen.getByText('행동 A')).toBeInTheDocument();
+    expect(screen.queryByText('행동 B')).not.toBeInTheDocument();
+  });
+
+  it('goal → ALL로 다시 전환하면 전체 데이터가 다시 표시된다', () => {
+    render(
+      <AccumulatedBehaviorStats
+        allTopBehaviors={allTopBehaviors}
+        goalTopBehaviors={goalTopBehaviors}
+      />,
+    );
+
+    fireEvent.click(screen.getAllByText('목표 1')[0]);
+    fireEvent.click(screen.getByText('ALL'));
+
+    expect(screen.getByText('행동 A')).toBeInTheDocument();
+    expect(screen.getByText('행동 B')).toBeInTheDocument();
+  });
+});

--- a/apps/frontend/src/features/stat/components/AccumulatedBehaviorStats.tsx
+++ b/apps/frontend/src/features/stat/components/AccumulatedBehaviorStats.tsx
@@ -1,0 +1,140 @@
+import { useState, useMemo } from 'react';
+import { ResponsivePie, type DatumId, type PieTooltipProps } from '@nivo/pie';
+import type { AllBehaviorStatItem, BehaviorStatItem, GoalBehaviorStat } from '@web24/shared';
+import { SwiperTabs } from '@/features/behavior/components/SwiperTabs';
+import { DifficultyBadge } from '@/shared/components/behavior/DifficultyBadge';
+
+interface Datum {
+  id: string;
+  label: string;
+  value: number;
+  color: string;
+}
+
+function PieTooltip({ datum }: PieTooltipProps<Datum>) {
+  return (
+    <div className="bg-bg-light border-primary-strong text-label-alternative rounded-sm border p-1 text-sm">
+      {datum.value}
+    </div>
+  );
+}
+
+interface AccumulatedBehaviorStatsProps {
+  allTopBehaviors: AllBehaviorStatItem;
+  goalTopBehaviors: GoalBehaviorStat[];
+}
+
+export function AccumulatedBehaviorStats({
+  allTopBehaviors,
+  goalTopBehaviors,
+}: AccumulatedBehaviorStatsProps) {
+  const [activeGoal, setActiveGoal] = useState<string>('ALL');
+  const [activeId, setActiveId] = useState<DatumId | null>(null);
+
+  // 서버에서 TOP10 내림차순 정렬된 데이터를 받는다고 가정
+  const currentData = useMemo(() => {
+    if (activeGoal === 'ALL') {
+      return allTopBehaviors;
+    }
+
+    const goalStat = goalTopBehaviors.find((b) => b.id === activeGoal);
+    if (!goalStat) return { totalCount: 0, items: [] };
+
+    const enrichedItems: BehaviorStatItem[] = goalStat.items.map((item) => ({
+      ...item,
+      goalTitle: goalStat.goalTitle,
+      goalColor: goalStat.goalColor,
+    }));
+
+    return {
+      totalCount: goalStat.totalCount,
+      items: enrichedItems,
+    };
+  }, [activeGoal, allTopBehaviors, goalTopBehaviors]);
+
+  const chartData = currentData.items.map((item) => ({
+    id: item.id,
+    label: item.behaviorTitle,
+    value: item.count,
+    color: `var(--color-goal-${item.goalColor})`,
+  }));
+
+  const goalTabs = [
+    { label: 'ALL', value: 'ALL' },
+    ...goalTopBehaviors.map((b) => ({
+      label: b.goalTitle,
+      value: b.id,
+    })),
+  ];
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="relative flex-1 overflow-hidden">
+        <SwiperTabs tabs={goalTabs} onChange={setActiveGoal} />
+      </div>
+      <div className="flex flex-col items-start gap-4 md:flex-row">
+        <div className="min-h-85 w-full p-2 md:min-h-100 md:w-1/2">
+          <ResponsivePie
+            data={chartData}
+            margin={{ top: 10, right: 10, bottom: 10, left: 10 }}
+            sortByValue
+            arcLabel="label"
+            arcLabelsTextColor="#252322"
+            enableArcLinkLabels={false}
+            activeOuterRadiusOffset={8}
+            // colors={(item) => item.data.color}
+            tooltip={PieTooltip}
+            activeId={activeId}
+            onMouseEnter={(datum) => setActiveId(datum.id)}
+            onMouseLeave={() => setActiveId(null)}
+          />
+        </div>
+        <div className="flex h-fit w-full flex-col gap-1 p-2 md:w-1/2">
+          {currentData.items.map((item) => (
+            <button
+              key={item.id}
+              type="button"
+              onMouseEnter={() => setActiveId(item.id)}
+              onMouseLeave={() => setActiveId(null)}
+              className={`flex cursor-default items-center justify-between rounded-xl border px-4 py-3 transition-all duration-200 ${
+                activeId === item.id
+                  ? 'border-bg-alternative scale-[1.02] bg-gray-50 shadow-sm'
+                  : 'bg-bg-light hover:bg-bg-alternative border-bg-alternative'
+              }`}
+            >
+              {/* 리스트카드 왼쪽 */}
+              <div className="min-w-0">
+                <div
+                  className={`flex h-9 flex-col ${
+                    activeGoal === 'ALL' ? 'justify-between' : 'justify-center'
+                  }`}
+                >
+                  {activeGoal === 'ALL' && (
+                    <p className="text-label-disable mr-auto truncate text-[10px] font-medium">
+                      {item.goalTitle}
+                    </p>
+                  )}
+
+                  <div className="flex items-center gap-2">
+                    <p className="text-label-normal truncate text-sm font-bold">
+                      {item.behaviorTitle}
+                    </p>
+                    <DifficultyBadge level={item.behaviorDifficulty} />
+                  </div>
+                </div>
+              </div>
+
+              {/* 리스트카드 오른쪽 */}
+              <div className="shrink-0 text-right">
+                <span className="text-label-normal block text-sm font-bold">{item.count}회</span>
+                <span className="text-[10px] text-gray-400">
+                  {Math.round((item.count / currentData.totalCount) * 100)}%
+                </span>
+              </div>
+            </button>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/pages/StatsPage.spec.tsx
+++ b/apps/frontend/src/pages/StatsPage.spec.tsx
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { StatsPage } from './StatsPage';
+
+vi.mock('@nivo/pie', async () => {
+  const actual = await vi.importActual<any>('@nivo/pie');
+  return {
+    ...actual,
+    ResponsivePie: ({ data, onMouseEnter, onMouseLeave }: any) => (
+      <div data-testid="pie-chart">
+        {data.map((d: any) => (
+          <button
+            type="button"
+            key={d.id}
+            data-testid={`pie-${d.id}`}
+            onMouseEnter={() => onMouseEnter?.({ id: d.id })}
+            onMouseLeave={() => onMouseLeave?.()}
+          >
+            {d.label}
+          </button>
+        ))}
+      </div>
+    ),
+  };
+});
+
+describe('StatsPage', () => {
+  it('페이지가 정상 렌더링된다', () => {
+    render(<StatsPage />);
+    expect(screen.getByText(/지금까지 행동을 총/i)).toBeInTheDocument();
+  });
+
+  it('리스트 hover 시 active 스타일이 적용된다', () => {
+    render(<StatsPage />);
+
+    const listButtons = screen.getAllByRole('button');
+
+    const listItem = listButtons.find(
+      (el) => el.textContent?.includes('물 한 잔 마시기') && !el.dataset.testid?.startsWith('pie'),
+    )!;
+
+    fireEvent.mouseEnter(listItem);
+    expect(listItem.className).toContain('scale-[1.02]');
+
+    fireEvent.mouseLeave(listItem);
+    expect(listItem.className).not.toContain('scale-[1.02]');
+  });
+
+  it('파이 hover 시 리스트와 동일한 activeId 흐름을 탄다', () => {
+    render(<StatsPage />);
+
+    const pieSlice = screen.getByTestId('pie-b1');
+    fireEvent.mouseEnter(pieSlice);
+
+    const listButtons = screen.getAllByRole('button');
+    const listItem = listButtons.find(
+      (el) => el.textContent?.includes('물 한 잔 마시기') && el.className.includes('scale-[1.02]'),
+    );
+
+    expect(listItem).toBeTruthy();
+  });
+
+  it('goal 탭 선택 시 goalTitle이 사라진다', () => {
+    render(<StatsPage />);
+
+    const goalTab = screen.getByRole('button', { name: '건강 관리' });
+    fireEvent.click(goalTab);
+
+    expect(screen.queryByText('건강 관리')).toBeInTheDocument();
+
+    const goalTitles = screen.queryAllByText('건강 관리');
+    expect(goalTitles.length).toBeLessThan(2);
+  });
+});

--- a/apps/frontend/src/pages/StatsPage.spec.tsx
+++ b/apps/frontend/src/pages/StatsPage.spec.tsx
@@ -1,10 +1,9 @@
+import { render, screen, waitFor } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
 import { fetchTopBehaviors } from '@/features/stat/apis/fetchTopBehaviors.api';
 import { fetchTotalCompletedCount } from '@/features/stat/apis/fetchTotalCompletedCount.api';
 import { StatsPage } from './StatsPage';
 
-// API mock
 vi.mock('@/features/stat/apis/fetchTopBehaviors.api', () => ({
   fetchTopBehaviors: vi.fn(),
 }));
@@ -13,125 +12,55 @@ vi.mock('@/features/stat/apis/fetchTotalCompletedCount.api', () => ({
   fetchTotalCompletedCount: vi.fn(),
 }));
 
-vi.mock('@nivo/pie', () => ({
-  ResponsivePie: () => <div data-testid="pie-chart" />,
-}));
-
-// SwiperTabs mock
-vi.mock('@/features/behavior/components/SwiperTabs', () => ({
-  SwiperTabs: ({ tabs, onChange }: any) => (
-    <div>
-      {tabs.map((tab: any) => (
-        <button
-          type="button"
-          key={tab.value}
-          data-testid={`tab-${tab.value}`}
-          onClick={() => onChange(tab.value)}
-        >
-          {tab.label}
-        </button>
-      ))}
+vi.mock('@/features/stat/components/AccumulatedBehaviorStats', () => ({
+  AccumulatedBehaviorStats: ({ allTopBehaviors, goalTopBehaviors }: any) => (
+    <div data-testid="accumulated-stats">
+      <span>all-count:{allTopBehaviors.totalCount}</span>
+      <span>goal-count:{goalTopBehaviors.length}</span>
     </div>
   ),
 }));
 
-const mockResponse = {
-  all: {
-    totalCount: 10,
-    items: [
-      {
-        id: 'b1',
-        behaviorTitle: '운동',
-        behaviorDifficulty: '몰입하기',
-        goalTitle: '건강',
-        goalColor: 'mint',
-        count: 6,
-      },
-      {
-        id: 'b2',
-        behaviorTitle: '독서',
-        behaviorDifficulty: '이어가기',
-        goalTitle: '성장',
-        goalColor: 'lavender',
-        count: 4,
-      },
-    ],
-  },
-  goals: [
-    {
-      id: 'g1',
-      goalTitle: '건강',
-      goalColor: 'mint',
-      totalCount: 6,
-      items: [
-        {
-          id: 'b1',
-          behaviorTitle: '운동',
-          behaviorDifficulty: '몰입하기',
-          count: 6,
-        },
-      ],
-    },
-  ],
-};
-
 describe('StatsPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.mocked(fetchTopBehaviors).mockResolvedValue(mockResponse as any);
-    vi.mocked(fetchTotalCompletedCount).mockResolvedValue({
-      totalCompletedCount: 184,
-    } as any);
   });
 
-  it('마운트 시 fetchTopBehaviors가 호출된다', async () => {
+  it('API 데이터를 fetch하고 화면에 정상적으로 렌더링한다', async () => {
+    (fetchTopBehaviors as any).mockResolvedValue({
+      all: {
+        totalCount: 10,
+        items: [],
+      },
+      goals: [
+        {
+          id: 'g1',
+          goalTitle: '목표 1',
+          goalColor: 'pink',
+          totalCount: 5,
+          items: [],
+        },
+      ],
+    });
+
+    (fetchTotalCompletedCount as any).mockResolvedValue({
+      count: 184,
+    });
+
     render(<StatsPage />);
 
+    // 총 완료 횟수
+    await waitFor(() => {
+      expect(screen.getByText('184')).toBeInTheDocument();
+    });
+
+    // 하위 컴포넌트 렌더 확인
+    expect(screen.getByTestId('accumulated-stats')).toBeInTheDocument();
+    expect(screen.getByText('all-count:10')).toBeInTheDocument();
+    expect(screen.getByText('goal-count:1')).toBeInTheDocument();
+
+    // API 호출 검증
     expect(fetchTopBehaviors).toHaveBeenCalledTimes(1);
-
-    // 데이터 로딩 확인
-    expect(await screen.findByText('운동')).toBeInTheDocument();
-  });
-
-  it('기본 상태(ALL)에서 전체 행동이 렌더링된다', async () => {
-    render(<StatsPage />);
-
-    expect(await screen.findByText('운동')).toBeInTheDocument();
-    expect(screen.getByText('독서')).toBeInTheDocument();
-
-    // 차트 렌더 확인
-    expect(screen.getByTestId('pie-chart')).toBeInTheDocument();
-  });
-
-  it('goal 탭 클릭 시 해당 goal 데이터만 표시된다', async () => {
-    render(<StatsPage />);
-
-    // 초기 데이터 로딩
-    await screen.findByText('운동');
-
-    // 건강(goal g1) 탭 클릭
-    fireEvent.click(screen.getByTestId('tab-g1'));
-
-    // 운동은 남고
-    expect(screen.getByText('운동')).toBeInTheDocument();
-
-    // 독서는 사라짐
-    expect(screen.queryByText('독서')).not.toBeInTheDocument();
-  });
-
-  it('goal → ALL로 다시 전환하면 전체 데이터가 다시 표시된다', async () => {
-    render(<StatsPage />);
-
-    await screen.findByText('운동');
-
-    // goal 클릭
-    fireEvent.click(screen.getByTestId('tab-g1'));
-    expect(screen.queryByText('독서')).not.toBeInTheDocument();
-
-    // ALL 클릭
-    fireEvent.click(screen.getByTestId('tab-ALL'));
-
-    expect(screen.getByText('운동')).toBeInTheDocument();
-    expect(screen.getByText('독서')).toBeInTheDocument();
+    expect(fetchTotalCompletedCount).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/frontend/src/pages/StatsPage.spec.tsx
+++ b/apps/frontend/src/pages/StatsPage.spec.tsx
@@ -1,74 +1,137 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
+import { fetchTopBehaviors } from '@/features/stat/apis/fetchTopBehaviors.api';
+import { fetchTotalCompletedCount } from '@/features/stat/apis/fetchTotalCompletedCount.api';
 import { StatsPage } from './StatsPage';
 
-vi.mock('@nivo/pie', async () => {
-  const actual = await vi.importActual<any>('@nivo/pie');
-  return {
-    ...actual,
-    ResponsivePie: ({ data, onMouseEnter, onMouseLeave }: any) => (
-      <div data-testid="pie-chart">
-        {data.map((d: any) => (
-          <button
-            type="button"
-            key={d.id}
-            data-testid={`pie-${d.id}`}
-            onMouseEnter={() => onMouseEnter?.({ id: d.id })}
-            onMouseLeave={() => onMouseLeave?.()}
-          >
-            {d.label}
-          </button>
-        ))}
-      </div>
-    ),
-  };
-});
+// API mock
+vi.mock('@/features/stat/apis/fetchTopBehaviors.api', () => ({
+  fetchTopBehaviors: vi.fn(),
+}));
+
+vi.mock('@/features/stat/apis/fetchTotalCompletedCount.api', () => ({
+  fetchTotalCompletedCount: vi.fn(),
+}));
+
+vi.mock('@nivo/pie', () => ({
+  ResponsivePie: () => <div data-testid="pie-chart" />,
+}));
+
+// SwiperTabs mock
+vi.mock('@/features/behavior/components/SwiperTabs', () => ({
+  SwiperTabs: ({ tabs, onChange }: any) => (
+    <div>
+      {tabs.map((tab: any) => (
+        <button
+          type="button"
+          key={tab.value}
+          data-testid={`tab-${tab.value}`}
+          onClick={() => onChange(tab.value)}
+        >
+          {tab.label}
+        </button>
+      ))}
+    </div>
+  ),
+}));
+
+const mockResponse = {
+  all: {
+    totalCount: 10,
+    items: [
+      {
+        id: 'b1',
+        behaviorTitle: '운동',
+        behaviorDifficulty: '몰입하기',
+        goalTitle: '건강',
+        goalColor: 'mint',
+        count: 6,
+      },
+      {
+        id: 'b2',
+        behaviorTitle: '독서',
+        behaviorDifficulty: '이어가기',
+        goalTitle: '성장',
+        goalColor: 'lavender',
+        count: 4,
+      },
+    ],
+  },
+  goals: [
+    {
+      id: 'g1',
+      goalTitle: '건강',
+      goalColor: 'mint',
+      totalCount: 6,
+      items: [
+        {
+          id: 'b1',
+          behaviorTitle: '운동',
+          behaviorDifficulty: '몰입하기',
+          count: 6,
+        },
+      ],
+    },
+  ],
+};
 
 describe('StatsPage', () => {
-  it('페이지가 정상 렌더링된다', () => {
-    render(<StatsPage />);
-    expect(screen.getByText(/지금까지 행동을 총/i)).toBeInTheDocument();
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(fetchTopBehaviors).mockResolvedValue(mockResponse as any);
+    vi.mocked(fetchTotalCompletedCount).mockResolvedValue({
+      totalCompletedCount: 184,
+    } as any);
   });
 
-  it('리스트 hover 시 active 스타일이 적용된다', () => {
+  it('마운트 시 fetchTopBehaviors가 호출된다', async () => {
     render(<StatsPage />);
 
-    const listButtons = screen.getAllByRole('button');
+    expect(fetchTopBehaviors).toHaveBeenCalledTimes(1);
 
-    const listItem = listButtons.find(
-      (el) => el.textContent?.includes('물 한 잔 마시기') && !el.dataset.testid?.startsWith('pie'),
-    )!;
-
-    fireEvent.mouseEnter(listItem);
-    expect(listItem.className).toContain('scale-[1.02]');
-
-    fireEvent.mouseLeave(listItem);
-    expect(listItem.className).not.toContain('scale-[1.02]');
+    // 데이터 로딩 확인
+    expect(await screen.findByText('운동')).toBeInTheDocument();
   });
 
-  it('파이 hover 시 리스트와 동일한 activeId 흐름을 탄다', () => {
+  it('기본 상태(ALL)에서 전체 행동이 렌더링된다', async () => {
     render(<StatsPage />);
 
-    const pieSlice = screen.getByTestId('pie-b1');
-    fireEvent.mouseEnter(pieSlice);
+    expect(await screen.findByText('운동')).toBeInTheDocument();
+    expect(screen.getByText('독서')).toBeInTheDocument();
 
-    const listButtons = screen.getAllByRole('button');
-    const listItem = listButtons.find(
-      (el) => el.textContent?.includes('물 한 잔 마시기') && el.className.includes('scale-[1.02]'),
-    );
-
-    expect(listItem).toBeTruthy();
+    // 차트 렌더 확인
+    expect(screen.getByTestId('pie-chart')).toBeInTheDocument();
   });
 
-  it('goal 탭 선택 시 goalTitle이 사라진다', () => {
+  it('goal 탭 클릭 시 해당 goal 데이터만 표시된다', async () => {
     render(<StatsPage />);
 
-    const goalTab = screen.getByRole('button', { name: '건강 관리' });
-    fireEvent.click(goalTab);
+    // 초기 데이터 로딩
+    await screen.findByText('운동');
 
-    expect(screen.queryByText('건강 관리')).toBeInTheDocument();
+    // 건강(goal g1) 탭 클릭
+    fireEvent.click(screen.getByTestId('tab-g1'));
 
-    const goalTitles = screen.queryAllByText('건강 관리');
-    expect(goalTitles.length).toBeLessThan(2);
+    // 운동은 남고
+    expect(screen.getByText('운동')).toBeInTheDocument();
+
+    // 독서는 사라짐
+    expect(screen.queryByText('독서')).not.toBeInTheDocument();
+  });
+
+  it('goal → ALL로 다시 전환하면 전체 데이터가 다시 표시된다', async () => {
+    render(<StatsPage />);
+
+    await screen.findByText('운동');
+
+    // goal 클릭
+    fireEvent.click(screen.getByTestId('tab-g1'));
+    expect(screen.queryByText('독서')).not.toBeInTheDocument();
+
+    // ALL 클릭
+    fireEvent.click(screen.getByTestId('tab-ALL'));
+
+    expect(screen.getByText('운동')).toBeInTheDocument();
+    expect(screen.getByText('독서')).toBeInTheDocument();
   });
 });

--- a/apps/frontend/src/pages/StatsPage.tsx
+++ b/apps/frontend/src/pages/StatsPage.tsx
@@ -1,101 +1,10 @@
 import { DifficultyGraph } from '@/features/stats/components/DifficultyGraph';
 import { SwiperTabs } from '@/features/behavior/components/SwiperTabs';
+import { fetchTopBehaviors } from '@/features/stat/apis/fetchTopBehaviors.api';
 import { DifficultyBadge } from '@/shared/components/behavior/DifficultyBadge';
 import { ResponsivePie, type DatumId, type PieTooltipProps } from '@nivo/pie';
-import type { BehaviorDifficulty, GoalColor } from '@web24/shared';
-import { MoreHorizontal } from 'lucide-react';
-import { useMemo, useState } from 'react';
-
-interface BehaviorStatItem {
-  id: string;
-  behaviorTitle: string;
-  behaviorDifficulty: BehaviorDifficulty;
-  goalTitle: string;
-  goalColor: GoalColor;
-  count: number;
-}
-
-type GoalSpecificBehaviorItem = Omit<BehaviorStatItem, 'goalTitle' | 'goalColor'>;
-
-interface GoalStat {
-  goalTitle: string;
-  goalColor: GoalColor;
-  totalCount: number;
-  items: GoalSpecificBehaviorItem[];
-}
-
-// --- Mock Data ---
-const MOCK_TOTAL_STATS = {
-  totalCount: 184,
-  items: [
-    {
-      id: 'b1',
-      behaviorTitle: '물 한 잔 마시기',
-      behaviorDifficulty: '마음열기',
-      goalTitle: '건강 관리',
-      goalColor: 'blue',
-      count: 45,
-    },
-    {
-      id: 'b2',
-      behaviorTitle: '책 10분 읽기',
-      behaviorDifficulty: '시작하기',
-      goalTitle: '독서 습관',
-      goalColor: 'beige',
-      count: 38,
-    },
-    {
-      id: 'b3',
-      behaviorTitle: '스쿼트 20회',
-      behaviorDifficulty: '이어가기',
-      goalTitle: '운동',
-      goalColor: 'yellow',
-      count: 32,
-    },
-    {
-      id: 'b4',
-      behaviorTitle: '일기 쓰기',
-      behaviorDifficulty: '몰입하기',
-      goalTitle: '기록',
-      goalColor: 'sand',
-      count: 25,
-    },
-    {
-      id: 'b5',
-      behaviorTitle: '영단어 5개 암기',
-      behaviorDifficulty: '시작하기',
-      goalTitle: '영어 공부',
-      goalColor: 'pink',
-      count: 18,
-    },
-    {
-      id: 'b6',
-      behaviorTitle: '명상하기',
-      behaviorDifficulty: '마음열기',
-      goalTitle: '멘탈 케어',
-      goalColor: 'mint',
-      count: 14,
-    },
-  ] as BehaviorStatItem[],
-};
-
-const MOCK_GOAL_STATS: Record<string, GoalStat> = {
-  'goal-1': {
-    goalTitle: '건강 관리',
-    goalColor: 'blue',
-    totalCount: 59,
-    items: [
-      { id: 'b1', behaviorTitle: '물 한 잔 마시기', behaviorDifficulty: '마음열기', count: 45 },
-      { id: 'b6', behaviorTitle: '명상하기', behaviorDifficulty: '마음열기', count: 14 },
-    ],
-  },
-  'goal-2': {
-    goalTitle: '독서 습관',
-    goalColor: 'beige',
-    totalCount: 38,
-    items: [{ id: 'b2', behaviorTitle: '책 10분 읽기', behaviorDifficulty: '시작하기', count: 38 }],
-  },
-};
+import type { AllBehaviorStatItem, BehaviorStatItem, GoalBehaviorStat } from '@web24/shared';
+import { useEffect, useMemo, useState } from 'react';
 
 interface StatsContainerProps {
   title: string;
@@ -129,14 +38,26 @@ function PieTooltip({ datum }: PieTooltipProps<Datum>) {
 export function StatsPage() {
   const [activeGoal, setActiveGoal] = useState<string>('ALL');
   const [activeId, setActiveId] = useState<DatumId | null>(null);
+  const [allTopBehaviors, setAllTopBehaviors] = useState<AllBehaviorStatItem>({
+    totalCount: 0,
+    items: [],
+  });
+  const [goalTopBehaviors, setGoalTopBehaviors] = useState<GoalBehaviorStat[]>([]);
+
+  useEffect(() => {
+    fetchTopBehaviors().then((data) => {
+      setAllTopBehaviors(data.all);
+      setGoalTopBehaviors(data.goals);
+    });
+  }, []);
 
   // 서버에서 TOP10 내림차순 정렬된 데이터를 받는다고 가정
   const currentData = useMemo(() => {
     if (activeGoal === 'ALL') {
-      return MOCK_TOTAL_STATS;
+      return allTopBehaviors;
     }
 
-    const goalStat = MOCK_GOAL_STATS[activeGoal];
+    const goalStat = goalTopBehaviors.find((b) => b.id === activeGoal);
     if (!goalStat) return { totalCount: 0, items: [] };
 
     const enrichedItems: BehaviorStatItem[] = goalStat.items.map((item) => ({
@@ -149,7 +70,7 @@ export function StatsPage() {
       totalCount: goalStat.totalCount,
       items: enrichedItems,
     };
-  }, [activeGoal]);
+  }, [activeGoal, allTopBehaviors, goalTopBehaviors]);
 
   const chartData = currentData.items.map((item) => ({
     id: item.id,
@@ -160,9 +81,9 @@ export function StatsPage() {
 
   const goalTabs = [
     { label: 'ALL', value: 'ALL' },
-    ...Object.entries(MOCK_GOAL_STATS).map(([key, goal]) => ({
-      label: goal.goalTitle,
-      value: key,
+    ...goalTopBehaviors.map((b) => ({
+      label: b.goalTitle,
+      value: b.id,
     })),
   ];
 
@@ -181,7 +102,7 @@ export function StatsPage() {
           <SwiperTabs tabs={goalTabs} onChange={setActiveGoal} />
         </div>
         <div className="flex flex-col items-start gap-4 md:flex-row">
-          <div className="min-h-85 w-full p-2 md:min-h-125 md:w-1/2">
+          <div className="min-h-85 w-full p-2 md:min-h-100 md:w-1/2">
             <ResponsivePie
               data={chartData}
               margin={{ top: 10, right: 10, bottom: 10, left: 10 }}
@@ -241,15 +162,6 @@ export function StatsPage() {
                 </div>
               </button>
             ))}
-
-            {/* 더보기 버튼 */}
-            <button
-              type="button"
-              onClick={() => {}}
-              className="border-bg-alternative text-label-alternative/40 hover:bg-bg-normal/40 mt-2 flex w-full items-center justify-center gap-1 rounded-xl border py-3 text-xs font-bold transition-colors"
-            >
-              더보기 <MoreHorizontal size={14} />
-            </button>
           </div>
         </div>
       </StatsContainer>

--- a/apps/frontend/src/pages/StatsPage.tsx
+++ b/apps/frontend/src/pages/StatsPage.tsx
@@ -1,11 +1,9 @@
 import { DifficultyGraph } from '@/features/stats/components/DifficultyGraph';
-import { SwiperTabs } from '@/features/behavior/components/SwiperTabs';
+import { useEffect, useState } from 'react';
+import type { AllBehaviorStatItem, GoalBehaviorStat } from '@web24/shared';
 import { fetchTopBehaviors } from '@/features/stat/apis/fetchTopBehaviors.api';
 import { fetchTotalCompletedCount } from '@/features/stat/apis/fetchTotalCompletedCount.api';
-import { DifficultyBadge } from '@/shared/components/behavior/DifficultyBadge';
-import { ResponsivePie, type DatumId, type PieTooltipProps } from '@nivo/pie';
-import type { AllBehaviorStatItem, BehaviorStatItem, GoalBehaviorStat } from '@web24/shared';
-import { useEffect, useMemo, useState } from 'react';
+import { AccumulatedBehaviorStats } from '@/features/stat/components/AccumulatedBehaviorStats';
 
 interface StatsContainerProps {
   title: string;
@@ -21,24 +19,7 @@ function StatsContainer({ title, children }: StatsContainerProps) {
   );
 }
 
-interface Datum {
-  id: string;
-  label: string;
-  value: number;
-  color: string;
-}
-
-function PieTooltip({ datum }: PieTooltipProps<Datum>) {
-  return (
-    <div className="bg-bg-light border-primary-strong text-label-alternative rounded-sm border p-1 text-sm">
-      {datum.value}
-    </div>
-  );
-}
-
 export function StatsPage() {
-  const [activeGoal, setActiveGoal] = useState<string>('ALL');
-  const [activeId, setActiveId] = useState<DatumId | null>(null);
   const [allTopBehaviors, setAllTopBehaviors] = useState<AllBehaviorStatItem>({
     totalCount: 0,
     items: [],
@@ -52,47 +33,12 @@ export function StatsPage() {
       setGoalTopBehaviors(data.goals);
     });
   }, []);
+
   useEffect(() => {
     fetchTotalCompletedCount().then((data) => {
       setTotalCompletedCount(data.count);
     });
   }, []);
-
-  // 서버에서 TOP10 내림차순 정렬된 데이터를 받는다고 가정
-  const currentData = useMemo(() => {
-    if (activeGoal === 'ALL') {
-      return allTopBehaviors;
-    }
-
-    const goalStat = goalTopBehaviors.find((b) => b.id === activeGoal);
-    if (!goalStat) return { totalCount: 0, items: [] };
-
-    const enrichedItems: BehaviorStatItem[] = goalStat.items.map((item) => ({
-      ...item,
-      goalTitle: goalStat.goalTitle,
-      goalColor: goalStat.goalColor,
-    }));
-
-    return {
-      totalCount: goalStat.totalCount,
-      items: enrichedItems,
-    };
-  }, [activeGoal, allTopBehaviors, goalTopBehaviors]);
-
-  const chartData = currentData.items.map((item) => ({
-    id: item.id,
-    label: item.behaviorTitle,
-    value: item.count,
-    color: `var(--color-goal-${item.goalColor})`,
-  }));
-
-  const goalTabs = [
-    { label: 'ALL', value: 'ALL' },
-    ...goalTopBehaviors.map((b) => ({
-      label: b.goalTitle,
-      value: b.id,
-    })),
-  ];
 
   return (
     <div className="mx-auto flex max-w-5xl flex-col gap-5 md:pt-2">
@@ -104,79 +50,20 @@ export function StatsPage() {
           해냈어요!
         </h2>
       </section>
+
       {/* 누적 행동 통계 */}
       <StatsContainer title="지금까지 가장 많이한 행동이에요">
-        <div className="relative flex-1 overflow-hidden">
-          <SwiperTabs tabs={goalTabs} onChange={setActiveGoal} />
-        </div>
-        <div className="flex flex-col items-start gap-4 md:flex-row">
-          <div className="min-h-85 w-full p-2 md:min-h-100 md:w-1/2">
-            <ResponsivePie
-              data={chartData}
-              margin={{ top: 10, right: 10, bottom: 10, left: 10 }}
-              sortByValue
-              arcLabel="label"
-              arcLabelsTextColor="#252322"
-              enableArcLinkLabels={false}
-              activeOuterRadiusOffset={8}
-              // colors={(item) => item.data.color}
-              tooltip={PieTooltip}
-              activeId={activeId}
-              onMouseEnter={(datum) => setActiveId(datum.id)}
-              onMouseLeave={() => setActiveId(null)}
-            />
-          </div>
-          <div className="flex h-fit w-full flex-col gap-1 p-2 md:w-1/2">
-            {currentData.items.map((item) => (
-              <button
-                key={item.id}
-                type="button"
-                onMouseEnter={() => setActiveId(item.id)}
-                onMouseLeave={() => setActiveId(null)}
-                className={`flex cursor-default items-center justify-between rounded-xl border px-4 py-3 transition-all duration-200 ${
-                  activeId === item.id
-                    ? 'border-bg-alternative scale-[1.02] bg-gray-50 shadow-sm'
-                    : 'bg-bg-light hover:bg-bg-alternative border-bg-alternative'
-                }`}
-              >
-                {/* 리스트카드 왼쪽 */}
-                <div className="min-w-0">
-                  <div
-                    className={`flex h-9 flex-col ${
-                      activeGoal === 'ALL' ? 'justify-between' : 'justify-center'
-                    }`}
-                  >
-                    {activeGoal === 'ALL' && (
-                      <p className="text-label-disable mr-auto truncate text-[10px] font-medium">
-                        {item.goalTitle}
-                      </p>
-                    )}
-
-                    <div className="flex items-center gap-2">
-                      <p className="text-label-normal truncate text-sm font-bold">
-                        {item.behaviorTitle}
-                      </p>
-                      <DifficultyBadge level={item.behaviorDifficulty} />
-                    </div>
-                  </div>
-                </div>
-
-                {/* 리스트카드 오른쪽 */}
-                <div className="shrink-0 text-right">
-                  <span className="text-label-normal block text-sm font-bold">{item.count}회</span>
-                  <span className="text-[10px] text-gray-400">
-                    {Math.round((item.count / currentData.totalCount) * 100)}%
-                  </span>
-                </div>
-              </button>
-            ))}
-          </div>
-        </div>
+        <AccumulatedBehaviorStats
+          allTopBehaviors={allTopBehaviors}
+          goalTopBehaviors={goalTopBehaviors}
+        />
       </StatsContainer>
+
       {/* 난이도 통계 */}
       <StatsContainer title="요즘 이런 흐름으로 행동했어요">
         <DifficultyGraph />
       </StatsContainer>
+
       {/* 랜덤 통계 */}
       <StatsContainer title="이런 점이 눈에 띄었어요">
         {/* 데스크톱: 2x2 카드, 모바일: 일렬 카드배치 */}

--- a/apps/frontend/src/pages/StatsPage.tsx
+++ b/apps/frontend/src/pages/StatsPage.tsx
@@ -1,4 +1,101 @@
 import { DifficultyGraph } from '@/features/stats/components/DifficultyGraph';
+import { SwiperTabs } from '@/features/behavior/components/SwiperTabs';
+import { DifficultyBadge } from '@/shared/components/behavior/DifficultyBadge';
+import { ResponsivePie, type DatumId, type PieTooltipProps } from '@nivo/pie';
+import type { BehaviorDifficulty, GoalColor } from '@web24/shared';
+import { MoreHorizontal } from 'lucide-react';
+import { useMemo, useState } from 'react';
+
+interface BehaviorStatItem {
+  id: string;
+  behaviorTitle: string;
+  behaviorDifficulty: BehaviorDifficulty;
+  goalTitle: string;
+  goalColor: GoalColor;
+  count: number;
+}
+
+type GoalSpecificBehaviorItem = Omit<BehaviorStatItem, 'goalTitle' | 'goalColor'>;
+
+interface GoalStat {
+  goalTitle: string;
+  goalColor: GoalColor;
+  totalCount: number;
+  items: GoalSpecificBehaviorItem[];
+}
+
+// --- Mock Data ---
+const MOCK_TOTAL_STATS = {
+  totalCount: 184,
+  items: [
+    {
+      id: 'b1',
+      behaviorTitle: '물 한 잔 마시기',
+      behaviorDifficulty: '마음열기',
+      goalTitle: '건강 관리',
+      goalColor: 'blue',
+      count: 45,
+    },
+    {
+      id: 'b2',
+      behaviorTitle: '책 10분 읽기',
+      behaviorDifficulty: '시작하기',
+      goalTitle: '독서 습관',
+      goalColor: 'beige',
+      count: 38,
+    },
+    {
+      id: 'b3',
+      behaviorTitle: '스쿼트 20회',
+      behaviorDifficulty: '이어가기',
+      goalTitle: '운동',
+      goalColor: 'yellow',
+      count: 32,
+    },
+    {
+      id: 'b4',
+      behaviorTitle: '일기 쓰기',
+      behaviorDifficulty: '몰입하기',
+      goalTitle: '기록',
+      goalColor: 'sand',
+      count: 25,
+    },
+    {
+      id: 'b5',
+      behaviorTitle: '영단어 5개 암기',
+      behaviorDifficulty: '시작하기',
+      goalTitle: '영어 공부',
+      goalColor: 'pink',
+      count: 18,
+    },
+    {
+      id: 'b6',
+      behaviorTitle: '명상하기',
+      behaviorDifficulty: '마음열기',
+      goalTitle: '멘탈 케어',
+      goalColor: 'mint',
+      count: 14,
+    },
+  ] as BehaviorStatItem[],
+};
+
+const MOCK_GOAL_STATS: Record<string, GoalStat> = {
+  'goal-1': {
+    goalTitle: '건강 관리',
+    goalColor: 'blue',
+    totalCount: 59,
+    items: [
+      { id: 'b1', behaviorTitle: '물 한 잔 마시기', behaviorDifficulty: '마음열기', count: 45 },
+      { id: 'b6', behaviorTitle: '명상하기', behaviorDifficulty: '마음열기', count: 14 },
+    ],
+  },
+  'goal-2': {
+    goalTitle: '독서 습관',
+    goalColor: 'beige',
+    totalCount: 38,
+    items: [{ id: 'b2', behaviorTitle: '책 10분 읽기', behaviorDifficulty: '시작하기', count: 38 }],
+  },
+};
 
 interface StatsContainerProps {
   title: string;
@@ -14,7 +111,61 @@ function StatsContainer({ title, children }: StatsContainerProps) {
   );
 }
 
+interface Datum {
+  id: string;
+  label: string;
+  value: number;
+  color: string;
+}
+
+function PieTooltip({ datum }: PieTooltipProps<Datum>) {
+  return (
+    <div className="bg-bg-light border-primary-strong text-label-alternative rounded-sm border p-1 text-sm">
+      {datum.value}
+    </div>
+  );
+}
+
 export function StatsPage() {
+  const [activeGoal, setActiveGoal] = useState<string>('ALL');
+  const [activeId, setActiveId] = useState<DatumId | null>(null);
+
+  // 서버에서 TOP10 내림차순 정렬된 데이터를 받는다고 가정
+  const currentData = useMemo(() => {
+    if (activeGoal === 'ALL') {
+      return MOCK_TOTAL_STATS;
+    }
+
+    const goalStat = MOCK_GOAL_STATS[activeGoal];
+    if (!goalStat) return { totalCount: 0, items: [] };
+
+    const enrichedItems: BehaviorStatItem[] = goalStat.items.map((item) => ({
+      ...item,
+      goalTitle: goalStat.goalTitle,
+      goalColor: goalStat.goalColor,
+    }));
+
+    return {
+      totalCount: goalStat.totalCount,
+      items: enrichedItems,
+    };
+  }, [activeGoal]);
+
+  const chartData = currentData.items.map((item) => ({
+    id: item.id,
+    label: item.behaviorTitle,
+    value: item.count,
+    color: `var(--color-goal-${item.goalColor})`,
+  }));
+
+  const goalTabs = [
+    { label: 'ALL', value: 'ALL' },
+    ...Object.entries(MOCK_GOAL_STATS).map(([key, goal]) => ({
+      label: goal.goalTitle,
+      value: key,
+    })),
+  ];
+
   return (
     <div className="mx-auto flex max-w-5xl flex-col gap-5 md:pt-2">
       {/* 총 횟수 */}
@@ -26,12 +177,78 @@ export function StatsPage() {
       </section>
       {/* 누적 행동 통계 */}
       <StatsContainer title="지금까지 가장 많이한 행동이에요">
+        <div className="relative flex-1 overflow-hidden">
+          <SwiperTabs tabs={goalTabs} onChange={setActiveGoal} />
+        </div>
         <div className="flex flex-col items-start gap-4 md:flex-row">
-          <div className="w-full border p-2 md:w-1/2">그래프 영역</div>
-          <div className="flex w-full flex-col border p-2 md:w-1/2">
-            <div>리스트 영역</div>
-            <button className="ml-auto border" type="button">
-              더보기
+          <div className="min-h-85 w-full p-2 md:min-h-125 md:w-1/2">
+            <ResponsivePie
+              data={chartData}
+              margin={{ top: 10, right: 10, bottom: 10, left: 10 }}
+              sortByValue
+              arcLabel="label"
+              arcLabelsTextColor="#252322"
+              enableArcLinkLabels={false}
+              activeOuterRadiusOffset={8}
+              // colors={(item) => item.data.color}
+              tooltip={PieTooltip}
+              activeId={activeId}
+              onMouseEnter={(datum) => setActiveId(datum.id)}
+              onMouseLeave={() => setActiveId(null)}
+            />
+          </div>
+          <div className="flex h-fit w-full flex-col gap-1 p-2 md:w-1/2">
+            {currentData.items.map((item) => (
+              <button
+                key={item.id}
+                type="button"
+                onMouseEnter={() => setActiveId(item.id)}
+                onMouseLeave={() => setActiveId(null)}
+                className={`flex cursor-default items-center justify-between rounded-xl border px-4 py-3 transition-all duration-200 ${
+                  activeId === item.id
+                    ? 'border-bg-alternative scale-[1.02] bg-gray-50 shadow-sm'
+                    : 'bg-bg-light hover:bg-bg-alternative border-bg-alternative'
+                }`}
+              >
+                {/* 리스트카드 왼쪽 */}
+                <div className="min-w-0">
+                  <div
+                    className={`flex h-9 flex-col ${
+                      activeGoal === 'ALL' ? 'justify-between' : 'justify-center'
+                    }`}
+                  >
+                    {activeGoal === 'ALL' && (
+                      <p className="text-label-disable mr-auto truncate text-[10px] font-medium">
+                        {item.goalTitle}
+                      </p>
+                    )}
+
+                    <div className="flex items-center gap-2">
+                      <p className="text-label-normal truncate text-sm font-bold">
+                        {item.behaviorTitle}
+                      </p>
+                      <DifficultyBadge level={item.behaviorDifficulty} />
+                    </div>
+                  </div>
+                </div>
+
+                {/* 리스트카드 오른쪽 */}
+                <div className="shrink-0 text-right">
+                  <span className="text-label-normal block text-sm font-bold">{item.count}회</span>
+                  <span className="text-[10px] text-gray-400">
+                    {Math.round((item.count / currentData.totalCount) * 100)}%
+                  </span>
+                </div>
+              </button>
+            ))}
+
+            {/* 더보기 버튼 */}
+            <button
+              type="button"
+              onClick={() => {}}
+              className="border-bg-alternative text-label-alternative/40 hover:bg-bg-normal/40 mt-2 flex w-full items-center justify-center gap-1 rounded-xl border py-3 text-xs font-bold transition-colors"
+            >
+              더보기 <MoreHorizontal size={14} />
             </button>
           </div>
         </div>

--- a/apps/frontend/src/pages/StatsPage.tsx
+++ b/apps/frontend/src/pages/StatsPage.tsx
@@ -1,6 +1,7 @@
 import { DifficultyGraph } from '@/features/stats/components/DifficultyGraph';
 import { SwiperTabs } from '@/features/behavior/components/SwiperTabs';
 import { fetchTopBehaviors } from '@/features/stat/apis/fetchTopBehaviors.api';
+import { fetchTotalCompletedCount } from '@/features/stat/apis/fetchTotalCompletedCount.api';
 import { DifficultyBadge } from '@/shared/components/behavior/DifficultyBadge';
 import { ResponsivePie, type DatumId, type PieTooltipProps } from '@nivo/pie';
 import type { AllBehaviorStatItem, BehaviorStatItem, GoalBehaviorStat } from '@web24/shared';
@@ -43,11 +44,17 @@ export function StatsPage() {
     items: [],
   });
   const [goalTopBehaviors, setGoalTopBehaviors] = useState<GoalBehaviorStat[]>([]);
+  const [totalCompletedCount, setTotalCompletedCount] = useState<number>(0);
 
   useEffect(() => {
     fetchTopBehaviors().then((data) => {
       setAllTopBehaviors(data.all);
       setGoalTopBehaviors(data.goals);
+    });
+  }, []);
+  useEffect(() => {
+    fetchTotalCompletedCount().then((data) => {
+      setTotalCompletedCount(data.count);
     });
   }, []);
 
@@ -92,7 +99,8 @@ export function StatsPage() {
       {/* 총 횟수 */}
       <section>
         <h2 className="text-headline-1 font-semibold">
-          지금까지 행동을 총 <span className="text-primary-strong text-3xl font-bold">184</span>번
+          지금까지 행동을 총{' '}
+          <span className="text-primary-strong text-3xl font-bold">{totalCompletedCount}</span>번
           해냈어요!
         </h2>
       </section>

--- a/packages/shared/src/schemas/stat.schemas.ts
+++ b/packages/shared/src/schemas/stat.schemas.ts
@@ -44,3 +44,8 @@ export const GetTopBehaviorsStatResponseSchema = z.object({
   goals: z.array(GoalBehaviorStatSchema),
 });
 export type GetTopBehaviorsStatResponse = z.infer<typeof GetTopBehaviorsStatResponseSchema>;
+
+export const GetTotalCompletedCountResponseSchema = z.object({
+  count: z.number(),
+});
+export type GetTotalCompletedCountResponse = z.infer<typeof GetTotalCompletedCountResponseSchema>;

--- a/packages/shared/src/schemas/stat.schemas.ts
+++ b/packages/shared/src/schemas/stat.schemas.ts
@@ -1,4 +1,4 @@
-import { BEHAVIOR_DIFFICULTIES, BehaviorDifficulty } from '../types/behavior.types';
+import { BEHAVIOR_DIFFICULTIES, BehaviorDifficulty, GOAL_COLORS } from '../types';
 import { z } from '../zod';
 
 export const DifficultyStatsSchema = z.record(z.enum(BEHAVIOR_DIFFICULTIES), z.number());
@@ -6,3 +6,41 @@ export type DifficultyStats = Record<BehaviorDifficulty, number>;
 
 export const GetDifficultyStatsResponseSchema = z.array(DifficultyStatsSchema);
 export type GetDifficultyStatsResponse = DifficultyStats[];
+
+export const BehaviorStatItemSchema = z.object({
+  id: z.uuid({ version: 'v7' }),
+  behaviorTitle: z.string().min(1),
+  behaviorDifficulty: z.enum(BEHAVIOR_DIFFICULTIES),
+  goalTitle: z.string().min(1),
+  goalColor: z.enum(GOAL_COLORS),
+  count: z.number(),
+});
+export type BehaviorStatItem = z.infer<typeof BehaviorStatItemSchema>;
+
+export const GoalSpecificBehaviorItemSchema = BehaviorStatItemSchema.omit({
+  goalTitle: true,
+  goalColor: true,
+});
+
+export type GoalSpecificBehaviorItem = z.infer<typeof GoalSpecificBehaviorItemSchema>;
+
+export const AllBehaviorStatItemSchema = z.object({
+  totalCount: z.number(),
+  items: z.array(BehaviorStatItemSchema),
+});
+export type AllBehaviorStatItem = z.infer<typeof AllBehaviorStatItemSchema>;
+
+export const GoalBehaviorStatSchema = z.object({
+  id: z.uuid({ version: 'v7' }),
+  goalTitle: z.string().min(1),
+  goalColor: z.enum(GOAL_COLORS),
+  totalCount: z.number(),
+  items: z.array(GoalSpecificBehaviorItemSchema),
+});
+export type GoalBehaviorStat = z.infer<typeof GoalBehaviorStatSchema>;
+
+export const GetTopBehaviorsStatResponseSchema = z.object({
+  all: AllBehaviorStatItemSchema,
+  goals: z.array(GoalBehaviorStatSchema),
+});
+export type GetTopBehaviorsStatResponse = z.infer<typeof GetTopBehaviorsStatResponseSchema>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -189,6 +189,12 @@ importers:
 
   apps/frontend:
     dependencies:
+      '@nivo/core':
+        specifier: ^0.99.0
+        version: 0.99.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@nivo/pie':
+        specifier: ^0.99.0
+        version: 0.99.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@web24/shared':
         specifier: workspace:*
         version: link:../../packages/shared
@@ -1184,6 +1190,46 @@ packages:
       rxjs: ^7.2.0
       typeorm: ^0.3.0
 
+  '@nivo/arcs@0.99.0':
+    resolution: {integrity: sha512-UcvWLQPl+A3APk2Gm74N5xDfT+ATnVs2XkP73WxhYPWJk+dBzF00cndA5g/dptOwdFBvvo62VgcCsNiwUsjKTw==}
+    peerDependencies:
+      react: ^16.14 || ^17.0 || ^18.0 || ^19.0
+
+  '@nivo/colors@0.99.0':
+    resolution: {integrity: sha512-hyYt4lEFIfXOUmQ6k3HXm3KwhcgoJpocmoGzLUqzk7DzuhQYJo+4d5jIGGU0N/a70+9XbHIdpKNSblHAIASD3w==}
+    peerDependencies:
+      react: ^16.14 || ^17.0 || ^18.0 || ^19.0
+
+  '@nivo/core@0.99.0':
+    resolution: {integrity: sha512-olCItqhPG3xHL5ei+vg52aB6o+6S+xR2idpkd9RormTTUniZb8U2rOdcQojOojPY5i9kVeQyLFBpV4YfM7OZ9g==}
+    peerDependencies:
+      react: ^16.14 || ^17.0 || ^18.0 || ^19.0
+
+  '@nivo/legends@0.99.0':
+    resolution: {integrity: sha512-P16FjFqNceuTTZphINAh5p0RF0opu3cCKoWppe2aRD9IuVkvRm/wS5K1YwMCxDzKyKh5v0AuTlu9K6o3/hk8hA==}
+    peerDependencies:
+      react: ^16.14 || ^17.0 || ^18.0 || ^19.0
+
+  '@nivo/pie@0.99.0':
+    resolution: {integrity: sha512-zUbo8UdLndp2RMljrOqitAKKEnl7YypkJrOzjKLk8jQGU7qqUKtgFoJIPhiBsvNPs3xtX2KwgtS1+JKNTNns7A==}
+    peerDependencies:
+      react: ^16.14 || ^17.0 || ^18.0 || ^19.0
+
+  '@nivo/text@0.99.0':
+    resolution: {integrity: sha512-ho3oZpAZApsJNjsIL5WJSAdg/wjzTBcwo1KiHBlRGUmD+yUWO8qp7V+mnYRhJchwygtRVALlPgZ/rlcW2Xr/MQ==}
+    peerDependencies:
+      react: ^16.14 || ^17.0 || ^18.0 || ^19.0
+
+  '@nivo/theming@0.99.0':
+    resolution: {integrity: sha512-KvXlf0nqBzh/g2hAIV9bzscYvpq1uuO3TnFN3RDXGI72CrbbZFTGzprPju3sy/myVsauv+Bb+V4f5TZ0jkYKRg==}
+    peerDependencies:
+      react: ^16.14 || ^17.0 || ^18.0 || ^19.0
+
+  '@nivo/tooltip@0.99.0':
+    resolution: {integrity: sha512-weoEGR3xAetV4k2P6k96cdamGzKQ5F2Pq+uyDaHr1P3HYArM879Pl+x+TkU0aWjP6wgUZPx/GOBiV1Hb1JxIqg==}
+    peerDependencies:
+      react: ^16.14 || ^17.0 || ^18.0 || ^19.0
+
   '@noble/hashes@1.8.0':
     resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
     engines: {node: ^14.21.3 || >=16}
@@ -1227,6 +1273,33 @@ packages:
 
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
+
+  '@react-spring/animated@10.0.3':
+    resolution: {integrity: sha512-7MrxADV3vaUADn2V9iYhaIL6iOWRx9nCJjYrsk2AHD2kwPr6fg7Pt0v+deX5RnCDmCKNnD6W5fasiyM8D+wzJQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  '@react-spring/core@10.0.3':
+    resolution: {integrity: sha512-D4DwNO68oohDf/0HG2G0Uragzb9IA1oXblxrd6MZAcBcUQG2EHUWXewjdECMPLNmQvlYVyyBRH6gPxXM5DX7DQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  '@react-spring/rafz@10.0.3':
+    resolution: {integrity: sha512-Ri2/xqt8OnQ2iFKkxKMSF4Nqv0LSWnxXT4jXFzBDsHgeeH/cHxTLupAWUwmV9hAGgmEhBmh5aONtj3J6R/18wg==}
+
+  '@react-spring/shared@10.0.3':
+    resolution: {integrity: sha512-geCal66nrkaQzUVhPkGomylo+Jpd5VPK8tPMEDevQEfNSWAQP15swHm+MCRG4wVQrQlTi9lOzKzpRoTL3CA84Q==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  '@react-spring/types@10.0.3':
+    resolution: {integrity: sha512-H5Ixkd2OuSIgHtxuHLTt7aJYfhMXKXT/rK32HPD/kSrOB6q6ooeiWAXkBy7L8F3ZxdkBb9ini9zP9UwnEFzWgQ==}
+
+  '@react-spring/web@10.0.3':
+    resolution: {integrity: sha512-ndU+kWY81rHsT7gTFtCJ6mrVhaJ6grFmgTnENipzmKqot4HGf5smPNK+cZZJqoGeDsj9ZsiWPW4geT/NyD484A==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   '@rolldown/pluginutils@1.0.0-beta.53':
     resolution: {integrity: sha512-vENRlFU4YbrwVqNDZ7fLvy+JR1CRkyr01jhSiDpE1u6py3OMzQfztQU2jxykW3ALNxO4kSlqIDeYyD0Y9RcQeQ==}
@@ -1532,6 +1605,24 @@ packages:
 
   '@types/cookiejar@2.1.5':
     resolution: {integrity: sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==}
+
+  '@types/d3-color@3.1.3':
+    resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
+
+  '@types/d3-path@3.1.1':
+    resolution: {integrity: sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==}
+
+  '@types/d3-scale-chromatic@3.1.0':
+    resolution: {integrity: sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==}
+
+  '@types/d3-scale@4.0.9':
+    resolution: {integrity: sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==}
+
+  '@types/d3-shape@3.1.8':
+    resolution: {integrity: sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==}
+
+  '@types/d3-time@3.0.4':
+    resolution: {integrity: sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==}
 
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
@@ -2397,6 +2488,50 @@ packages:
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
+  d3-array@2.12.1:
+    resolution: {integrity: sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==}
+
+  d3-array@3.2.4:
+    resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
+    engines: {node: '>=12'}
+
+  d3-color@3.1.0:
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+
+  d3-format@1.4.5:
+    resolution: {integrity: sha512-J0piedu6Z8iB6TbIGfZgDzfXxUFN3qQRMofy2oPdXzQibYGqPB/9iMcxr/TGalU+2RsyDO+U4f33id8tbnSRMQ==}
+
+  d3-interpolate@3.0.1:
+    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
+
+  d3-path@3.1.0:
+    resolution: {integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==}
+    engines: {node: '>=12'}
+
+  d3-scale-chromatic@3.1.0:
+    resolution: {integrity: sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==}
+    engines: {node: '>=12'}
+
+  d3-scale@4.0.2:
+    resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
+    engines: {node: '>=12'}
+
+  d3-shape@3.2.0:
+    resolution: {integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==}
+    engines: {node: '>=12'}
+
+  d3-time-format@3.0.0:
+    resolution: {integrity: sha512-UXJh6EKsHBTjopVqZBhFysQcoXSv/5yLONZvkQ5Kk3qbwiUYkdX17Xa1PT6U1ZWXGGfB1ey5L8dKMlFq2DO0Ag==}
+
+  d3-time@2.1.1:
+    resolution: {integrity: sha512-/eIQe/eR4kCQwq7yxi7z4c6qEXf2IYGcjoWB5OOQy4Tq9Uv39/947qlDcN2TLkiTzQWzvnsuYPB9TrWaNfipKQ==}
+
+  d3-time@3.1.0:
+    resolution: {integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==}
+    engines: {node: '>=12'}
+
   damerau-levenshtein@1.0.8:
     resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
 
@@ -3177,6 +3312,13 @@ packages:
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
+
+  internmap@1.0.1:
+    resolution: {integrity: sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==}
+
+  internmap@2.0.3:
+    resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
+    engines: {node: '>=12'}
 
   ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
@@ -4323,6 +4465,12 @@ packages:
       react: ^18 || ^19
       react-dom: ^18 || ^19
 
+  react-virtualized-auto-sizer@1.0.26:
+    resolution: {integrity: sha512-CblNyiNVw2o+hsa5/49NH2ogGxZ+t+3aweRvNSq7TVjDIlwk7ir4lencEg5HxHeSzwNarSkNkiu0qJSOXtxm5A==}
+    peerDependencies:
+      react: ^15.3.0 || ^16.0.0-alpha || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^15.3.0 || ^16.0.0-alpha || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   react@19.2.3:
     resolution: {integrity: sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==}
     engines: {node: '>=0.10.0'}
@@ -5068,6 +5216,12 @@ packages:
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  use-debounce@10.1.0:
+    resolution: {integrity: sha512-lu87Za35V3n/MyMoEpD5zJv0k7hCn0p+V/fK2kWD+3k2u3kOCwO593UArbczg1fhfs2rqPEnHpULJ3KmGdDzvg==}
+    engines: {node: '>= 16.0.0'}
+    peerDependencies:
+      react: '*'
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
@@ -6319,6 +6473,104 @@ snapshots:
       rxjs: 7.8.2
       typeorm: 0.3.28(pg@8.16.3)(ts-node@10.9.2(@types/node@22.19.3)(typescript@5.9.3))
 
+  '@nivo/arcs@0.99.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@nivo/colors': 0.99.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@nivo/core': 0.99.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@nivo/text': 0.99.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@nivo/theming': 0.99.0(react@19.2.3)
+      '@react-spring/core': 10.0.3(react@19.2.3)
+      '@react-spring/web': 10.0.3(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@types/d3-shape': 3.1.8
+      d3-shape: 3.2.0
+      react: 19.2.3
+    transitivePeerDependencies:
+      - react-dom
+
+  '@nivo/colors@0.99.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@nivo/core': 0.99.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@nivo/theming': 0.99.0(react@19.2.3)
+      '@types/d3-color': 3.1.3
+      '@types/d3-scale': 4.0.9
+      '@types/d3-scale-chromatic': 3.1.0
+      d3-color: 3.1.0
+      d3-scale: 4.0.2
+      d3-scale-chromatic: 3.1.0
+      lodash: 4.17.21
+      react: 19.2.3
+    transitivePeerDependencies:
+      - react-dom
+
+  '@nivo/core@0.99.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@nivo/theming': 0.99.0(react@19.2.3)
+      '@nivo/tooltip': 0.99.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@react-spring/web': 10.0.3(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@types/d3-shape': 3.1.8
+      d3-color: 3.1.0
+      d3-format: 1.4.5
+      d3-interpolate: 3.0.1
+      d3-scale: 4.0.2
+      d3-scale-chromatic: 3.1.0
+      d3-shape: 3.2.0
+      d3-time-format: 3.0.0
+      lodash: 4.17.21
+      react: 19.2.3
+      react-virtualized-auto-sizer: 1.0.26(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      use-debounce: 10.1.0(react@19.2.3)
+    transitivePeerDependencies:
+      - react-dom
+
+  '@nivo/legends@0.99.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@nivo/colors': 0.99.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@nivo/core': 0.99.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@nivo/text': 0.99.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@nivo/theming': 0.99.0(react@19.2.3)
+      '@types/d3-scale': 4.0.9
+      d3-scale: 4.0.2
+      react: 19.2.3
+    transitivePeerDependencies:
+      - react-dom
+
+  '@nivo/pie@0.99.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@nivo/arcs': 0.99.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@nivo/colors': 0.99.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@nivo/core': 0.99.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@nivo/legends': 0.99.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@nivo/theming': 0.99.0(react@19.2.3)
+      '@nivo/tooltip': 0.99.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@types/d3-shape': 3.1.8
+      d3-shape: 3.2.0
+      react: 19.2.3
+    transitivePeerDependencies:
+      - react-dom
+
+  '@nivo/text@0.99.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@nivo/core': 0.99.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@nivo/theming': 0.99.0(react@19.2.3)
+      '@react-spring/web': 10.0.3(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      react: 19.2.3
+    transitivePeerDependencies:
+      - react-dom
+
+  '@nivo/theming@0.99.0(react@19.2.3)':
+    dependencies:
+      lodash: 4.17.21
+      react: 19.2.3
+
+  '@nivo/tooltip@0.99.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@nivo/core': 0.99.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@nivo/theming': 0.99.0(react@19.2.3)
+      '@react-spring/web': 10.0.3(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      react: 19.2.3
+    transitivePeerDependencies:
+      - react-dom
+
   '@noble/hashes@1.8.0': {}
 
   '@nodelib/fs.scandir@2.1.5':
@@ -6353,6 +6605,38 @@ snapshots:
       playwright: 1.57.0
 
   '@polka/url@1.0.0-next.29': {}
+
+  '@react-spring/animated@10.0.3(react@19.2.3)':
+    dependencies:
+      '@react-spring/shared': 10.0.3(react@19.2.3)
+      '@react-spring/types': 10.0.3
+      react: 19.2.3
+
+  '@react-spring/core@10.0.3(react@19.2.3)':
+    dependencies:
+      '@react-spring/animated': 10.0.3(react@19.2.3)
+      '@react-spring/shared': 10.0.3(react@19.2.3)
+      '@react-spring/types': 10.0.3
+      react: 19.2.3
+
+  '@react-spring/rafz@10.0.3': {}
+
+  '@react-spring/shared@10.0.3(react@19.2.3)':
+    dependencies:
+      '@react-spring/rafz': 10.0.3
+      '@react-spring/types': 10.0.3
+      react: 19.2.3
+
+  '@react-spring/types@10.0.3': {}
+
+  '@react-spring/web@10.0.3(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@react-spring/animated': 10.0.3(react@19.2.3)
+      '@react-spring/core': 10.0.3(react@19.2.3)
+      '@react-spring/shared': 10.0.3(react@19.2.3)
+      '@react-spring/types': 10.0.3
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
 
   '@rolldown/pluginutils@1.0.0-beta.53': {}
 
@@ -6608,6 +6892,22 @@ snapshots:
       '@types/node': 22.19.3
 
   '@types/cookiejar@2.1.5': {}
+
+  '@types/d3-color@3.1.3': {}
+
+  '@types/d3-path@3.1.1': {}
+
+  '@types/d3-scale-chromatic@3.1.0': {}
+
+  '@types/d3-scale@4.0.9':
+    dependencies:
+      '@types/d3-time': 3.0.4
+
+  '@types/d3-shape@3.1.8':
+    dependencies:
+      '@types/d3-path': 3.1.1
+
+  '@types/d3-time@3.0.4': {}
 
   '@types/deep-eql@4.0.2': {}
 
@@ -7556,6 +7856,53 @@ snapshots:
       rrweb-cssom: 0.8.0
 
   csstype@3.2.3: {}
+
+  d3-array@2.12.1:
+    dependencies:
+      internmap: 1.0.1
+
+  d3-array@3.2.4:
+    dependencies:
+      internmap: 2.0.3
+
+  d3-color@3.1.0: {}
+
+  d3-format@1.4.5: {}
+
+  d3-interpolate@3.0.1:
+    dependencies:
+      d3-color: 3.1.0
+
+  d3-path@3.1.0: {}
+
+  d3-scale-chromatic@3.1.0:
+    dependencies:
+      d3-color: 3.1.0
+      d3-interpolate: 3.0.1
+
+  d3-scale@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+      d3-format: 1.4.5
+      d3-interpolate: 3.0.1
+      d3-time: 3.1.0
+      d3-time-format: 3.0.0
+
+  d3-shape@3.2.0:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-time-format@3.0.0:
+    dependencies:
+      d3-time: 2.1.1
+
+  d3-time@2.1.1:
+    dependencies:
+      d3-array: 2.12.1
+
+  d3-time@3.1.0:
+    dependencies:
+      d3-array: 3.2.4
 
   damerau-levenshtein@1.0.8: {}
 
@@ -8528,6 +8875,10 @@ snapshots:
       es-errors: 1.3.0
       hasown: 2.0.2
       side-channel: 1.1.0
+
+  internmap@1.0.1: {}
+
+  internmap@2.0.3: {}
 
   ipaddr.js@1.9.1: {}
 
@@ -9748,6 +10099,11 @@ snapshots:
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
 
+  react-virtualized-auto-sizer@1.0.26(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+    dependencies:
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+
   react@19.2.3: {}
 
   readable-stream@3.6.2:
@@ -10561,6 +10917,10 @@ snapshots:
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
+
+  use-debounce@10.1.0(react@19.2.3):
+    dependencies:
+      react: 19.2.3
 
   util-deprecate@1.0.2: {}
 


### PR DESCRIPTION
## 🔗 관련 이슈

- close: #57 

## ✅ 작업 내용

- 누적 행동 통계 레이아웃 구현

## 📸 스크린샷 / 데모 (옵션)

<img width="700" alt="stats" src="https://github.com/user-attachments/assets/e5f70264-5de5-41e9-86e6-35b59e5abe20" />

## 💡 체크리스트

- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (예: `feature/login` -> `develop`)
- [x] 테스트는 잘 통과했나요?
- [x] 빌드에 성공했나요?

## 💬 To Reviewers

