### PR TITLE
feat: 대사·목표·메인 페이지 UX 개선

### DIFF
--- a/apps/backend/src/features/behavior/behavior.service.spec.ts
+++ b/apps/backend/src/features/behavior/behavior.service.spec.ts
@@ -577,27 +577,31 @@ describe('BehaviorService', () => {
   });
 
   describe('refreshTodayBehaviors', () => {
-    it('기존 행동을 재사용하고 skipped를 pending으로 되돌린다', async () => {
+    it('기존 행동을 재사용하고 skipped를 pending으로 되돌리고 completed는 그대로 내려준다', async () => {
       const user = { id: 'user-1', nickname: '테스트유저' };
       const goal = { title: '건강한 생활', color: 'mint' };
+
       const behavior1 = {
         id: 'b-1',
         title: '물 1컵 마시기',
         difficulty: '마음열기',
         goal,
       } as Behavior;
+
       const behavior2 = {
         id: 'b-2',
         title: '스트레칭',
         difficulty: '시작하기',
         goal,
       } as Behavior;
+
       const behavior3 = {
         id: 'b-3',
         title: '걷기',
         difficulty: '이어가기',
         goal,
       } as Behavior;
+
       const existing = [
         { id: 'tb-1', status: 'completed', behavior: behavior1 },
         { id: 'tb-2', status: 'skipped', behavior: behavior2 },
@@ -612,20 +616,26 @@ describe('BehaviorService', () => {
       const userRepository = {
         createQueryBuilder: jest.fn().mockReturnValue(userQueryBuilder),
       };
+
       const todayRepository = {
-        find: jest.fn().mockResolvedValueOnce(existing).mockResolvedValueOnce([]),
+        find: jest
+          .fn()
+          .mockResolvedValueOnce(existing) // 기존 todayBehavior 조회
+          .mockResolvedValueOnce([]), // deleted 조회
         update: jest.fn().mockResolvedValue({ affected: 1 }),
         create: jest.fn((value) => value),
         save: jest.fn(),
       };
+
       const behaviorRepository = {
         find: jest.fn().mockResolvedValue([behavior1, behavior2, behavior3]),
       };
+
       const manager = {
         getRepository: (entity: unknown) => {
-          if (entity === (User as unknown)) return userRepository;
-          if (entity === (TodayBehavior as unknown)) return todayRepository;
-          if (entity === (Behavior as unknown)) return behaviorRepository;
+          if (entity === User) return userRepository;
+          if (entity === TodayBehavior) return todayRepository;
+          if (entity === Behavior) return behaviorRepository;
           return null;
         },
       };
@@ -633,34 +643,13 @@ describe('BehaviorService', () => {
       dataSource.transaction.mockImplementation(async (work: (m: typeof manager) => unknown) =>
         work(manager),
       );
-      const extractSpy = jest
-        .spyOn(service, 'extractTodayBehaviors')
-        .mockReturnValue([behavior1, behavior2]);
+
+      // extractTodayBehaviors는 tb-1 제외 후 새로 뽑을 후보
+      const extractSpy = jest.spyOn(service, 'extractTodayBehaviors').mockReturnValue([behavior2]); // completed 제외
 
       const result = await service.refreshTodayBehaviors(user.id);
 
-      expect(userRepository.createQueryBuilder).toHaveBeenCalledWith('user');
-      expect(userQueryBuilder.setLock).toHaveBeenCalledWith('pessimistic_write');
-      expect(userQueryBuilder.where).toHaveBeenCalledWith('user.id = :id', { id: user.id });
-      expect(todayRepository.find).toHaveBeenNthCalledWith(1, {
-        where: {
-          date: expect.any(String),
-          user: { id: user.id },
-          status: Not(In(['deleted'])),
-        },
-        relations: { behavior: { goal: true }, user: true },
-      });
-      expect(todayRepository.update).toHaveBeenNthCalledWith(
-        1,
-        { date: expect.any(String), user: { id: user.id }, status: 'pending' },
-        { status: 'skipped' },
-      );
-      expect(todayRepository.update).toHaveBeenNthCalledWith(
-        2,
-        { id: In(['tb-2']) },
-        { status: 'pending' },
-      );
-      expect(todayRepository.save).not.toHaveBeenCalled();
+      // 기존 completed는 그대로, skipped->pending으로 변환
       expect(result).toEqual([
         {
           id: 'tb-1',
@@ -681,52 +670,7 @@ describe('BehaviorService', () => {
           isRecommended: false,
         },
       ]);
-      extractSpy.mockRestore();
-    });
 
-    it('추출 결과가 없으면 빈 배열을 반환한다', async () => {
-      const user = { id: 'user-1', nickname: '테스트유저' };
-
-      const userQueryBuilder = {
-        setLock: jest.fn().mockReturnThis(),
-        where: jest.fn().mockReturnThis(),
-        getOne: jest.fn().mockResolvedValue(user),
-      };
-      const userRepository = {
-        createQueryBuilder: jest.fn().mockReturnValue(userQueryBuilder),
-      };
-      const todayRepository = {
-        find: jest.fn().mockResolvedValue([]),
-        update: jest.fn().mockResolvedValue({ affected: 0 }),
-        create: jest.fn((value) => value),
-        save: jest.fn(),
-      };
-      const behaviorRepository = {
-        find: jest.fn().mockResolvedValue([]),
-      };
-      const manager = {
-        getRepository: (entity: unknown) => {
-          if (entity === (User as unknown)) return userRepository;
-          if (entity === (TodayBehavior as unknown)) return todayRepository;
-          if (entity === (Behavior as unknown)) return behaviorRepository;
-          return null;
-        },
-      };
-
-      dataSource.transaction.mockImplementation(async (work: (m: typeof manager) => unknown) =>
-        work(manager),
-      );
-      const extractSpy = jest.spyOn(service, 'extractTodayBehaviors').mockReturnValue([]);
-
-      const result = await service.refreshTodayBehaviors(user.id);
-
-      expect(userQueryBuilder.where).toHaveBeenCalledWith('user.id = :id', { id: user.id });
-      expect(todayRepository.update).toHaveBeenCalledWith(
-        { date: expect.any(String), user: { id: user.id }, status: 'pending' },
-        { status: 'skipped' },
-      );
-      expect(todayRepository.save).not.toHaveBeenCalled();
-      expect(result).toEqual([]);
       extractSpy.mockRestore();
     });
 

--- a/apps/backend/src/features/behavior/behavior.service.ts
+++ b/apps/backend/src/features/behavior/behavior.service.ts
@@ -145,8 +145,15 @@ export class BehaviorService {
         deletedTodayBehaviors.map((todayBehavior) => todayBehavior.behavior.id),
       );
 
+      const completedBehaviorIds = new Set(
+        existingTodayBehaviors
+          .filter((tb) => tb.status === 'completed')
+          .map((tb) => tb.behavior.id),
+      );
+
       const candidateBehaviors = behaviors.filter(
-        (behavior) => !deletedBehaviorIds.has(behavior.id),
+        (behavior) =>
+          !deletedBehaviorIds.has(behavior.id) && !completedBehaviorIds.has(behavior.id),
       );
 
       const extractedTodayBehavior = this.extractTodayBehaviors(candidateBehaviors);
@@ -197,6 +204,10 @@ export class BehaviorService {
       const newTodayBehaviors =
         toInsert.length > 0 ? await todayBehaviorRepository.save(toInsert) : [];
 
+      const completedTodayBehaviors = existingTodayBehaviors.filter(
+        (tb) => tb.status === 'completed',
+      );
+
       // TodayBehavior를 응답 형태로 매핑한다(관계 누락 시 fallback 사용).
       const mapToResponse = (todayBehavior: TodayBehavior, fallbackBehavior?: Behavior) => {
         const behavior = todayBehavior.behavior ?? fallbackBehavior;
@@ -216,6 +227,7 @@ export class BehaviorService {
       };
 
       return [
+        ...completedTodayBehaviors.map((behavior) => mapToResponse(behavior)),
         ...selectedExisting.map((behavior) => mapToResponse(behavior)),
         ...newTodayBehaviors.map((behavior, index) =>
           mapToResponse(behavior, toInsert[index]?.behavior),

--- a/apps/backend/src/features/behavior/behavior.service.ts
+++ b/apps/backend/src/features/behavior/behavior.service.ts
@@ -157,9 +157,6 @@ export class BehaviorService {
       );
 
       const extractedTodayBehavior = this.extractTodayBehaviors(candidateBehaviors);
-      if (extractedTodayBehavior.length === 0) {
-        return [];
-      }
 
       // behaviorId 기준으로 중복을 제거하고, 기존 row를 재사용한다.
       const existingByBehaviorId = new Map(

--- a/apps/frontend/src/features/behavior/components/TodayBehaviorCardGrid.tsx
+++ b/apps/frontend/src/features/behavior/components/TodayBehaviorCardGrid.tsx
@@ -20,6 +20,9 @@ export function TodayBehaviorCardGrid({
     BEHAVIOR_DIFFICULTIES.map((difficulty, index) => [difficulty, index]),
   );
   const sortedBehaviors = [...behaviors].sort((a, b) => {
+    if (a.isChecked !== b.isChecked) {
+      return a.isChecked ? 1 : -1;
+    }
     const difficultyDelta =
       (difficultyRank.get(a.difficulty) ?? Number.POSITIVE_INFINITY) -
       (difficultyRank.get(b.difficulty) ?? Number.POSITIVE_INFINITY);

--- a/apps/frontend/src/features/dodoroom/components/DodoActionButton.tsx
+++ b/apps/frontend/src/features/dodoroom/components/DodoActionButton.tsx
@@ -4,19 +4,23 @@ import type { DodoAction } from '@web24/shared';
 interface DodoActionButtonProps {
   readonly action: Exclude<DodoAction, 'None'>;
   readonly onClick: (action: Exclude<DodoAction, 'None'>) => void;
+  readonly disabled: boolean;
 }
 
-export function DodoActionButton({ action, onClick }: DodoActionButtonProps) {
+export function DodoActionButton({ action, onClick, disabled }: DodoActionButtonProps) {
   return (
     <button
       type="button"
       onClick={() => onClick(action)}
-      className="flex h-12 w-12 items-center justify-center rounded-md bg-white/80 p-1 hover:bg-white"
+      className={`flex h-12 w-12 items-center justify-center rounded-md p-1 transition ${
+        disabled ? 'cursor-not-allowed bg-white/60 opacity-70' : 'bg-white/80 hover:bg-white'
+      } `}
     >
       <img
         className="h-full w-full object-contain select-none"
         src={DODO_ACTION_IMAGE_MAP[action].src}
         alt={DODO_ACTION_IMAGE_MAP[action].alt}
+        draggable={false}
       />
     </button>
   );

--- a/apps/frontend/src/features/dodoroom/hooks/useDodoChat.ts
+++ b/apps/frontend/src/features/dodoroom/hooks/useDodoChat.ts
@@ -31,13 +31,22 @@ export const useDodoChat = () => {
   const [input, setInput] = useState('');
   const [isLoadingHistory, setIsLoadingHistory] = useState(false);
   const [isSendingMessage, setIsSendingMessage] = useState(false);
+  const [isTyping, setIsTyping] = useState(false);
   const [hasMore, setHasMore] = useState(true);
   const [nextCursor, setNextCursor] = useState<string | null>(null);
+
   const typingTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const isInitialLoadRef = useRef(true);
   const actionTimeoutRef = useRef<NodeJS.Timeout | null>(null);
 
-  const canSend = input.trim().length > 0;
+  const isDodoResponding = useMemo(
+    () => isSendingMessage || isTyping,
+    [isSendingMessage, isTyping],
+  );
+  const canSend = useMemo(
+    () => input.trim().length > 0 && !isDodoResponding,
+    [input, isDodoResponding],
+  );
   const latestDodoMessage = useMemo(
     () => [...messages].reverse().find((message) => message.role === 'dodo'),
     [messages],
@@ -93,6 +102,7 @@ export const useDodoChat = () => {
       globalThis.clearInterval(typingTimerRef.current);
     }
 
+    setIsTyping(true);
     let index = 0;
     typingTimerRef.current = globalThis.setInterval(() => {
       index += 1;
@@ -103,6 +113,7 @@ export const useDodoChat = () => {
       if (index >= fullText.length && typingTimerRef.current) {
         globalThis.clearInterval(typingTimerRef.current);
         typingTimerRef.current = null;
+        setIsTyping(false);
       }
     }, TYPING_ANIMATION_INTERVAL);
   }, []);
@@ -124,7 +135,7 @@ export const useDodoChat = () => {
 
   const send = useCallback(
     (value: string) => {
-      if (!value) return;
+      if (!value || isDodoResponding) return;
 
       const userMessageId = createMessageId();
       setMessages((prev) => [...prev, { id: userMessageId, role: 'user', text: value }]);
@@ -149,23 +160,25 @@ export const useDodoChat = () => {
         })
         .finally(() => setIsSendingMessage(false));
     },
-    [animateDodoReply, animateDodoAction],
+    [animateDodoReply, animateDodoAction, isDodoResponding],
   );
 
   const handleSend = useCallback(() => {
+    if (isDodoResponding) return;
     const value = input.trim();
     if (value) {
       send(value);
       setInput('');
     }
-  }, [input, send]);
+  }, [input, send, isDodoResponding]);
 
   const handleActionButton = useCallback(
     (action: Exclude<DodoAction, 'None'>) => {
+      if (isDodoResponding) return;
       const command = DODO_ACTION_COMMAND_MAP[action];
       send(command);
     },
-    [send],
+    [send, isDodoResponding],
   );
 
   return {
@@ -177,6 +190,7 @@ export const useDodoChat = () => {
     latestDodoMessage,
     handleSend,
     isSendingMessage,
+    isDodoResponding,
     loadMoreMessages,
     isLoadingHistory,
     hasMore,

--- a/apps/frontend/src/features/goal/components/GoalTemplateButton.tsx
+++ b/apps/frontend/src/features/goal/components/GoalTemplateButton.tsx
@@ -10,13 +10,13 @@ export function GoalTemplateButton({ label, selected, onClick }: GoalTemplateBut
       type="button"
       onClick={onClick}
       aria-pressed={selected}
-      className={`flex h-16 w-full items-center justify-between rounded-2xl px-6 text-left transition-colors ${
+      className={`flex w-full items-center justify-between rounded-2xl px-6 py-4 text-left transition-colors ${
         selected
           ? 'bg-secondary-normal text-label-normal ring-secondary-normal ring-1'
           : 'bg-bg-normal text-label-normal hover:bg-bg-alternative hover:text-label-alternative'
       }`}
     >
-      <span className="text-headline-1 font-semibold">{label}</span>
+      <span className="text-sm font-semibold md:text-base lg:text-lg">{label}</span>
     </button>
   );
 }

--- a/apps/frontend/src/features/goal/components/InputItemRow.tsx
+++ b/apps/frontend/src/features/goal/components/InputItemRow.tsx
@@ -46,7 +46,7 @@ export function InputItemRow({
       <button
         type="button"
         onClick={onAdd}
-        className="text-primary-strong hover:bg-bg-alternative bg-bg-normal flex h-16 w-full shrink-0 items-center justify-center rounded-2xl transition-colors"
+        className="text-primary-strong hover:bg-bg-alternative bg-bg-normal flex w-full shrink-0 items-center justify-center rounded-2xl px-6 py-4 transition-colors"
       >
         <Plus className="h-6 w-6 stroke-[3px]" />
       </button>
@@ -56,7 +56,7 @@ export function InputItemRow({
   const isMaxLengthReached = maxLength && value.length >= maxLength;
 
   return (
-    <div className="bg-bg-normal group focus-within:ring-primary-weak flex h-16 w-full shrink-0 items-center gap-2 rounded-2xl px-6 transition-all focus-within:ring-2">
+    <div className="bg-bg-normal group focus-within:ring-primary-weak flex w-full shrink-0 items-center gap-2 rounded-2xl px-6 py-4 transition-all focus-within:ring-2">
       <div className="relative flex h-full min-w-0 flex-1 items-center">
         <div
           ref={containerRef}
@@ -73,7 +73,7 @@ export function InputItemRow({
               onFocus={updateBlurs}
               placeholder={placeholder}
               maxLength={maxLength}
-              className="text-label-normal placeholder:text-primary-weak md:text-headline-1 text-body-1 absolute inset-0 h-full w-full bg-transparent font-semibold outline-none placeholder:font-normal"
+              className="placeholder:text-primary-weak text-label-normal absolute inset-0 h-full w-full bg-transparent text-sm font-semibold outline-none placeholder:font-normal md:text-base lg:text-lg"
             />
             <span
               className={`text-body-1 md:text-headline-1 invisible whitespace-pre ${

--- a/apps/frontend/src/features/goal/components/NewGoalFrame.tsx
+++ b/apps/frontend/src/features/goal/components/NewGoalFrame.tsx
@@ -31,7 +31,8 @@ export function NewGoalFrame({
   const [direction, setDirection] = useState<'next' | 'prev'>('next');
   const [dialogueIdx, setDialogueIdx] = useState(0);
   const [isDialogueVisible, setIsDialogueVisible] = useState(true);
-  const [resetTimer, setResetTimer] = useState(0);
+  const [isAutoMode, setIsAutoMode] = useState(true);
+
   const changeDialogueTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const currentStep = steps[currStepIdx];
@@ -48,41 +49,42 @@ export function NewGoalFrame({
   useEffect(() => {
     setDialogueIdx(0);
     setIsDialogueVisible(true);
-    setResetTimer((prev) => prev + 1);
+    setIsAutoMode(true);
   }, [currStepIdx]);
 
-  useEffect(() => {
-    let timer: NodeJS.Timeout | undefined;
+  // 대사 변경 함수
+  const changeDialogue = (targetIdx: number, isAutoTrigger = false) => {
+    if (!isAutoTrigger) {
+      setIsAutoMode(false);
+    }
 
-    const transitionToNextDialogue = () => {
-      setDialogueIdx((prev) => prev + 1);
+    setIsDialogueVisible(false);
+    if (changeDialogueTimerRef.current) {
+      clearTimeout(changeDialogueTimerRef.current);
+    }
+
+    changeDialogueTimerRef.current = setTimeout(() => {
+      setDialogueIdx(targetIdx);
       setIsDialogueVisible(true);
-    };
+    }, 300);
+  };
 
-    const startTransition = () => {
-      setIsDialogueVisible(false);
-      setTimeout(transitionToNextDialogue, 300);
-    };
+  // 자동 대사 전환 로직
+  useEffect(() => {
+    let autoTimer: ReturnType<typeof setTimeout> | undefined;
 
-    if (!isLastDialogue) {
-      timer = setTimeout(startTransition, 3000);
+    if (isAutoMode && !isLastDialogue) {
+      autoTimer = setTimeout(() => {
+        changeDialogue(dialogueIdx + 1, true);
+      }, 3000);
     }
 
     return () => {
-      if (timer) {
-        clearTimeout(timer);
+      if (autoTimer) {
+        clearTimeout(autoTimer);
       }
     };
-  }, [dialogueIdx, isLastDialogue, resetTimer]);
-
-  useEffect(
-    () => () => {
-      if (changeDialogueTimerRef.current) {
-        clearTimeout(changeDialogueTimerRef.current);
-      }
-    },
-    [],
-  );
+  }, [dialogueIdx, isAutoMode, isLastDialogue]);
 
   const animationStyles = {
     next: '-translate-x-full opacity-0',
@@ -130,18 +132,6 @@ export function NewGoalFrame({
   const handleSkip = () => {
     if (currentStep.validate && !currentStep.validate()) return;
     onSkip?.();
-  };
-
-  const changeDialogue = (targetIdx: number) => {
-    setIsDialogueVisible(false);
-    if (changeDialogueTimerRef.current) {
-      clearTimeout(changeDialogueTimerRef.current);
-    }
-    changeDialogueTimerRef.current = setTimeout(() => {
-      setDialogueIdx(targetIdx);
-      setIsDialogueVisible(true);
-      setResetTimer((prev) => prev + 1);
-    }, 300);
   };
 
   const handlePrevDialogue = () => {

--- a/apps/frontend/src/features/goal/components/NewGoalFrame.tsx
+++ b/apps/frontend/src/features/goal/components/NewGoalFrame.tsx
@@ -86,6 +86,15 @@ export function NewGoalFrame({
     };
   }, [dialogueIdx, isAutoMode, isLastDialogue]);
 
+  useEffect(
+    () => () => {
+      if (changeDialogueTimerRef.current) {
+        clearTimeout(changeDialogueTimerRef.current);
+      }
+    },
+    [],
+  );
+
   const animationStyles = {
     next: '-translate-x-full opacity-0',
     prev: 'translate-x-full opacity-0',

--- a/apps/frontend/src/pages/DodoRoomPage.tsx
+++ b/apps/frontend/src/pages/DodoRoomPage.tsx
@@ -20,6 +20,7 @@ export function DodoRoomPage() {
     loadMoreMessages,
     isLoadingHistory,
     isSendingMessage,
+    isDodoResponding,
     hasMore,
     handleActionButton,
   } = useDodoChat();
@@ -38,7 +39,12 @@ export function DodoRoomPage() {
           </div>
           <div className="absolute bottom-4 left-4 z-20 flex flex-col gap-2">
             {DODO_ACTION_VALUES.filter((v) => v !== 'None').map((action) => (
-              <DodoActionButton key={action} action={action} onClick={handleActionButton} />
+              <DodoActionButton
+                key={action}
+                action={action}
+                onClick={handleActionButton}
+                disabled={isDodoResponding}
+              />
             ))}
           </div>
         </section>

--- a/apps/frontend/src/shared/components/behavior/BehaviorCard.tsx
+++ b/apps/frontend/src/shared/components/behavior/BehaviorCard.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import type { Behavior } from '@/shared/components/behavior/BehaviorCard.types';
 import { GOAL_COLOR_STYLES } from '@/shared/constants/goalColor';
 import { Trash2 } from 'lucide-react';
@@ -16,19 +16,34 @@ export function BehaviorCard({ behavior, onToggle, onDelete }: BehaviorProps) {
   const bgColor = GOAL_COLOR_STYLES[behavior.goalColor].bg;
   const [isActionVisible, setIsActionVisible] = useState(false);
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
+  const cardRef = useRef<HTMLDivElement>(null);
   const canDelete = Boolean(onDelete) && !behavior.isChecked;
 
-  const handleCardPointerDown = (event: React.PointerEvent<HTMLDivElement>) => {
-    if (!canDelete) return;
-    if (event.pointerType !== 'touch') return;
-    if ((event.target as HTMLElement).closest('button')) return;
-    setIsActionVisible(true);
-  };
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (cardRef.current && !cardRef.current.contains(event.target as Node)) {
+        setIsActionVisible(false);
+      }
+    };
 
-  const actionTriggerClasses =
-    isActionVisible || isDeleteModalOpen
-      ? 'pointer-events-auto opacity-100'
-      : 'pointer-events-none opacity-0';
+    if (isActionVisible) {
+      document.addEventListener('mousedown', handleClickOutside);
+    }
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, [isActionVisible]);
+
+  const handleCardPointerDown = (e: React.MouseEvent) => {
+    // 버튼이나 인터랙티브 요소 클릭 시 무시
+    if ((e.target as HTMLElement).closest('button')) return;
+
+    if (canDelete) {
+      // 터치 환경인지 확인
+      const isTouch = globalThis.matchMedia('(pointer: coarse)').matches;
+      if (isTouch) {
+        setIsActionVisible(!isActionVisible);
+      }
+    }
+  };
 
   const closeDeleteModal = () => {
     setIsDeleteModalOpen(false);
@@ -37,6 +52,7 @@ export function BehaviorCard({ behavior, onToggle, onDelete }: BehaviorProps) {
 
   return (
     <div
+      ref={cardRef}
       onPointerDown={handleCardPointerDown}
       className={`group bg-bg-light relative flex items-center gap-4 rounded-2xl px-7 py-5 transition-all duration-500 ${
         behavior.isChecked
@@ -56,11 +72,15 @@ export function BehaviorCard({ behavior, onToggle, onDelete }: BehaviorProps) {
               <button
                 type="button"
                 aria-label="행동 삭제"
-                onClick={() => {
-                  setIsActionVisible(true);
+                onPointerDown={(e) => {
+                  e.stopPropagation();
                   setIsDeleteModalOpen(true);
                 }}
-                className={`text-label-alternative hover:text-difficulty-4 transition ${actionTriggerClasses} pointer-events-none opacity-0 group-hover:pointer-events-auto group-hover:opacity-100`}
+                className={`hover:text-accent-red text-label-alternative/40 transition-all duration-300 ${
+                  isActionVisible || isDeleteModalOpen
+                    ? 'pointer-events-auto translate-x-0 opacity-100'
+                    : 'pointer-events-none -translate-x-2 opacity-0 group-hover:pointer-events-auto group-hover:translate-x-0 group-hover:opacity-100'
+                } `}
               >
                 <Trash2 size={16} />
               </button>
@@ -79,14 +99,16 @@ export function BehaviorCard({ behavior, onToggle, onDelete }: BehaviorProps) {
         </div>
       </div>
       {/* 토글 버튼 */}
-      <StickerCell
-        isFilled={behavior.isChecked}
-        isClickable
-        onClick={onToggle}
-        ariaLabel={`${behavior.title} 완료 토글`}
-        ariaPressed={behavior.isChecked}
-        stickerColor={behavior.goalColor}
-      />{' '}
+      <div onPointerDown={(e) => e.stopPropagation()}>
+        <StickerCell
+          isFilled={behavior.isChecked}
+          isClickable
+          onClick={onToggle}
+          ariaLabel={`${behavior.title} 완료 토글`}
+          ariaPressed={behavior.isChecked}
+          stickerColor={behavior.goalColor}
+        />{' '}
+      </div>
       <Modal
         isOpen={isDeleteModalOpen}
         onRequestClose={closeDeleteModal}

--- a/apps/frontend/src/shared/components/behavior/BehaviorCard.tsx
+++ b/apps/frontend/src/shared/components/behavior/BehaviorCard.tsx
@@ -32,7 +32,7 @@ export function BehaviorCard({ behavior, onToggle, onDelete }: BehaviorProps) {
     return () => document.removeEventListener('mousedown', handleClickOutside);
   }, [isActionVisible]);
 
-  const handleCardPointerDown = (e: React.MouseEvent) => {
+  const handleCardPointerDown = (e: React.PointerEvent) => {
     // 버튼이나 인터랙티브 요소 클릭 시 무시
     if ((e.target as HTMLElement).closest('button')) return;
 


### PR DESCRIPTION
## 🔗 관련 이슈

- close:

## ✅ 작업 내용

[목표]
- [ ] 템플릿 아이템이 너무 많음 → **선택이 아닌 추가 방식으로 개선**
- [x] 대사 읽는 중 자동으로 넘어감 → **버튼 클릭 시에만 다음 대사로 진행되도록 수정**
- [ ] 모바일 레이아웃 사용성 개선
- [ ] 대사 가독성 개선 (쉼표 과다 문제)

[두두의 방]
- [x] 진행 중인 대화가 있을 경우 **추가 보내기 / 액션 버튼 비활성화**

[메인 페이지]
- [x] 완료된 행동을 목록 하단으로 이동
- [x] 새로고침 시 완료된 행동은 목록에서 제외

[버그]
- [x] (모바일) 오늘의 행동 삭제가 되지 않는 문제

## 📸 스크린샷 / 데모 (옵션)

<img width="1666" height="878" alt="image" src="https://github.com/user-attachments/assets/739b5873-accb-4949-a16a-2a54db9c2b30" />

## 🧪 테스트 방법 (옵션)

## 💡 체크리스트

<!-- PR을 제출하기 전에 아래 항목들을 확인해주세요. -->

- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (예: `feature/login` -> `develop`)
- [x] 테스트는 잘 통과했나요?
- [x] 빌드에 성공했나요?

## 💬 To Reviewers
