### PR TITLE
refactor: 메인페이지 UX 개선

### DIFF
--- a/apps/frontend/src/features/behavior/components/AIBehaviorContainer.spec.tsx
+++ b/apps/frontend/src/features/behavior/components/AIBehaviorContainer.spec.tsx
@@ -1,5 +1,5 @@
-import { render, screen, fireEvent } from '@testing-library/react';
-import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { Behavior } from '@/shared/components/behavior/BehaviorCard.types';
 import { AIBehaviorContainer } from './AIBehaviorContainer';
 
@@ -25,6 +25,14 @@ describe('AIBehaviorContainer', () => {
     },
   ];
 
+  beforeEach(() => {
+    vi.useFakeTimers(); // 가짜 타이머 활성화
+  });
+
+  afterEach(() => {
+    vi.clearAllTimers(); // 타이머 초기화 (RealTimer로 복구하지 않음)
+  });
+
   it('로딩 중이거나 데이터가 없으면 빈 컨테이너를 렌더링한다', () => {
     const { container } = render(
       <AIBehaviorContainer behaviors={[]} onToggle={vi.fn()} isLoading isMaking={false} />,
@@ -49,6 +57,11 @@ describe('AIBehaviorContainer', () => {
         isMaking={false}
       />,
     );
+
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
     expect(screen.getByText('AI 맞춤 추천')).toBeInTheDocument();
     expect(screen.getByText('Behavior 1')).toBeInTheDocument();
     expect(screen.getByText('Behavior 2')).toBeInTheDocument();
@@ -64,6 +77,10 @@ describe('AIBehaviorContainer', () => {
         isMaking={false}
       />,
     );
+
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
 
     const toggleButton = screen.getByLabelText('Behavior 1 완료 토글');
     fireEvent.click(toggleButton);

--- a/apps/frontend/src/features/behavior/components/AIBehaviorContainer.tsx
+++ b/apps/frontend/src/features/behavior/components/AIBehaviorContainer.tsx
@@ -30,18 +30,19 @@ export function AIBehaviorContainer({
   const containerClassName =
     'animate-in fade-in slide-in-from-top-4 border-primary-weak/60 bg-primary-weak/30 relative mb-10 overflow-hidden rounded-4xl border p-6 duration-500 min-h-55';
 
-  const [isMinLoading, setIsMinLoading] = useState(true);
+  const [showLoading, setShowLoading] = useState(isLoading || isMaking);
 
   useEffect(() => {
-    const timer = setTimeout(() => {
-      setIsMinLoading(false);
-    }, MIN_LOADING_TIME_MS);
-
+    let timer: NodeJS.Timeout;
+    if (isLoading || isMaking) {
+      setShowLoading(true);
+    } else {
+      timer = setTimeout(() => {
+        setShowLoading(false);
+      }, MIN_LOADING_TIME_MS);
+    }
     return () => clearTimeout(timer);
-  }, []);
-
-  // 실제 데이터 로딩 중이거나, 생성 중이거나, 최소 시간이 지나지 않았으면 로딩 표시
-  const showLoading = isLoading || isMaking || isMinLoading;
+  }, [isLoading, isMaking]);
 
   if (showLoading) {
     return (

--- a/apps/frontend/src/features/behavior/components/AIBehaviorContainer.tsx
+++ b/apps/frontend/src/features/behavior/components/AIBehaviorContainer.tsx
@@ -1,6 +1,7 @@
 import { BehaviorCard } from '@/shared/components/behavior/BehaviorCard';
 import type { Behavior } from '@/shared/components/behavior/BehaviorCard.types';
 import { ICON_SIZE } from '@/shared/constants/icon';
+import { useEffect, useState } from 'react';
 
 interface AIBehaviorContainerProps {
   behaviors: Behavior[];
@@ -18,6 +19,8 @@ function MakingIndicator() {
   );
 }
 
+const MIN_LOADING_TIME_MS = 500;
+
 export function AIBehaviorContainer({
   behaviors,
   onToggle,
@@ -27,7 +30,20 @@ export function AIBehaviorContainer({
   const containerClassName =
     'animate-in fade-in slide-in-from-top-4 border-primary-weak/60 bg-primary-weak/30 relative mb-10 overflow-hidden rounded-4xl border p-6 duration-500 min-h-55';
 
-  if (isLoading || isMaking) {
+  const [isMinLoading, setIsMinLoading] = useState(true);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setIsMinLoading(false);
+    }, MIN_LOADING_TIME_MS);
+
+    return () => clearTimeout(timer);
+  }, []);
+
+  // 실제 데이터 로딩 중이거나, 생성 중이거나, 최소 시간이 지나지 않았으면 로딩 표시
+  const showLoading = isLoading || isMaking || isMinLoading;
+
+  if (showLoading) {
     return (
       <div className={containerClassName}>
         <div className="absolute inset-0 flex items-center justify-center">

--- a/apps/frontend/src/features/behavior/components/TodayBehaviorList.tsx
+++ b/apps/frontend/src/features/behavior/components/TodayBehaviorList.tsx
@@ -7,6 +7,7 @@ import { useTodayBehaviorAdd } from '@/features/behavior/hooks/useTodayBehaviorA
 import { useFilteredTodayBehaviors } from '@/features/behavior/hooks/useFilteredTodayBehaviors';
 import { TodayBehaviorAddModal } from '@/features/behavior/components/TodayBehaviorAddModal';
 import { EmptyGoal } from '@/shared/components/goal/EmptyGoal';
+import { useState } from 'react';
 import { SwiperTabs } from './SwiperTabs';
 import { TodayBehaviorCardGrid } from './TodayBehaviorCardGrid';
 
@@ -43,6 +44,7 @@ export function TodayBehaviorList({
     handleBehaviorSelect,
     resetGoalSelection,
   } = useTodayBehaviorAdd({ goals, onAddBehavior });
+  const [showTooltip, setShowTooltip] = useState(false);
 
   return (
     <div className="mb-4 flex-col items-center justify-between px-4">
@@ -50,18 +52,25 @@ export function TodayBehaviorList({
         <h3 className="flex items-center gap-2 text-lg font-bold">
           <span>오늘의 행동</span>
           <span className="rounded-full px-2 py-0.5 text-xs font-bold">{behaviors.length}</span>
-          <span className="group relative inline-flex">
+          <span className="relative inline-flex">
             <button
               type="button"
               aria-label="오늘의 행동 안내"
               aria-describedby="today-behavior-tooltip"
+              aria-expanded={showTooltip}
+              // 데스크톱: 마우스 올리면 보이고, 떼면 숨김
+              onMouseEnter={() => setShowTooltip(true)}
+              onMouseLeave={() => setShowTooltip(false)}
+              // 모바일 & 데스크톱: 클릭(터치) 시 토글
+              onClick={() => setShowTooltip((prev) => !prev)}
             >
               <Info size={ICON_SIZE.xxs} />
             </button>
+
             <span
               id="today-behavior-tooltip"
               role="tooltip"
-              className="bg-bg-light text-label-normal border-bg-alternative pointer-events-none absolute top-1/2 left-full z-20 ml-2 w-max max-w-[50vw] -translate-y-1/2 rounded-xl border px-3 py-2 text-xs font-medium break-words whitespace-normal opacity-0 shadow-(--shadow-normal) transition-opacity duration-200 group-focus-within:opacity-100 group-hover:opacity-100"
+              className={`bg-bg-light text-label-normal border-bg-alternative pointer-events-none absolute top-1/2 left-full z-20 ml-2 w-max max-w-[50vw] -translate-y-1/2 rounded-xl border px-3 py-2 text-xs font-medium wrap-break-word whitespace-normal shadow-(--shadow-normal) transition-opacity duration-200 ${showTooltip ? 'visible opacity-100' : 'invisible opacity-0'} `}
             >
               오늘을 위해 추출된 행동만 보여줍니다
             </span>
@@ -71,7 +80,7 @@ export function TodayBehaviorList({
           <button
             type="button"
             onClick={onRefresh}
-            className="text-label-disable hover:text-label-normal hover:bg-primary-weak/30 inline-flex items-center gap-1 rounded-lg p-2 text-sm font-semibold transition"
+            className="text-label-disable hover:text-label-normal hover:bg-primary-weak/30 inline-flex items-center gap-1 rounded-lg text-sm font-semibold transition"
           >
             <RefreshCw size={ICON_SIZE.xxs} />
             오늘의 행동 다시 뽑기

--- a/apps/frontend/src/features/dodoroom/components/DodoSpeechBubble.tsx
+++ b/apps/frontend/src/features/dodoroom/components/DodoSpeechBubble.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 interface DodoSpeechBubbleProps {
   text?: string;
@@ -10,17 +10,16 @@ export function DodoSpeechBubble({ text }: DodoSpeechBubbleProps) {
   const [showBottomBlur, setShowBottomBlur] = useState(false);
 
   // 스크롤 위치에 따라 상/하단 블러 표시 여부 결정
-  const handleScroll = () => {
+  const handleScroll = useCallback(() => {
     if (!scrollRef.current) return;
     const { scrollTop, scrollHeight, clientHeight } = scrollRef.current;
-
     setShowTopBlur(scrollTop > 0);
     setShowBottomBlur(scrollTop + clientHeight < scrollHeight - 1);
-  };
+  }, []);
 
   useEffect(() => {
     handleScroll();
-  }, [text]);
+  }, [text, handleScroll]);
 
   if (!text) return null;
 

--- a/apps/frontend/src/features/dodoroom/components/DodoSpeechBubble.tsx
+++ b/apps/frontend/src/features/dodoroom/components/DodoSpeechBubble.tsx
@@ -1,14 +1,56 @@
-type DodoSpeechBubbleProps = {
+import { useEffect, useRef, useState } from 'react';
+
+interface DodoSpeechBubbleProps {
   text?: string;
-};
+}
 
 export function DodoSpeechBubble({ text }: DodoSpeechBubbleProps) {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const [showTopBlur, setShowTopBlur] = useState(false);
+  const [showBottomBlur, setShowBottomBlur] = useState(false);
+
+  // 스크롤 위치에 따라 상/하단 블러 표시 여부 결정
+  const handleScroll = () => {
+    if (!scrollRef.current) return;
+    const { scrollTop, scrollHeight, clientHeight } = scrollRef.current;
+
+    setShowTopBlur(scrollTop > 0);
+    setShowBottomBlur(scrollTop + clientHeight < scrollHeight - 1);
+  };
+
+  useEffect(() => {
+    handleScroll();
+  }, [text]);
+
   if (!text) return null;
 
   return (
-    <div className="absolute bottom-[70%] left-1/2 w-fit -translate-x-1/2 md:bottom-[67%]">
-      <div className="border-primary-strong-2 bg-bg-light text-label-normal text-md relative rounded-2xl border px-4 py-3 text-center font-bold shadow">
-        {text}
+    <div className="absolute bottom-[68%] left-1/2 z-20 w-full max-w-[90%] -translate-x-1/2 px-4 md:bottom-[70%] md:w-fit md:max-w-[80%] md:px-0">
+      <div className="border-primary-strong-2 bg-bg-light text-label-normal text-md relative rounded-2xl border p-2 text-center font-bold shadow">
+        <div className="relative">
+          {/* 상단 페이드 */}
+          <div
+            className={`from-bg-light pointer-events-none absolute top-0 right-0 left-0 z-10 h-6 bg-linear-to-b to-transparent transition-opacity duration-200 ${
+              showTopBlur ? 'opacity-100' : 'opacity-0'
+            }`}
+          />
+
+          <div
+            ref={scrollRef}
+            onScroll={handleScroll}
+            className="scrollbar-pretty max-h-24 overflow-y-auto overscroll-contain break-keep"
+          >
+            {text}
+          </div>
+
+          {/* 하단 페이드 */}
+          <div
+            className={`from-bg-light pointer-events-none absolute right-0 bottom-0 left-0 z-10 h-6 bg-linear-to-t to-transparent transition-opacity duration-200 ${
+              showBottomBlur ? 'opacity-100' : 'opacity-0'
+            }`}
+          />
+        </div>
+
         <span className="border-primary-strong-2 bg-bg-light absolute -bottom-1.5 left-1/2 h-3 w-3 -translate-x-1/2 rotate-45 border-r border-b" />
       </div>
     </div>

--- a/apps/frontend/src/pages/AllGoalsPage.tsx
+++ b/apps/frontend/src/pages/AllGoalsPage.tsx
@@ -19,6 +19,19 @@ export function AllGoalsPage() {
 
   const { allBehaviors, isLoading: isBehaviorsLoading } = useAllBehaviors(isAllExpanded);
 
+  // 전체 토글 상태 동기화 로직
+  useEffect(() => {
+    if (!goals) return;
+
+    const totalGoals = goals.length;
+
+    if (totalGoals > 0 && expandedGoalIds.size === totalGoals) {
+      setIsAllExpanded(true);
+    } else if (isAllExpanded) {
+      setIsAllExpanded(false);
+    }
+  }, [expandedGoalIds, goals, isAllExpanded]);
+
   const behaviorsByGoal = allBehaviors?.reduce(
     (acc: Record<string, Behavior[]>, behavior: Behavior) => {
       const { goalId } = behavior;
@@ -59,11 +72,9 @@ export function AllGoalsPage() {
     if (isAllExpanded) {
       setIsAllExpanded(false);
       setExpandedGoalIds(new Set());
-    } else {
+    } else if (goals) {
       setIsAllExpanded(true);
-      if (goals) {
-        setExpandedGoalIds(new Set(goals.map((g) => g.id)));
-      }
+      setExpandedGoalIds(new Set(goals.map((g) => g.id)));
     }
   };
 
@@ -72,7 +83,6 @@ export function AllGoalsPage() {
       const next = new Set(prev);
       if (next.has(id)) {
         next.delete(id);
-        setIsAllExpanded(false);
       } else {
         next.add(id);
       }


### PR DESCRIPTION
## 🔗 관련 이슈

- close: #194

## ✅ 작업 내용

[메인페이지]

- [x] 오늘의 행동 다시 뽑기 / + 목표 오른쪽 패딩 맞추기
- [x] 모바일 오늘의 행동 툴팁 보이게 해결
- [x] AI 맞춤 추천 로딩중 인디케이터 깜빡임 해결

[두두의방페이지]
- [x] 두두의 방 말풍선 잘림 문제 해결

[전체 목표 페이지]
- [x] 전체 목표 전부 펼치기/접기 버튼 상태 동기화

## 📸 스크린샷 / 데모 (옵션)

<img width="800" alt="dodoroom" src="https://github.com/user-attachments/assets/b07cc0e3-9873-4b9f-ba8c-4ac9703dc328" />

## 🧪 테스트 방법 (옵션)

## 💡 체크리스트

- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (예: `feature/login` -> `develop`)
- [x] 테스트는 잘 통과했나요?
- [x] 빌드에 성공했나요?

## 💬 To Reviewers
- 오늘의 행동 뽑기 버튼은 현재 오늘의 행동을 불러오는 로직(get or create)으로 인해 작업 보류했습니다
