### PR TITLE
feat: 모두에게 웹푸시하기

### DIFF
--- a/apps/backend/src/features/push/push.controller.spec.ts
+++ b/apps/backend/src/features/push/push.controller.spec.ts
@@ -17,6 +17,7 @@ describe('PushController', () => {
             upsertSubscription: jest.fn(),
             removeSubscription: jest.fn(),
             sendToUser: jest.fn(),
+            sendToAllUsers: jest.fn(),
           },
         },
       ],
@@ -77,6 +78,18 @@ describe('PushController', () => {
 
       expect(pushService.sendToUser).toHaveBeenCalledWith('user-id', payload);
       expect(result).toEqual({ sent: 1, failed: 0, removed: 0 });
+    });
+  });
+
+  describe('sendTestNotificationToALl', () => {
+    it('전체 사용자에게 테스트 푸시를 전송하고 결과를 반환한다', async () => {
+      const payload = { title: 'Hello', body: 'World', url: '/home' };
+      pushService.sendToAllUsers.mockResolvedValue({ sent: 2, failed: 0, removed: 0 });
+
+      const result = await controller.sendTestNotificationToALl(payload);
+
+      expect(pushService.sendToAllUsers).toHaveBeenCalledWith(payload);
+      expect(result).toEqual({ sent: 2, failed: 0, removed: 0 });
     });
   });
 });

--- a/apps/backend/src/features/push/push.controller.spec.ts
+++ b/apps/backend/src/features/push/push.controller.spec.ts
@@ -81,12 +81,12 @@ describe('PushController', () => {
     });
   });
 
-  describe('sendTestNotificationToALl', () => {
+  describe('sendTestNotificationToAll', () => {
     it('전체 사용자에게 테스트 푸시를 전송하고 결과를 반환한다', async () => {
       const payload = { title: 'Hello', body: 'World', url: '/home' };
       pushService.sendToAllUsers.mockResolvedValue({ sent: 2, failed: 0, removed: 0 });
 
-      const result = await controller.sendTestNotificationToALl(payload);
+      const result = await controller.sendTestNotificationToAll(payload);
 
       expect(pushService.sendToAllUsers).toHaveBeenCalledWith(payload);
       expect(result).toEqual({ sent: 2, failed: 0, removed: 0 });

--- a/apps/backend/src/features/push/push.controller.ts
+++ b/apps/backend/src/features/push/push.controller.ts
@@ -59,4 +59,13 @@ export class PushController {
     const result = await this.pushService.sendToUser(userId, body);
     return result;
   }
+
+  @Post('notifications/test/all')
+  async sendTestNotificationToALl(
+    @Body(new ZodValidationPipe(SendPushNotificationRequestSchema))
+    body: SendPushNotificationRequest,
+  ): Promise<SendPushNotificationResponse> {
+    const result = await this.pushService.sendToAllUsers(body);
+    return result;
+  }
 }

--- a/apps/backend/src/features/push/push.controller.ts
+++ b/apps/backend/src/features/push/push.controller.ts
@@ -61,7 +61,7 @@ export class PushController {
   }
 
   @Post('notifications/test/all')
-  async sendTestNotificationToALl(
+  async sendTestNotificationToAll(
     @Body(new ZodValidationPipe(SendPushNotificationRequestSchema))
     body: SendPushNotificationRequest,
   ): Promise<SendPushNotificationResponse> {

--- a/apps/backend/src/features/push/push.docs.ts
+++ b/apps/backend/src/features/push/push.docs.ts
@@ -142,4 +142,28 @@ export function registerPushApi(registry: OpenAPIRegistry, common: CommonSchemas
       },
     },
   });
+
+  registry.registerPath({
+    method: 'post',
+    path: '/push/notifications/test/all',
+    request: {
+      body: {
+        content: {
+          'application/json': {
+            schema: sendPushNotificationRequest,
+          },
+        },
+      },
+    },
+    responses: {
+      201: {
+        description: '전체 사용자에게 테스트 푸시 알림을 전송한다.',
+        content: {
+          'application/json': {
+            schema: sendPushNotificationResponse,
+          },
+        },
+      },
+    },
+  });
 }

--- a/apps/backend/src/features/push/push.service.spec.ts
+++ b/apps/backend/src/features/push/push.service.spec.ts
@@ -242,6 +242,84 @@ describe('PushService', () => {
     });
   });
 
+  describe('sendToAllUsers', () => {
+    const payload: SendPushNotificationRequest = {
+      title: 'Hello',
+      body: 'World',
+      url: '/home',
+    };
+
+    it('구독이 없으면 0건으로 응답한다', async () => {
+      pushSubscriptionRepository.find.mockResolvedValue([]);
+
+      const result = await service.sendToAllUsers(payload);
+
+      expect(result).toEqual({ sent: 0, failed: 0, removed: 0 });
+      expect(mockWebpush.sendNotification).not.toHaveBeenCalled();
+    });
+
+    it('정상 전송하면 성공 카운트를 올린다', async () => {
+      const subscription = {
+        id: 'sub-id',
+        subscription: {
+          endpoint: 'https://example.com/push/1',
+          keys: { p256dh: 'p256dh', auth: 'auth' },
+        },
+      } as PushSubscriptionEntity;
+
+      pushSubscriptionRepository.find.mockResolvedValue([subscription]);
+      mockWebpush.sendNotification.mockResolvedValue(undefined);
+
+      const result = await service.sendToAllUsers(payload);
+
+      expect(mockWebpush.sendNotification).toHaveBeenCalledWith(
+        subscription.subscription,
+        JSON.stringify({
+          title: payload.title,
+          body: payload.body,
+          url: payload.url,
+        }),
+      );
+      expect(result).toEqual({ sent: 1, failed: 0, removed: 0 });
+    });
+
+    it('410/404 에러면 구독을 제거한다', async () => {
+      const subscription = {
+        id: 'sub-id',
+        subscription: {
+          endpoint: 'https://example.com/push/1',
+          keys: { p256dh: 'p256dh', auth: 'auth' },
+        },
+      } as PushSubscriptionEntity;
+
+      pushSubscriptionRepository.find.mockResolvedValue([subscription]);
+      mockWebpush.sendNotification.mockRejectedValue({ statusCode: 410 });
+
+      const result = await service.sendToAllUsers(payload);
+
+      expect(pushSubscriptionRepository.remove).toHaveBeenCalledWith(subscription);
+      expect(result).toEqual({ sent: 0, failed: 1, removed: 1 });
+    });
+
+    it('기타 에러면 실패 카운트만 올린다', async () => {
+      const subscription = {
+        id: 'sub-id',
+        subscription: {
+          endpoint: 'https://example.com/push/1',
+          keys: { p256dh: 'p256dh', auth: 'auth' },
+        },
+      } as PushSubscriptionEntity;
+
+      pushSubscriptionRepository.find.mockResolvedValue([subscription]);
+      mockWebpush.sendNotification.mockRejectedValue(new Error('send failed'));
+
+      const result = await service.sendToAllUsers(payload);
+
+      expect(pushSubscriptionRepository.remove).not.toHaveBeenCalled();
+      expect(result).toEqual({ sent: 0, failed: 1, removed: 0 });
+    });
+  });
+
   describe('Scheduled Pushes', () => {
     let mockQueryBuilder: any;
 

--- a/apps/backend/src/features/push/push.service.ts
+++ b/apps/backend/src/features/push/push.service.ts
@@ -125,6 +125,52 @@ export class PushService implements OnModuleInit {
     );
   }
 
+  async sendToAllUsers(
+    payload: SendPushNotificationRequest,
+  ): Promise<SendPushNotificationResponse> {
+    const subscriptions = await this.pushSubscriptionRepository.find();
+
+    if (subscriptions.length === 0) {
+      return { sent: 0, failed: 0, removed: 0 };
+    }
+
+    const payloadString = JSON.stringify({
+      title: payload.title,
+      body: payload.body ?? '',
+      url: payload.url ?? '/',
+    });
+
+    const limit = pLimit(10);
+    const results = await Promise.all(
+      subscriptions.map((subscription) =>
+        limit(async () => {
+          try {
+            await webpush.sendNotification(subscription.subscription, payloadString);
+            return { sent: 1, failed: 0, removed: 0 };
+          } catch (error) {
+            if (error && typeof error === 'object' && 'statusCode' in error) {
+              const { statusCode } = error as { statusCode: number };
+              if (statusCode === 404 || statusCode === 410) {
+                await this.pushSubscriptionRepository.remove(subscription);
+                return { sent: 0, failed: 1, removed: 1 };
+              }
+            }
+            return { sent: 0, failed: 1, removed: 0 };
+          }
+        }),
+      ),
+    );
+
+    return results.reduce(
+      (acc, item) => ({
+        sent: acc.sent + item.sent,
+        failed: acc.failed + item.failed,
+        removed: acc.removed + item.removed,
+      }),
+      { sent: 0, failed: 0, removed: 0 },
+    );
+  }
+
   @Cron('0 0 13 * * *', { name: 'dodo_lunch_push', timeZone: 'Asia/Seoul' })
   async handleLunchPush() {
     await this.sendDodoPush('LUNCH');


### PR DESCRIPTION
<!-- PR 제목 예시 : feat: 로그인 기능 구현 -->
<!-- PR 제목은 위 형식을 참고하여 작성해주세요. -->
<!-- 필요 없는 내용은 지우고 작성해주세요 -->

## 🔗 관련 이슈

- close: #58

## ✅ 작업 내용

- 모두에게 웹푸시를 보내는 엔드포인트를 추가했습니다.
- 관리자만 실행하도록 하는 것이 베스트이지만, 우선은 모두에게 엔드포인트를 열어 놓았습니다.

## 📸 스크린샷 / 데모

### Swagger 문서를 통해 실행하는 사진
<img width="658" height="573" alt="스크린샷 2026-01-29 오후 10 20 00" src="https://github.com/user-attachments/assets/4cbe3413-2086-4a66-b087-1747ef11174f" />

### Swagger 문서를 통햇 실행한 결과 웹푸시를 받은 모습
<img width="364" height="93" alt="스크린샷 2026-01-29 오후 10 20 06" src="https://github.com/user-attachments/assets/25969f82-da7c-49ac-967f-e43684409797" />

## 🧪 테스트 방법 

1. curl, postman, swagger 문서 등을 통해 호출할 수 있습니다.

## 💡 체크리스트

- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (예: `feature/login` -> `develop`)
- [x] 테스트는 잘 통과했나요?
- [x] 빌드에 성공했나요?

