### PR TITLE
feat: User의 닉네임 길이 제한 30으로 증가

### DIFF
--- a/apps/backend/src/common/database/migrations/1770173002866-manual.ts
+++ b/apps/backend/src/common/database/migrations/1770173002866-manual.ts
@@ -1,0 +1,15 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class Manual1770173002866 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "users" ALTER COLUMN "nickname" TYPE character varying(30)`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "users" ALTER COLUMN "nickname" TYPE character varying(10)`,
+    );
+  }
+}

--- a/packages/shared/src/constants/user.constants.ts
+++ b/packages/shared/src/constants/user.constants.ts
@@ -1,1 +1,1 @@
-export const USER_NICKNAME_MAX_LENGTH = 10;
+export const USER_NICKNAME_MAX_LENGTH = 30;


### PR DESCRIPTION
## 🔗 관련 이슈

- 없음

## ✅ 작업 내용

- User의 닉네임 길이 제한을 기존 10에서 30으로 증가
- users 테이블의 nickname Column의 값을 30으로 변경하는 migration

## 💡 체크리스트

- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (예: `feature/login` -> `develop`)
- [x] 테스트는 잘 통과했나요?
- [x] 빌드에 성공했나요?

## 💬 To Reviewers

migration:run 을 해주세요
