### PR TITLE
feat: 두두의 방에서 두두의 애니매이션(변화)를 볼 수 있다.

### DIFF
--- a/apps/backend/src/features/ai/ai.service.spec.ts
+++ b/apps/backend/src/features/ai/ai.service.spec.ts
@@ -1,5 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { ConfigService } from '@nestjs/config';
+import { DODO_ACTIONS } from '@web24/shared';
 import { AIService } from './ai.service';
 import { DodoChatMessage } from '../chat/dodo-chat-message.entity';
 
@@ -63,6 +64,64 @@ describe('AIService', () => {
       });
 
       await expect(service.createDodoMessage([], 'hello')).rejects.toThrow();
+    });
+  });
+
+  describe('getDodoAction', () => {
+    it('Clova API를 호출하고 유효한 행동을 반환한다', async () => {
+      const message = '사랑해';
+
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: jest.fn().mockResolvedValue({
+          result: {
+            message: {
+              content: DODO_ACTIONS.wink,
+            },
+          },
+        }),
+      });
+
+      const result = await service.getDodoAction(message);
+
+      expect(result).toBe(DODO_ACTIONS.wink);
+      expect(global.fetch).toHaveBeenCalledWith(
+        expect.stringContaining('clovastudio.stream.ntruss.com'),
+        expect.objectContaining({
+          method: 'POST',
+          headers: expect.objectContaining({
+            'Content-Type': 'application/json',
+            Authorization: expect.any(String),
+          }),
+          body: expect.stringContaining(message),
+        }),
+      );
+    });
+
+    it('Clova API 응답이 유효하지 않으면 none을 반환한다', async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: jest.fn().mockResolvedValue({
+          result: {
+            message: {
+              content: 'INVALID_ACTION',
+            },
+          },
+        }),
+      });
+
+      const result = await service.getDodoAction('아무 말');
+
+      expect(result).toBe(DODO_ACTIONS.none);
+    });
+
+    it('Clova API 호출 실패 시 에러를 던진다', async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: false,
+        status: 500,
+      });
+
+      await expect(service.getDodoAction('hello')).rejects.toThrow();
     });
   });
 });

--- a/apps/backend/src/features/ai/ai.service.ts
+++ b/apps/backend/src/features/ai/ai.service.ts
@@ -208,19 +208,19 @@ JSON 외의 설명, 문장, 코드블록, 주석은 **절대 출력하지 마**.
     const systemPrompt = `
       너는 행동 기록 서비스 "뚜웰"의 캐릭터 "두두"가 취할 적절한 행동을 정해야 한다.
       두두는 다음 네가지 행동을 할 수 있다.
-      "None", "Sitdown", "Wink", "Hurray"
+      "${DODO_ACTION_VALUES.join('", "')}"
       반드시 위 네가지 행동 중에 하나만을 응답하고, 그 외의 다른 말은 일체 하지마.
       응답 기준은 질문에 대해서 두두가 취할 답변과 가장 어울리는 행동이야.
-      특별히 어울리는 게 없다면 "None"을 출력해.
+      특별히 어울리는 게 없다면 "${DODO_ACTIONS.none}"을 출력해.
 
       ## 예시
-      사랑해 -> Wink
-      두두 예쁘다 -> Wink
-      오늘 할 일 다 했어 -> Hurray
-      두두야 다리 안아파? -> Sitdown
-      힘드네 좀 쉬고 싶어 -> Sitdown
-      심심해 -> None
-      점심 먹었어? -> None
+      사랑해 -> ${DODO_ACTIONS.wink}
+      두두 예쁘다 -> ${DODO_ACTIONS.wink}
+      오늘 할 일 다 했어 -> ${DODO_ACTIONS.hurray}
+      두두야 다리 안아파? -> ${DODO_ACTIONS.sitDown}
+      힘드네 좀 쉬고 싶어 -> ${DODO_ACTIONS.sitDown}
+      심심해 -> ${DODO_ACTIONS.none}
+      점심 먹었어? -> ${DODO_ACTIONS.none}
     `;
 
     const messages = [

--- a/apps/backend/src/features/ai/ai.service.ts
+++ b/apps/backend/src/features/ai/ai.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, Logger, ServiceUnavailableException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
+import { DODO_ACTION_VALUES, DODO_ACTIONS, type DodoAction } from '@web24/shared';
 import { Goal } from '../goal/goal.entity';
 import { DodoChatMessage } from '../chat/dodo-chat-message.entity';
 
@@ -201,5 +202,60 @@ JSON 외의 설명, 문장, 코드블록, 주석은 **절대 출력하지 마**.
     const reply = responseJson.result.message.content;
 
     return reply;
+  }
+
+  async getDodoAction(message: string): Promise<DodoAction> {
+    const systemPrompt = `
+      너는 행동 기록 서비스 "뚜웰"의 캐릭터 "두두"가 취할 적절한 행동을 정해야 한다.
+      두두는 다음 네가지 행동을 할 수 있다.
+      "None", "Sitdown", "Wink", "Hurray"
+      반드시 위 네가지 행동 중에 하나만을 응답하고, 그 외의 다른 말은 일체 하지마.
+      응답 기준은 질문에 대해서 두두가 취할 답변과 가장 어울리는 행동이야.
+      특별히 어울리는 게 없다면 "None"을 출력해.
+
+      ## 예시
+      사랑해 -> Wink
+      두두 예쁘다 -> Wink
+      오늘 할 일 다 했어 -> Hurray
+      두두야 다리 안아파? -> Sitdown
+      힘드네 좀 쉬고 싶어 -> Sitdown
+      심심해 -> None
+      점심 먹었어? -> None
+    `;
+
+    const messages = [
+      {
+        role: 'system' as const,
+        content: [{ type: 'text', text: systemPrompt }],
+      },
+      {
+        role: 'user' as const,
+        content: [{ type: 'text', text: message }],
+      },
+    ];
+
+    const modelName = 'HCX-005';
+    const clovaApiUrl = `https://clovastudio.stream.ntruss.com/v3/chat-completions/${modelName}`;
+    const clovaApiKey = this.configService.getOrThrow<string>('CLOVA_API_KEY');
+
+    const response = await fetch(clovaApiUrl, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${clovaApiKey}`,
+      },
+      body: JSON.stringify({ messages }),
+    });
+
+    if (!response.ok) {
+      this.logger.error(`CLOVA API error: ${response.status}`);
+      throw new ServiceUnavailableException('Failed to fetch CLOVA response');
+    }
+
+    const responseJson = (await response.json()) as ClovaChatResponse;
+    const action = responseJson.result.message.content as DodoAction;
+
+    if (DODO_ACTION_VALUES.includes(action)) return action;
+    return DODO_ACTIONS.none;
   }
 }

--- a/apps/backend/src/features/chat/chat.controller.spec.ts
+++ b/apps/backend/src/features/chat/chat.controller.spec.ts
@@ -28,12 +28,12 @@ describe('ChatController', () => {
   });
 
   it('getDodoChat은 서비스 결과를 반환한다', async () => {
-    service.getDodoChat.mockResolvedValue({ reply: '반가워요!' });
+    service.getDodoChat.mockResolvedValue({ reply: '반가워요!', action: 'None' });
 
     const result = await controller.getDodoChat('user-1', { message: '안녕' });
 
     expect(service.getDodoChat).toHaveBeenCalledWith('user-1', '안녕');
-    expect(result).toEqual({ reply: '반가워요!' });
+    expect(result).toEqual({ reply: '반가워요!', action: 'None' });
   });
 
   it('getDodoChatHistory는 서비스 결과를 반환한다', async () => {

--- a/apps/backend/src/features/chat/chat.service.spec.ts
+++ b/apps/backend/src/features/chat/chat.service.spec.ts
@@ -20,10 +20,11 @@ describe('ChatService', () => {
   const configService = {
     getOrThrow: jest.fn().mockReturnValue('test-key'),
   };
-  const aiService = { createDodoMessage: jest.fn() };
+  const aiService = { createDodoMessage: jest.fn(), getDodoAction: jest.fn() };
 
   beforeEach(async () => {
     aiService.createDodoMessage.mockReset();
+    aiService.getDodoAction.mockReset();
     dodoChatRepository.find.mockReset();
     dodoChatRepository.save.mockReset();
     dodoChatRepository.create.mockReset();
@@ -65,7 +66,7 @@ describe('ChatService', () => {
     await expect(service.getDodoChat('user-1', '안녕')).rejects.toThrow('User not found');
   });
 
-  it('getDodoChat은 응답을 저장하고 reply를 반환한다', async () => {
+  it('getDodoChat은 응답을 저장하고 reply와 action을 반환한다', async () => {
     userRepository.findOne.mockResolvedValue({ id: 'user-1' });
 
     dodoChatRepository.find.mockResolvedValue([
@@ -74,6 +75,7 @@ describe('ChatService', () => {
     ]);
 
     aiService.createDodoMessage.mockResolvedValue('반가워요!');
+    aiService.getDodoAction.mockResolvedValue('None');
 
     const result = await service.getDodoChat('user-1', '안녕');
 
@@ -84,6 +86,7 @@ describe('ChatService', () => {
       ],
       '안녕',
     );
+    expect(aiService.getDodoAction).toHaveBeenCalledWith('안녕');
 
     expect(dodoChatRepository.save).toHaveBeenCalledTimes(1);
     expect(dodoChatRepository.save).toHaveBeenCalledWith([
@@ -97,7 +100,7 @@ describe('ChatService', () => {
       }),
     ]);
 
-    expect(result).toEqual({ reply: '반가워요!' });
+    expect(result).toEqual({ reply: '반가워요!', action: 'None' });
   });
 
   describe('getDodoChatHistory', () => {

--- a/apps/backend/src/features/chat/chat.service.ts
+++ b/apps/backend/src/features/chat/chat.service.ts
@@ -29,7 +29,10 @@ export class ChatService {
       take: ChatService.CHAT_HISTORY_LIMIT,
     });
 
-    const reply = await this.aiService.createDodoMessage(history, message);
+    const [reply, action] = await Promise.all([
+      this.aiService.createDodoMessage(history, message),
+      this.aiService.getDodoAction(message),
+    ]);
 
     await this.dodoChatRepository.save([
       this.dodoChatRepository.create({
@@ -44,7 +47,7 @@ export class ChatService {
       }),
     ]);
 
-    return { reply };
+    return { reply, action };
   }
 
   async getDodoChatHistory(userId: string, cursor?: string, limit: number = 10) {

--- a/apps/frontend/src/features/dodoroom/components/ChatMessages.tsx
+++ b/apps/frontend/src/features/dodoroom/components/ChatMessages.tsx
@@ -2,16 +2,23 @@ import { useEffect, useRef, useLayoutEffect } from 'react';
 import type { Message } from '@/features/dodoroom/types/dodo-chat.types';
 
 type ChatMessagesProps = {
-  messages: Message[];
-  onLoadMore?: () => void;
-  isLoading?: boolean;
-  hasMore?: boolean;
+  readonly messages: Message[];
+  readonly onLoadMore?: () => void;
+  readonly isLoading?: boolean;
+  readonly isSendingMessage?: boolean;
+  readonly hasMore?: boolean;
 };
 
 const SCROLL_BOTTOM_THRESHOLD = 50;
 const LOAD_MORE_SCROLL_PERCENTAGE = 20;
 
-export function ChatMessages({ messages, onLoadMore, isLoading, hasMore }: ChatMessagesProps) {
+export function ChatMessages({
+  messages,
+  onLoadMore,
+  isLoading,
+  hasMore,
+  isSendingMessage,
+}: ChatMessagesProps) {
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const shouldScrollToBottomRef = useRef(true);
   const isMountedRef = useRef(false);
@@ -84,6 +91,13 @@ export function ChatMessages({ messages, onLoadMore, isLoading, hasMore }: ChatM
           </div>
         </div>
       ))}
+      {isSendingMessage ? (
+        <div className="flex justify-start">
+          <div className="bg-bg-light text-label-normal border-primary-weak/60 max-w-[75%] rounded-2xl border px-3 py-2 text-sm">
+            ...
+          </div>
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/apps/frontend/src/features/dodoroom/components/DodoActionButton.tsx
+++ b/apps/frontend/src/features/dodoroom/components/DodoActionButton.tsx
@@ -1,0 +1,23 @@
+import { DODO_ACTION_IMAGE_MAP } from '@/features/dodoroom/constants/dodo-action';
+import type { DodoAction } from '@web24/shared';
+
+interface DodoACtionButtonProps {
+  readonly action: Exclude<DodoAction, 'None'>;
+  readonly onClick: (action: Exclude<DodoAction, 'None'>) => void;
+}
+
+export function DodoActionButton({ action, onClick }: DodoACtionButtonProps) {
+  return (
+    <button
+      type="button"
+      onClick={() => onClick(action)}
+      className="flex h-12 w-12 items-center justify-center rounded-md bg-white/80 p-1 hover:bg-white"
+    >
+      <img
+        className="h-full w-full object-contain select-none"
+        src={DODO_ACTION_IMAGE_MAP[action]}
+        alt="두두 캐릭터"
+      />
+    </button>
+  );
+}

--- a/apps/frontend/src/features/dodoroom/components/DodoActionButton.tsx
+++ b/apps/frontend/src/features/dodoroom/components/DodoActionButton.tsx
@@ -1,12 +1,12 @@
 import { DODO_ACTION_IMAGE_MAP } from '@/features/dodoroom/constants/dodo-action';
 import type { DodoAction } from '@web24/shared';
 
-interface DodoACtionButtonProps {
+interface DodoActionButtonProps {
   readonly action: Exclude<DodoAction, 'None'>;
   readonly onClick: (action: Exclude<DodoAction, 'None'>) => void;
 }
 
-export function DodoActionButton({ action, onClick }: DodoACtionButtonProps) {
+export function DodoActionButton({ action, onClick }: DodoActionButtonProps) {
   return (
     <button
       type="button"

--- a/apps/frontend/src/features/dodoroom/components/DodoActionButton.tsx
+++ b/apps/frontend/src/features/dodoroom/components/DodoActionButton.tsx
@@ -15,8 +15,8 @@ export function DodoActionButton({ action, onClick }: DodoActionButtonProps) {
     >
       <img
         className="h-full w-full object-contain select-none"
-        src={DODO_ACTION_IMAGE_MAP[action]}
-        alt="두두 캐릭터"
+        src={DODO_ACTION_IMAGE_MAP[action].src}
+        alt={DODO_ACTION_IMAGE_MAP[action].alt}
       />
     </button>
   );

--- a/apps/frontend/src/features/dodoroom/components/DodoCharacter.tsx
+++ b/apps/frontend/src/features/dodoroom/components/DodoCharacter.tsx
@@ -1,11 +1,5 @@
-import { DODO_ACTIONS, type DodoAction } from '@web24/shared';
-
-const DODO_ACTION_IMAGE_MAP: Record<DodoAction, string> = {
-  [DODO_ACTIONS.none]: '/DodoStand.png',
-  [DODO_ACTIONS.sitDown]: '/DodoSitdown.png',
-  [DODO_ACTIONS.wink]: '/DodoWink.png',
-  [DODO_ACTIONS.hurray]: '/DodoHurray.png',
-};
+import { type DodoAction } from '@web24/shared';
+import { DODO_ACTION_IMAGE_MAP } from '../constants/dodo-action';
 
 interface DodoCharacterProps {
   readonly action: DodoAction;

--- a/apps/frontend/src/features/dodoroom/components/DodoCharacter.tsx
+++ b/apps/frontend/src/features/dodoroom/components/DodoCharacter.tsx
@@ -8,8 +8,8 @@ interface DodoCharacterProps {
 export function DodoCharacter({ action }: DodoCharacterProps) {
   return (
     <img
-      src={DODO_ACTION_IMAGE_MAP[action]}
-      alt="두두 캐릭터"
+      src={DODO_ACTION_IMAGE_MAP[action].src}
+      alt={DODO_ACTION_IMAGE_MAP[action].alt}
       className="h-[60%] max-h-90 w-auto select-none"
     />
   );

--- a/apps/frontend/src/features/dodoroom/components/DodoCharacter.tsx
+++ b/apps/frontend/src/features/dodoroom/components/DodoCharacter.tsx
@@ -1,0 +1,22 @@
+import { DODO_ACTIONS, type DodoAction } from '@web24/shared';
+
+const DODO_ACTION_IMAGE_MAP: Record<DodoAction, string> = {
+  [DODO_ACTIONS.none]: '/DodoStand.png',
+  [DODO_ACTIONS.sitDown]: '/DodoSitdown.png',
+  [DODO_ACTIONS.wink]: '/DodoWink.png',
+  [DODO_ACTIONS.hurray]: '/DodoHurray.png',
+};
+
+interface DodoCharacterProps {
+  readonly action: DodoAction;
+}
+
+export function DodoCharacter({ action }: DodoCharacterProps) {
+  return (
+    <img
+      src={DODO_ACTION_IMAGE_MAP[action]}
+      alt="두두 캐릭터"
+      className="h-[60%] max-h-90 w-auto select-none"
+    />
+  );
+}

--- a/apps/frontend/src/features/dodoroom/constants/dodo-action.ts
+++ b/apps/frontend/src/features/dodoroom/constants/dodo-action.ts
@@ -1,10 +1,16 @@
 import { DODO_ACTIONS, type DodoAction } from '@web24/shared';
 
-export const DODO_ACTION_IMAGE_MAP: Record<DodoAction, string> = {
-  [DODO_ACTIONS.none]: '/DodoStand.png',
-  [DODO_ACTIONS.sitDown]: '/DodoSitdown.png',
-  [DODO_ACTIONS.wink]: '/DodoWink.png',
-  [DODO_ACTIONS.hurray]: '/DodoHurray.png',
+export const DODO_ACTION_IMAGE_MAP: Record<
+  DodoAction,
+  {
+    src: string;
+    alt: string;
+  }
+> = {
+  [DODO_ACTIONS.none]: { src: '/DodoStand.png', alt: '서있는 두두' },
+  [DODO_ACTIONS.sitDown]: { src: '/DodoSitdown.png', alt: '앉은 두두' },
+  [DODO_ACTIONS.wink]: { src: '/DodoWink.png', alt: '윙크하는 두두' },
+  [DODO_ACTIONS.hurray]: { src: '/DodoHurray.png', alt: '만세하는 두두' },
 };
 
 export const DODO_ACTION_COMMAND_MAP: Record<Exclude<DodoAction, 'None'>, string> = {

--- a/apps/frontend/src/features/dodoroom/constants/dodo-action.ts
+++ b/apps/frontend/src/features/dodoroom/constants/dodo-action.ts
@@ -1,0 +1,14 @@
+import { DODO_ACTIONS, type DodoAction } from '@web24/shared';
+
+export const DODO_ACTION_IMAGE_MAP: Record<DodoAction, string> = {
+  [DODO_ACTIONS.none]: '/DodoStand.png',
+  [DODO_ACTIONS.sitDown]: '/DodoSitdown.png',
+  [DODO_ACTIONS.wink]: '/DodoWink.png',
+  [DODO_ACTIONS.hurray]: '/DodoHurray.png',
+};
+
+export const DODO_ACTION_COMMAND_MAP: Record<Exclude<DodoAction, 'None'>, string> = {
+  [DODO_ACTIONS.sitDown]: '두두야, 앉아!',
+  [DODO_ACTIONS.wink]: '두두야, 윙크해!',
+  [DODO_ACTIONS.hurray]: '두두야, 만세해!',
+};

--- a/apps/frontend/src/features/dodoroom/hooks/useDodoChat.spec.tsx
+++ b/apps/frontend/src/features/dodoroom/hooks/useDodoChat.spec.tsx
@@ -3,6 +3,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { sendDodoChat } from '@/features/dodoroom/apis/sendDodoChat.api';
 import { fetchChatHistory } from '@/features/dodoroom/apis/fetchChatHistory.api';
 import { useDodoChat } from './useDodoChat';
+import { DODO_ACTION_COMMAND_MAP } from '../constants/dodo-action';
 
 // --- Mocks ---
 vi.mock('@/features/dodoroom/apis/sendDodoChat.api', () => ({
@@ -59,7 +60,7 @@ describe('useDodoChat Hook', () => {
     const userMessage = '안녕 두두';
     const dodoReply = '반가워!';
 
-    (sendDodoChat as any).mockResolvedValue({ reply: dodoReply });
+    (sendDodoChat as any).mockResolvedValue({ reply: dodoReply, action: 'None' });
 
     act(() => {
       result.current.setInput(userMessage);
@@ -136,5 +137,56 @@ describe('useDodoChat Hook', () => {
     // 메시지 병합 확인
     expect(result.current.messages).toHaveLength(2);
     expect(result.current.hasMore).toBe(false);
+  });
+
+  it('handleActionButton 호출 시 해당 액션에 매핑된 명령어로 메시지를 전송해야 한다', async () => {
+    vi.useFakeTimers();
+
+    const { result } = renderHook(() => useDodoChat());
+    const action = 'Wink';
+    const command = DODO_ACTION_COMMAND_MAP[action];
+    const dodoReply = '폴짝!';
+
+    (sendDodoChat as any).mockResolvedValue({ reply: dodoReply, action });
+
+    // handleActionButton 호출
+    await act(async () => {
+      result.current.handleActionButton(action as any);
+    });
+
+    expect(result.current.messages).toHaveLength(3); // 초기 + 유저 + 두두
+
+    const userMsg = result.current.messages[1];
+    expect(userMsg.role).toBe('user');
+    expect(userMsg.text).toBe(command);
+
+    expect(sendDodoChat).toHaveBeenCalledWith(command);
+
+    const dodoMsg = result.current.messages[2];
+    expect(dodoMsg.role).toBe('dodo');
+
+    act(() => {
+      vi.advanceTimersByTime(35 * dodoReply.length + 100);
+    });
+
+    expect(result.current.messages[2].text).toBe(dodoReply);
+  });
+
+  it('handleSend에 command 인자를 직접 전달하면 input 상태와 무관하게 전송되어야 한다', async () => {
+    const { result } = renderHook(() => useDodoChat());
+    const command = '/test_command';
+    const dodoReply = '테스트 응답';
+
+    (sendDodoChat as any).mockResolvedValue({ reply: dodoReply, action: 'None' });
+
+    // input은 비어있는 상태
+    expect(result.current.input).toBe('');
+
+    await act(async () => {
+      result.current.handleSend(command);
+    });
+
+    expect(sendDodoChat).toHaveBeenCalledWith(command);
+    expect(result.current.messages[1].text).toBe(command);
   });
 });

--- a/apps/frontend/src/features/dodoroom/hooks/useDodoChat.spec.tsx
+++ b/apps/frontend/src/features/dodoroom/hooks/useDodoChat.spec.tsx
@@ -171,22 +171,4 @@ describe('useDodoChat Hook', () => {
 
     expect(result.current.messages[2].text).toBe(dodoReply);
   });
-
-  it('handleSend에 command 인자를 직접 전달하면 input 상태와 무관하게 전송되어야 한다', async () => {
-    const { result } = renderHook(() => useDodoChat());
-    const command = '/test_command';
-    const dodoReply = '테스트 응답';
-
-    (sendDodoChat as any).mockResolvedValue({ reply: dodoReply, action: 'None' });
-
-    // input은 비어있는 상태
-    expect(result.current.input).toBe('');
-
-    await act(async () => {
-      result.current.handleSend(command);
-    });
-
-    expect(sendDodoChat).toHaveBeenCalledWith(command);
-    expect(result.current.messages[1].text).toBe(command);
-  });
 });

--- a/apps/frontend/src/features/dodoroom/hooks/useDodoChat.ts
+++ b/apps/frontend/src/features/dodoroom/hooks/useDodoChat.ts
@@ -122,13 +122,12 @@ export const useDodoChat = () => {
     }, ANIMATION_DURATION_MS);
   }, []);
 
-  const handleSend = useCallback(
-    (command?: string) => {
-      const value = command ?? input.trim();
+  const send = useCallback(
+    (value: string) => {
       if (!value) return;
+
       const userMessageId = createMessageId();
       setMessages((prev) => [...prev, { id: userMessageId, role: 'user', text: value }]);
-      setInput('');
       setIsSendingMessage(true);
 
       sendDodoChat(value)
@@ -150,15 +149,23 @@ export const useDodoChat = () => {
         })
         .finally(() => setIsSendingMessage(false));
     },
-    [animateDodoReply, animateDodoAction, input],
+    [animateDodoReply, animateDodoAction],
   );
+
+  const handleSend = useCallback(() => {
+    const value = input.trim();
+    if (value) {
+      send(value);
+      setInput('');
+    }
+  }, [input, send]);
 
   const handleActionButton = useCallback(
     (action: Exclude<DodoAction, 'None'>) => {
       const command = DODO_ACTION_COMMAND_MAP[action];
-      handleSend(command);
+      send(command);
     },
-    [handleSend],
+    [send],
   );
 
   return {

--- a/apps/frontend/src/features/dodoroom/hooks/useDodoChat.ts
+++ b/apps/frontend/src/features/dodoroom/hooks/useDodoChat.ts
@@ -3,6 +3,7 @@ import { sendDodoChat } from '@/features/dodoroom/apis/sendDodoChat.api';
 import { fetchChatHistory } from '@/features/dodoroom/apis/fetchChatHistory.api';
 import type { Message } from '@/features/dodoroom/types/dodo-chat.types';
 import { DODO_ACTIONS, type DodoAction } from '@web24/shared';
+import { DODO_ACTION_COMMAND_MAP } from '../constants/dodo-action';
 
 const INITIAL_MESSAGES: Message[] = [
   {
@@ -120,31 +121,42 @@ export const useDodoChat = () => {
     }, ANIMATION_DURATION_MS);
   }, []);
 
-  const handleSend = useCallback(() => {
-    const value = input.trim();
-    if (!value) return;
-    const userMessageId = createMessageId();
-    setMessages((prev) => [...prev, { id: userMessageId, role: 'user', text: value }]);
-    setInput('');
+  const handleSend = useCallback(
+    (command?: string) => {
+      const value = command ?? input.trim();
+      if (!value) return;
+      const userMessageId = createMessageId();
+      setMessages((prev) => [...prev, { id: userMessageId, role: 'user', text: value }]);
+      setInput('');
 
-    sendDodoChat(value)
-      .then((data) => {
-        const dodoMessageId = createMessageId();
-        setMessages((prev) => [...prev, { id: dodoMessageId, role: 'dodo', text: '' }]);
-        animateDodoReply(dodoMessageId, data.reply);
-        animateDodoAction(data.action);
-      })
-      .catch(() => {
-        setMessages((prev) => [
-          ...prev,
-          {
-            id: createMessageId(),
-            role: 'dodo',
-            text: '잠시 후 다시 이야기해요.',
-          },
-        ]);
-      });
-  }, [animateDodoReply, animateDodoAction, input]);
+      sendDodoChat(value)
+        .then((data) => {
+          const dodoMessageId = createMessageId();
+          setMessages((prev) => [...prev, { id: dodoMessageId, role: 'dodo', text: '' }]);
+          animateDodoReply(dodoMessageId, data.reply);
+          animateDodoAction(data.action);
+        })
+        .catch(() => {
+          setMessages((prev) => [
+            ...prev,
+            {
+              id: createMessageId(),
+              role: 'dodo',
+              text: '잠시 후 다시 이야기해요.',
+            },
+          ]);
+        });
+    },
+    [animateDodoReply, animateDodoAction, input],
+  );
+
+  const handleActionButton = useCallback(
+    (action: Exclude<DodoAction, 'None'>) => {
+      const command = DODO_ACTION_COMMAND_MAP[action];
+      handleSend(command);
+    },
+    [handleSend],
+  );
 
   return {
     dodoAction,
@@ -157,5 +169,6 @@ export const useDodoChat = () => {
     loadMoreMessages,
     isLoadingHistory,
     hasMore,
+    handleActionButton,
   };
 };

--- a/apps/frontend/src/features/dodoroom/hooks/useDodoChat.ts
+++ b/apps/frontend/src/features/dodoroom/hooks/useDodoChat.ts
@@ -30,6 +30,7 @@ export const useDodoChat = () => {
   const [messages, setMessages] = useState<Message[]>(INITIAL_MESSAGES);
   const [input, setInput] = useState('');
   const [isLoadingHistory, setIsLoadingHistory] = useState(false);
+  const [isSendingMessage, setIsSendingMessage] = useState(false);
   const [hasMore, setHasMore] = useState(true);
   const [nextCursor, setNextCursor] = useState<string | null>(null);
   const typingTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
@@ -128,6 +129,7 @@ export const useDodoChat = () => {
       const userMessageId = createMessageId();
       setMessages((prev) => [...prev, { id: userMessageId, role: 'user', text: value }]);
       setInput('');
+      setIsSendingMessage(true);
 
       sendDodoChat(value)
         .then((data) => {
@@ -145,7 +147,8 @@ export const useDodoChat = () => {
               text: '잠시 후 다시 이야기해요.',
             },
           ]);
-        });
+        })
+        .finally(() => setIsSendingMessage(false));
     },
     [animateDodoReply, animateDodoAction, input],
   );
@@ -166,6 +169,7 @@ export const useDodoChat = () => {
     canSend,
     latestDodoMessage,
     handleSend,
+    isSendingMessage,
     loadMoreMessages,
     isLoadingHistory,
     hasMore,

--- a/apps/frontend/src/features/dodoroom/hooks/useDodoChat.ts
+++ b/apps/frontend/src/features/dodoroom/hooks/useDodoChat.ts
@@ -14,7 +14,7 @@ const INITIAL_MESSAGES: Message[] = [
 ];
 
 const TYPING_ANIMATION_INTERVAL = 35;
-const ANIMATION_DURATION_MS = 3000; // 3초
+const ANIMATION_DURATION_MS = 5000; // 5초
 
 const updateMessageText = (messages: Message[], id: string, text: string) =>
   messages.map((message) => (message.id === id ? { ...message, text } : message));

--- a/apps/frontend/src/features/dodoroom/hooks/useDodoChat.ts
+++ b/apps/frontend/src/features/dodoroom/hooks/useDodoChat.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { sendDodoChat } from '@/features/dodoroom/apis/sendDodoChat.api';
 import { fetchChatHistory } from '@/features/dodoroom/apis/fetchChatHistory.api';
 import type { Message } from '@/features/dodoroom/types/dodo-chat.types';
+import { DODO_ACTIONS, type DodoAction } from '@web24/shared';
 
 const INITIAL_MESSAGES: Message[] = [
   {
@@ -12,6 +13,7 @@ const INITIAL_MESSAGES: Message[] = [
 ];
 
 const TYPING_ANIMATION_INTERVAL = 35;
+const ANIMATION_DURATION_MS = 3000; // 3초
 
 const updateMessageText = (messages: Message[], id: string, text: string) =>
   messages.map((message) => (message.id === id ? { ...message, text } : message));
@@ -23,6 +25,7 @@ const createMessageId = () => {
 };
 
 export const useDodoChat = () => {
+  const [dodoAction, setDodoAction] = useState<DodoAction>(DODO_ACTIONS.none);
   const [messages, setMessages] = useState<Message[]>(INITIAL_MESSAGES);
   const [input, setInput] = useState('');
   const [isLoadingHistory, setIsLoadingHistory] = useState(false);
@@ -30,6 +33,7 @@ export const useDodoChat = () => {
   const [nextCursor, setNextCursor] = useState<string | null>(null);
   const typingTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const isInitialLoadRef = useRef(true);
+  const actionTimeoutRef = useRef<NodeJS.Timeout | null>(null);
 
   const canSend = input.trim().length > 0;
   const latestDodoMessage = useMemo(
@@ -101,6 +105,21 @@ export const useDodoChat = () => {
     }, TYPING_ANIMATION_INTERVAL);
   }, []);
 
+  const animateDodoAction = useCallback((action: DodoAction) => {
+    if (action === 'None') return;
+
+    if (actionTimeoutRef.current) {
+      clearTimeout(actionTimeoutRef.current);
+    }
+
+    setDodoAction(action);
+
+    actionTimeoutRef.current = setTimeout(() => {
+      setDodoAction('None');
+      actionTimeoutRef.current = null;
+    }, ANIMATION_DURATION_MS);
+  }, []);
+
   const handleSend = useCallback(() => {
     const value = input.trim();
     if (!value) return;
@@ -113,6 +132,7 @@ export const useDodoChat = () => {
         const dodoMessageId = createMessageId();
         setMessages((prev) => [...prev, { id: dodoMessageId, role: 'dodo', text: '' }]);
         animateDodoReply(dodoMessageId, data.reply);
+        animateDodoAction(data.action);
       })
       .catch(() => {
         setMessages((prev) => [
@@ -124,9 +144,10 @@ export const useDodoChat = () => {
           },
         ]);
       });
-  }, [animateDodoReply, input]);
+  }, [animateDodoReply, animateDodoAction, input]);
 
   return {
+    dodoAction,
     messages,
     input,
     setInput,

--- a/apps/frontend/src/pages/DodoRoomPage.spec.tsx
+++ b/apps/frontend/src/pages/DodoRoomPage.spec.tsx
@@ -1,0 +1,135 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { useDodoChat } from '@/features/dodoroom/hooks/useDodoChat';
+import { DODO_ACTION_VALUES } from '@web24/shared';
+import { DodoRoomPage } from './DodoRoomPage';
+
+vi.mock('@/features/dodoroom/hooks/useDodoChat', () => ({
+  useDodoChat: vi.fn(),
+}));
+
+vi.mock('@/features/dodoroom/components/ChatInput', () => ({
+  ChatInput: ({ value, onChange, onSend }: any) => (
+    <div data-testid="chat-input">
+      <input data-testid="input-field" value={value} onChange={(e) => onChange(e.target.value)} />
+      <button type="button" data-testid="send-button" onClick={onSend}>
+        Send
+      </button>
+    </div>
+  ),
+}));
+
+vi.mock('@/features/dodoroom/components/ChatMessages', () => ({
+  ChatMessages: ({ messages, onLoadMore }: any) => (
+    <div data-testid="chat-messages">
+      {messages.map((m: any) => (
+        <div key={m.id}>{m.text}</div>
+      ))}
+      <button type="button" data-testid="load-more-button" onClick={onLoadMore}>
+        Load More
+      </button>
+    </div>
+  ),
+}));
+
+vi.mock('@/features/dodoroom/components/DodoSpeechBubble', () => ({
+  DodoSpeechBubble: ({ text }: any) => <div data-testid="speech-bubble">{text}</div>,
+}));
+
+vi.mock('@/features/dodoroom/components/DodoCharacter', () => ({
+  DodoCharacter: ({ action }: any) => <div data-testid="dodo-character">{action}</div>,
+}));
+
+vi.mock('@/features/dodoroom/components/DodoActionButton', () => ({
+  DodoActionButton: ({ action, onClick }: any) => (
+    <button type="button" data-testid={`action-btn-${action}`} onClick={() => onClick(action)}>
+      {action}
+    </button>
+  ),
+}));
+
+describe('DodoRoomPage', () => {
+  const mockHandleSend = vi.fn();
+  const mockLoadMoreMessages = vi.fn();
+  const mockSetInput = vi.fn();
+  const mockHandleActionButton = vi.fn();
+
+  const defaultHookValues = {
+    dodoAction: 'Idle',
+    messages: [
+      { id: '1', role: 'dodo', text: '안녕!' },
+      { id: '2', role: 'user', text: '반가워' },
+    ],
+    input: '',
+    setInput: mockSetInput,
+    canSend: false,
+    latestDodoMessage: { id: '1', role: 'dodo', text: '안녕!' },
+    handleSend: mockHandleSend,
+    loadMoreMessages: mockLoadMoreMessages,
+    isLoadingHistory: false,
+    isSendingMessage: false,
+    hasMore: true,
+    handleActionButton: mockHandleActionButton,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (useDodoChat as any).mockReturnValue(defaultHookValues);
+  });
+
+  it('페이지가 정상적으로 렌더링되어야 한다', () => {
+    render(<DodoRoomPage />);
+
+    expect(screen.getByTestId('dodo-character')).toHaveTextContent('Idle');
+    expect(screen.getByTestId('speech-bubble')).toHaveTextContent('안녕!');
+
+    const validActions = DODO_ACTION_VALUES.filter((v) => v !== 'None');
+    validActions.forEach((action) => {
+      expect(screen.getByTestId(`action-btn-${action}`)).toBeInTheDocument();
+    });
+
+    expect(screen.getAllByTestId('chat-input')).toHaveLength(2);
+    expect(screen.getAllByTestId('chat-messages')).toHaveLength(1);
+  });
+
+  it('메시지 입력 및 전송이 동작해야 한다', () => {
+    render(<DodoRoomPage />);
+
+    const inputField = screen.getAllByTestId('input-field')[0]; // Desktop input
+    const sendButton = screen.getAllByTestId('send-button')[0];
+
+    fireEvent.change(inputField, { target: { value: 'Hello' } });
+    expect(mockSetInput).toHaveBeenCalledWith('Hello');
+
+    fireEvent.click(sendButton);
+    expect(mockHandleSend).toHaveBeenCalled();
+  });
+
+  it('액션 버튼을 클릭하면 handleActionButton이 호출되어야 한다', () => {
+    render(<DodoRoomPage />);
+
+    const action = 'Wink';
+    const actionBtn = screen.getByTestId(`action-btn-${action}`);
+
+    fireEvent.click(actionBtn);
+    expect(mockHandleActionButton).toHaveBeenCalledWith(action);
+  });
+
+  it('모바일에서 "채팅 내역 보기" 버튼을 누르면 시트가 열려야 한다', async () => {
+    render(<DodoRoomPage />);
+
+    const openSheetBtn = screen.getByText('채팅 내역 보기');
+    fireEvent.click(openSheetBtn);
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId('chat-messages')).toHaveLength(2);
+    });
+
+    const closeSheetBtn = screen.getByText('닫기');
+    fireEvent.click(closeSheetBtn);
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId('chat-messages')).toHaveLength(1);
+    });
+  });
+});

--- a/apps/frontend/src/pages/DodoRoomPage.tsx
+++ b/apps/frontend/src/pages/DodoRoomPage.tsx
@@ -3,10 +3,12 @@ import { ChatInput } from '@/features/dodoroom/components/ChatInput';
 import { ChatMessages } from '@/features/dodoroom/components/ChatMessages';
 import { DodoSpeechBubble } from '@/features/dodoroom/components/DodoSpeechBubble';
 import { useDodoChat } from '@/features/dodoroom/hooks/useDodoChat';
+import { DodoCharacter } from '@/features/dodoroom/components/DodoCharacter';
 
 export function DodoRoomPage() {
   const [isMobileSheetOpen, setIsMobileSheetOpen] = useState(false);
   const {
+    dodoAction,
     messages,
     input,
     setInput,
@@ -28,11 +30,7 @@ export function DodoRoomPage() {
           <div className="absolute inset-0" />
           <div className="relative z-10 flex h-full w-full items-end justify-center rounded-2xl pb-10">
             <DodoSpeechBubble text={latestDodoMessage?.text} />
-            <img
-              src="/DodoStand.png"
-              alt="두두 캐릭터"
-              className="h-[60%] max-h-90 w-auto select-none"
-            />
+            <DodoCharacter action={dodoAction} />
           </div>
         </section>
 

--- a/apps/frontend/src/pages/DodoRoomPage.tsx
+++ b/apps/frontend/src/pages/DodoRoomPage.tsx
@@ -4,6 +4,8 @@ import { ChatMessages } from '@/features/dodoroom/components/ChatMessages';
 import { DodoSpeechBubble } from '@/features/dodoroom/components/DodoSpeechBubble';
 import { useDodoChat } from '@/features/dodoroom/hooks/useDodoChat';
 import { DodoCharacter } from '@/features/dodoroom/components/DodoCharacter';
+import { DODO_ACTION_VALUES } from '@web24/shared';
+import { DodoActionButton } from '@/features/dodoroom/components/DodoActionButton';
 
 export function DodoRoomPage() {
   const [isMobileSheetOpen, setIsMobileSheetOpen] = useState(false);
@@ -18,6 +20,7 @@ export function DodoRoomPage() {
     loadMoreMessages,
     isLoadingHistory,
     hasMore,
+    handleActionButton,
   } = useDodoChat();
 
   return (
@@ -31,6 +34,11 @@ export function DodoRoomPage() {
           <div className="relative z-10 flex h-full w-full items-end justify-center rounded-2xl pb-10">
             <DodoSpeechBubble text={latestDodoMessage?.text} />
             <DodoCharacter action={dodoAction} />
+          </div>
+          <div className="absolute bottom-4 left-4 z-20 flex flex-col gap-2">
+            {DODO_ACTION_VALUES.filter((v) => v !== 'None').map((action) => (
+              <DodoActionButton key={action} action={action} onClick={handleActionButton} />
+            ))}
           </div>
         </section>
 

--- a/apps/frontend/src/pages/DodoRoomPage.tsx
+++ b/apps/frontend/src/pages/DodoRoomPage.tsx
@@ -19,6 +19,7 @@ export function DodoRoomPage() {
     handleSend,
     loadMoreMessages,
     isLoadingHistory,
+    isSendingMessage,
     hasMore,
     handleActionButton,
   } = useDodoChat();
@@ -48,14 +49,25 @@ export function DodoRoomPage() {
             messages={messages}
             onLoadMore={loadMoreMessages}
             isLoading={isLoadingHistory}
+            isSendingMessage={isSendingMessage}
             hasMore={hasMore}
           />
-          <ChatInput value={input} canSend={canSend} onChange={setInput} onSend={handleSend} />
+          <ChatInput
+            value={input}
+            canSend={canSend}
+            onChange={setInput}
+            onSend={() => handleSend()}
+          />
         </section>
       </div>
 
       <div className="mt-4 flex flex-col gap-3 md:hidden">
-        <ChatInput value={input} canSend={canSend} onChange={setInput} onSend={handleSend} />
+        <ChatInput
+          value={input}
+          canSend={canSend}
+          onChange={setInput}
+          onSend={() => handleSend()}
+        />
         <button
           type="button"
           onClick={() => setIsMobileSheetOpen(true)}
@@ -90,7 +102,12 @@ export function DodoRoomPage() {
               isLoading={isLoadingHistory}
               hasMore={hasMore}
             />
-            <ChatInput value={input} canSend={canSend} onChange={setInput} onSend={handleSend} />
+            <ChatInput
+              value={input}
+              canSend={canSend}
+              onChange={setInput}
+              onSend={() => handleSend()}
+            />
           </div>
         </div>
       )}

--- a/packages/shared/src/schemas/chat.schemas.ts
+++ b/packages/shared/src/schemas/chat.schemas.ts
@@ -1,3 +1,4 @@
+import { DODO_ACTION_VALUES } from '../types';
 import { z } from '../zod';
 
 export const DodoChatRequestSchema = z.object({
@@ -7,6 +8,7 @@ export type DodoChatRequest = z.infer<typeof DodoChatRequestSchema>;
 
 export const DodoChatResponseSchema = z.object({
   reply: z.string().min(1),
+  action: z.enum(DODO_ACTION_VALUES),
 });
 export type DodoChatResponse = z.infer<typeof DodoChatResponseSchema>;
 

--- a/packages/shared/src/types/dodo.types.ts
+++ b/packages/shared/src/types/dodo.types.ts
@@ -1,0 +1,10 @@
+export const DODO_ACTIONS = {
+  none: 'None',
+  sitDown: 'SitDown',
+  wink: 'Wink',
+  hurray: 'Hurray',
+} as const;
+
+export const DODO_ACTION_VALUES = Object.values(DODO_ACTIONS);
+
+export type DodoAction = (typeof DODO_ACTIONS)[keyof typeof DODO_ACTIONS];

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -2,3 +2,4 @@ export * from './some.types';
 export * from './goal.types';
 export * from './behavior.types';
 export * from './user.types';
+export * from './dodo.types';


### PR DESCRIPTION
## 🔗 관련 이슈

- close: #25

## ✅ 작업 내용

- 사용자가 채팅을 입력시 해당하는 채팅에 반응하여 적절하게 두두의 모습이 5초간 변화하고 다시 원상태로 복귀하게 됨.
  - 두두는 앉아있는 모습, 만세하는 모습, 윙크하는 모습으로 변할 수 있음
  - 참고사항으로 POST /chat 의 응답에 action을 추가하는 방식으로 구현함
- 두두가 위치한 좌측하단에 세로로 두두가 변하는 모션 버튼을 추가했음
  - 모션 버튼을 누르면 해당하는 모션을 위한 명령어를 입력하고 거기에 따라 두두가 변하는 형태임
- 채팅을 입력하고 응답을 기다리는 동안 채팅 화면에서 ... 이 표시된 말풍선을 보여줌

## 📸 스크린샷 / 데모

### 두두의 방

<img width="991" height="586" alt="스크린샷 2026-01-28 오후 6 57 22" src="https://github.com/user-attachments/assets/e14bce83-5571-433d-a803-58dfb65c288a" />

<img width="991" alt="image-sit" src="https://github.com/user-attachments/assets/fd18d90d-62bf-432b-91d2-33abcb8df9b3" />


## 💡 체크리스트

<!-- PR을 제출하기 전에 아래 항목들을 확인해주세요. -->

- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (예: `feature/login` -> `develop`)
- [x] 테스트는 잘 통과했나요?
- [x] 빌드에 성공했나요?

## 💬 To Reviewers

<!-- 리뷰어에게 전달하고 싶은 내용이나 특별히 확인이 필요한 부분을 작성해주세요. -->
